### PR TITLE
Only check bimodal access for valid API versions

### DIFF
--- a/pfs_middleware/pfs_middleware/bimodal_checker.py
+++ b/pfs_middleware/pfs_middleware/bimodal_checker.py
@@ -26,7 +26,7 @@ import eventlet
 import socket
 import time
 
-from swift.common import swob
+from swift.common import swob, constraints
 from swift.common.utils import get_logger
 from swift.proxy.controllers.base import get_account_info
 
@@ -205,7 +205,7 @@ class BimodalChecker(object):
     def __call__(self, req):
         vrs, acc, con, obj = utils.parse_path(req.path)
 
-        if not acc:
+        if not acc or not constraints.valid_api_version(vrs):
             # could be a GET /info request or something made up by some
             # other middleware; get out of the way.
             return self.app

--- a/pfs_middleware/tests/test_bimodal_checker.py
+++ b/pfs_middleware/tests/test_bimodal_checker.py
@@ -108,6 +108,19 @@ class TestDecision(unittest.TestCase):
         self.assertEqual(self.fake_rpc.calls, (
             ('Server.RpcIsAccountBimodal', ({'AccountName': 'bob'},)),))
 
+    def test_bad_path(self):
+        self.app.register('GET', '//v1/alice', 404, {}, '')
+        req = swob.Request.blank("//v1/alice")
+        # (in)sanity check
+        self.assertNotEqual(req.environ['PATH_INFO'], '//v1/alice')
+        # fix it
+        req.environ['PATH_INFO'] = '//v1/alice'
+        resp = req.get_response(self.bc)
+
+        self.assertEqual("no", resp.headers["Is-Bimodal"])
+        # We just passed through -- didn't bother with an RPC.
+        self.assertEqual(tuple(), self.fake_rpc.calls)
+
     def test_disagreement(self):
         def fake_RpcIsAccountBimodal(request):
             return {


### PR DESCRIPTION
This fixes up `test/functional/tests.py:TestAccount.testInvalidPath` so it doesn't just 500