### PR TITLE
Update pfs-stress to support configurable flush rate

### DIFF
--- a/pfs-stress/pfs-stress.conf
+++ b/pfs-stress/pfs-stress.conf
@@ -5,5 +5,6 @@ FileSize:                            10000000
 MinExtentSize:                              1
 MaxExtentSize:                          10000
 NumExtentsToWritePerFile:                1000
+NumExtentWritesPerFlush:                   50 # 0 means only perform Flush    function at the end
 NumExtentWritesPerValidate:               100 # 0 means only perform Validate function at the end
 DisplayUpdateInterval:                  100ms


### PR DESCRIPTION
Previously, pfs-stress would not issue any flushes (sync() calls).
There was only the implicit flush at the point of the close() call.
This change will issue periodic flushes as requested.