### PR TITLE
Clear err after recovering

### DIFF
--- a/headhunter/config.go
+++ b/headhunter/config.go
@@ -244,6 +244,7 @@ func Up(confMap conf.ConfMap) (err error) {
 	if nil != err {
 		// TODO: eventually, just return
 		bPlusTreeObjectCacheEvictHighLimit = 10010
+		err = nil
 	}
 
 	globals.bPlusTreeObjectCache = sortedmap.NewBPlusTreeCache(bPlusTreeObjectCacheEvictLowLimit, bPlusTreeObjectCacheEvictHighLimit)


### PR DESCRIPTION
Otherwise, we get spurious errors when no volumes are defined.