### PR TITLE
Fix large suffix-byte-range GET requests.

### DIFF
--- a/inode/file.go
+++ b/inode/file.go
@@ -231,8 +231,14 @@ func (vS *volumeStruct) getReadPlanHelper(fileInode *inMemoryInodeStruct, reques
 		return
 	} else if requestedOffset == nil {
 		// Suffix request, e.g. "bytes=-10", the last 10 bytes of the file
-		offset = fileInode.Size - *requestedLength
-		readPlanBytes = *requestedLength
+		if fileInode.Size > *requestedLength {
+			offset = fileInode.Size - *requestedLength
+			readPlanBytes = *requestedLength
+		} else {
+			// A suffix request for more bytes than the file has must get the whole file.
+			offset = 0
+			readPlanBytes = fileInode.Size
+		}
 	} else if requestedLength == nil {
 		// Prefix request, e.g. "bytes=25-", from byte 25 to the end
 		offset = *requestedOffset


### PR DESCRIPTION
Given a 100-byte file and a request for the last 101 bytes (Range:
bytes=-101), Swift will return a 206 Partial Content response with all
100 bytes included. Using a bimodal account, one would get a 416. This
was because ProxyFS was incorrectly handling such a request and
returning an empty read plan to the middleware.

This commit adds handling for such requests; now, a read plan for the
whole file will be returned to the middleware.