### PR TITLE
Implemented "chaos" error injection into ramswift

### DIFF
--- a/ramswift/chaos_settings.conf
+++ b/ramswift/chaos_settings.conf
@@ -1,0 +1,22 @@
+# Chaos injection settings
+#
+# If FailureHTTPStatus is omitted, 500 (Internal Server Error     ) is assumed
+# If a ...FailureRate  is omitted,   0 (meaning no errors injected) is assumed
+
+[RamSwiftChaos]
+#FailureHTTPStatus:          500
+#AccountDeleteFailureRate:     0
+#AccountGetFailureRate:        0
+#AccountHeadFailureRate:       0
+#AccountPostFailureRate:       0
+#AccountPutFailureRate:        0
+#ContainerDeleteFailureRate:   0
+#ContainerGetFailureRate:      0
+#ContainerHeadFailureRate:     0
+#ContainerPostFailureRate:     0
+#ContainerPutFailureRate:      0
+#ObjectDeleteFailureRate:      0
+#ObjectGetFailureRate:         0
+#ObjectHeadFailureRate:        0
+#ObjectPostFailureRate:        0
+#ObjectPutFailureRate:         0

--- a/ramswift/macramswift0.conf
+++ b/ramswift/macramswift0.conf
@@ -2,4 +2,6 @@
 
 .include ../proxyfsd/macproxyfsd0.conf
 
+.include ./chaos_settings.conf
+
 .include ./swift_info.conf

--- a/ramswift/ramswift0.conf
+++ b/ramswift/ramswift0.conf
@@ -2,4 +2,6 @@
 
 .include ../proxyfsd/proxyfsd0.conf
 
+.include ./chaos_settings.conf
+
 .include ./swift_info.conf

--- a/ramswift/saioramswift0.conf
+++ b/ramswift/saioramswift0.conf
@@ -2,4 +2,6 @@
 
 .include ../proxyfsd/saioproxyfsd0.conf
 
+.include ./chaos_settings.conf
+
 .include ./swift_info.conf


### PR DESCRIPTION
This is an enhancement to ramswift that enables injecting regularly recurring errors for
any of the DELETE, GET, HEAD, POST, and PUT methods on Accounts, Containers, and
Objects. Note that POST on an Object is currently rejected by ramswift anyway...

This should enable e.g. @charmster to do some serious testing of his swiftclient retry
logic.

Please let me know if this is the correct granularity/feature-set of "chaos".