### PR TITLE
Partial fix for panic in flush code (doesn't address race condition)

### DIFF
--- a/headhunter/api_internal.go
+++ b/headhunter/api_internal.go
@@ -7,12 +7,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/swiftstack/cstruct"
-	"github.com/swiftstack/sortedmap"
-
 	"github.com/swiftstack/ProxyFS/blunder"
+	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/swiftclient"
 	"github.com/swiftstack/ProxyFS/utils"
+	"github.com/swiftstack/cstruct"
+	"github.com/swiftstack/sortedmap"
 )
 
 // TODO: allowFormat should change to doFormat when controller/runway pre-formats
@@ -1036,7 +1036,7 @@ func (volume *volumeStruct) GetInodeRec(inodeNumber uint64) (value []byte, err e
 	}
 	if !ok {
 		volume.Unlock()
-		err = fmt.Errorf("inodeNumber 0x%016X not found in volume \"%v\" inodeRecWrapper.bPlusTree", inodeNumber, volume.volumeName)
+		err = fmt.Errorf("inode %d not found in volume '%v' inodeRecWrapper.bPlusTree", inodeNumber, volume.volumeName)
 		return
 	}
 	valueFromTree := valueAsValue.([]byte)
@@ -1049,6 +1049,9 @@ func (volume *volumeStruct) GetInodeRec(inodeNumber uint64) (value []byte, err e
 }
 
 func (volume *volumeStruct) PutInodeRec(inodeNumber uint64, value []byte) (err error) {
+
+	logger.Tracef("headhunger.PutInodeRec(): volume '%s' inode %d", volume.volumeName, inodeNumber)
+
 	valueToTree := make([]byte, len(value))
 	copy(valueToTree, value)
 
@@ -1072,6 +1075,9 @@ func (volume *volumeStruct) PutInodeRec(inodeNumber uint64, value []byte) (err e
 }
 
 func (volume *volumeStruct) PutInodeRecs(inodeNumbers []uint64, values [][]byte) (err error) {
+
+	logger.Tracef("headhunter.PutInodeRecs(): volume '%s' inodes %v", volume.volumeName, inodeNumbers)
+
 	if len(inodeNumbers) != len(values) {
 		err = fmt.Errorf("InodeNumber and Values array don't match")
 		return

--- a/logger/api.go
+++ b/logger/api.go
@@ -129,9 +129,15 @@ var debugLevelEnabled = false
 // config variable, the package must be in this map with a value of false (or true).
 //
 var packageTraceSettings = map[string]bool{
-	"jrpcfs": false,
-	"inode":  false,
-	"logger": false,
+	"dlm":         false,
+	"fs":          false,
+	"fuse":        false,
+	"headhunter":  false,
+	"inode":       false,
+	"jrpcfs":      false,
+	"logger":      false,
+	"proxyfsd":    false,
+	"swiftclient": false,
 }
 
 func setTraceLoggingLevel(confStrSlice []string) {

--- a/proxyfsd/saioproxyfsd0.conf
+++ b/proxyfsd/saioproxyfsd0.conf
@@ -11,3 +11,7 @@ WhoAmI: Peer0
 .include ./stats.conf
 .include ./httpserver.conf
 .include ./debug.conf
+
+# put it here to have the last word (override previous)
+#[Logging]
+#TraceLevelLogging: inode fs headhunter


### PR DESCRIPTION
in fs.Unlink(), remove the correct inode from the inFlightFileInodeDataTracker()
map (remove the file inode, not the parent directory inode).

in inFlightFileInodeDataTracker() don't panic() if there's a problem flushing
the inode to disk (in Flush()), just log an error and go on with life.

Convert other calls to panic() in that routine to calls to logger.PanicfWithError()
so we get more info in the log.

Add trace messages in various places to track down this problem.

Cleanup the way we print inode numbers (decimal instead of a 16 character
hex string).

Add code so its possible to enable tracing in some packages that did not
support it (dlm, fs, fuse, headhunter, proxyfsd, swiftclient), not that
I added trace statements to all of those.