### PR TITLE
pfs_middleware: include Content-Range, etc. on 416

### DIFF
--- a/pfs_middleware/tests/test_pfs_middleware.py
+++ b/pfs_middleware/tests/test_pfs_middleware.py
@@ -909,7 +909,7 @@ class TestObjectGet(BaseMiddlewareTest):
                     "FileSize": 62,
                     "Metadata": "",
                     "InodeNumber": 1245,
-                    "NumWrites": 2424,
+                    "NumWrites": 2426,
                     "ModificationTime": 1481152134331862558,
                     "LeaseId": "borkbork",
                     "ReadEntsOut": None}}
@@ -922,6 +922,13 @@ class TestObjectGet(BaseMiddlewareTest):
         status, headers, body = self.call_pfs(req)
 
         self.assertEqual(status, '416 Requested Range Not Satisfiable')
+        self.assertEqual(headers.get('Content-Range'), 'bytes */62')
+        self.assertEqual(headers.get('ETag'),
+                         mware.construct_etag("AUTH_test", 1245, 2426))
+        self.assertEqual(headers.get('Last-Modified'),
+                         'Wed, 07 Dec 2016 23:08:55 GMT')
+        self.assertEqual(headers.get('X-Timestamp'),
+                         '1481152134.33186')
 
     def test_GET_multiple_ranges(self):
         self.app.register(


### PR DESCRIPTION
416 responses from Swift have a bunch of headers, including
Content-Range, object metadata, and so on. This commit adds these
headers to pfs_middleware's 416 response.