### PR TITLE
Fix memory leaks exposed by valgrind test

### DIFF
--- a/jrpcclient/proxyfs_api.c
+++ b/jrpcclient/proxyfs_api.c
@@ -467,6 +467,8 @@ int proxyfs_flock(mount_handle_t* in_mount_handle,
         flock->l_pid    = jsonrpc_get_resp_uint64(ctx, ptable[FLOCK_PID]);
     }
 
+    // Clean up jsonrpc context and return
+    jsonrpc_close(ctx);
     return rsp_status;
 }
 

--- a/vfs/vfs_proxyfs.c
+++ b/vfs/vfs_proxyfs.c
@@ -352,7 +352,7 @@ static uint32_t vfs_proxyfs_fs_capabilities(struct vfs_handle_struct *handle,
                                             enum timestamp_set_resolution *p_ts_res)
 {
 	DEBUG(10, ("vfs_proxyfs_fs_capabilities: %s\n", handle->conn->connectpath));
-	uint32_t caps = FILE_CASE_SENSITIVE_SEARCH | FILE_CASE_PRESERVED_NAMES;
+	uint32_t caps = FILE_CASE_SENSITIVE_SEARCH | FILE_CASE_PRESERVED_NAMES | FILE_SUPPORTS_REPARSE_POINTS;
 
 #ifdef STAT_HAVE_NSEC
 	*p_ts_res = TIMESTAMP_SET_NT_OR_BETTER;
@@ -425,7 +425,7 @@ static struct dirent *vfs_proxyfs_readdir(struct vfs_handle_struct *handle,
                                           SMB_STRUCT_STAT *sbuf)
 {
 	int ret;
-	struct dirent *dir_ent;
+	struct dirent *dir_ent = NULL;
 	file_handle_t *dir = (file_handle_t *)dirp;
 
 	uint64_t num_ents, size;


### PR DESCRIPTION
While running this test:

   # for i in {1...10000}
   do
      touch file-${i}
   done
   # ls

while running smbd under valgrind:

   # valgrind --leak-check=full /sbin/smbd

We noticed some large and small memory leaks when we did:

   # kill -15 <ppid of smbd>