### PR TITLE
Fix the ObjectChunkedPut retry functionality so it works and write un…

### DIFF
--- a/stats/strings.go
+++ b/stats/strings.go
@@ -222,6 +222,8 @@ var (
 	SwiftObjDeleteRetrySuccessOps        = "proxyfs.swiftclient.object-delete.retry.success.operations"
 	SwiftObjFetchPutCtxtRetryOps         = "proxyfs.swiftclient.object-fetch-put-ctxt.retry.operations"
 	SwiftObjFetchPutCtxtRetrySuccessOps  = "proxyfs.swiftclient.object-fetch-put-ctxt.retry.success.operations"
+	SwiftObjPutCtxtCloseRetryOps         = "proxyfs.swiftclient.object-put-ctxt-close.retry.operations"
+	SwiftObjPutCtxtCloseRetrySuccessOps  = "proxyfs.swiftclient.object-put-ctxt-close.retry.success.operations"
 	SwiftObjGetRetryOps                  = "proxyfs.swiftclient.object-get.retry.operations"
 	SwiftObjGetRetrySuccessOps           = "proxyfs.swiftclient.object-get.retry.success.operations"
 	SwiftObjHeadRetryOps                 = "proxyfs.swiftclient.object-head.retry.operations"

--- a/swiftclient/api.go
+++ b/swiftclient/api.go
@@ -13,11 +13,16 @@ type ChunkedCopyContext interface {
 }
 
 // ChunkedPutContext provides a context to use for Object HTTP PUTs using "chunked" Transfer-Encoding.
+//
+// The slice(s) passed to SendChunk() must not be modified until Close() has
+// been called and has returned success or failure.  Close() must always be
+// called on a successfullly opened ChunkedPutContext, even if SendChunk()
+// returns an error, or else we will leak open connections (although SendChunk()
+// does its best).
 type ChunkedPutContext interface {
 	BytesPut() (bytesPut uint64, err error)                    // Report how many bytes have been sent via SendChunk() for this ChunkedPutContext
-	Close() (err error)                                        // Finish the "chunked" HTTP PUT for this ChunkedPutContext
+	Close() (err error)                                        // Finish the "chunked" HTTP PUT for this ChunkedPutContext (with possible retry)
 	Read(offset uint64, length uint64) (buf []byte, err error) // Read back bytes previously sent via SendChunk()
-	Retry() (err error)                                        // Retry all the preceeding steps for this ChunkedPutContext
 	SendChunk(buf []byte) (err error)                          // Send the supplied "chunk" via this ChunkedPutContext
 }
 

--- a/swiftclient/config.go
+++ b/swiftclient/config.go
@@ -31,20 +31,22 @@ type pendingDeletesStruct struct {
 }
 
 type globalsStruct struct {
-	noAuthStringAddr         string
-	noAuthTCPAddr            *net.TCPAddr
-	timeout                  time.Duration // TODO: Currently not enforced
-	retryLimit               uint16        // maximum retries
-	retryLimitObject         uint16        // maximum retries for object ops
-	retryDelay               time.Duration // delay before first retry
-	retryDelayObject         time.Duration // delay before first retry for object ops
-	retryExpBackoff          float64       // increase delay by this factor each try (exponential backoff)
-	retryExpBackoffObject    float64       // increase delay by this factor each try for object ops
-	nilTCPConn               *net.TCPConn
-	chunkedConnectionPool    chan *net.TCPConn
-	nonChunkedConnectionPool chan *net.TCPConn
-	maxIntAsUint64           uint64
-	pendingDeletes           *pendingDeletesStruct
+	noAuthStringAddr                string
+	noAuthTCPAddr                   *net.TCPAddr
+	timeout                         time.Duration // TODO: Currently not enforced
+	retryLimit                      uint16        // maximum retries
+	retryLimitObject                uint16        // maximum retries for object ops
+	retryDelay                      time.Duration // delay before first retry
+	retryDelayObject                time.Duration // delay before first retry for object ops
+	retryExpBackoff                 float64       // increase delay by this factor each try (exponential backoff)
+	retryExpBackoffObject           float64       // increase delay by this factor each try for object ops
+	nilTCPConn                      *net.TCPConn
+	chunkedConnectionPool           chan *net.TCPConn
+	nonChunkedConnectionPool        chan *net.TCPConn
+	maxIntAsUint64                  uint64
+	pendingDeletes                  *pendingDeletesStruct
+	chaosSendChunkFailureRate       uint64 // set only during testing
+	chaosFetchChunkedPutFailureRate uint64 // set only during testing
 }
 
 var globals globalsStruct


### PR DESCRIPTION
…it tests.

Updated the comments in api.go for the ChunkedPutContext interface to explain
requirements for its use.

Formerly the ChunkedPutContext interface had a SendChunk() and Close() methods
where SendChunk() would return an error when it encountered a problem and
the Close() method would then retry the entire chunked put that was received
and return an error indicating success or failure.  (There was also a Retry()
method that would do the same thing.)

There were two problems with this.  First, consumers of the ChunkedPutContext
interface immediately abort when SendChunk() return an error and never call
Close() or Retry() (this also means a TCP connection would be leaked).

Second, even if Close() was invoked, a successful retry would only resend
the data passed to ChunkedPutContext upto the point of the error, and not
any other data that was supposed to be part of the object!  So the object
was still effectively corrupt.

Changed the way ChunkedPutContext works so that in "normal" error cases
SendChunk() still returns nil (success) and stashes the data to be sent
away so that the retry can attempt to send it.  Whence Close() is called,
it notices the pending error in ChunkedPutContext.err retries the entire
operation.  If the retry works, it returns success.  Otherwise, it returns
the final error it encountered.

There are some cases where SendChunk() cannot stash away the data to be
sent due to logic errors in the program or corruption of in memory data
structures.  These should probably just be dealt with by panic'ing, but
instead ChunkedPutContext treats this as a "fatal" error, which it returns
to the caller of SendChunk().  If Close() is called later, it does not
attempt to retry but instead returns the same error.  Just in case Close()
is not called (current code does not call Close() after SendChunk()
returns an error, SendChunk() also cleans up the TCP connection.