### PR TITLE
Misc container fixes

### DIFF
--- a/pfs_middleware/pfs_middleware/middleware.py
+++ b/pfs_middleware/pfs_middleware/middleware.py
@@ -948,7 +948,6 @@ class PfsMiddleware(object):
         if len(container_name) > maxlen:
             return swob.HTTPBadRequest(
                 request=req,
-                content_type="text/plain",
                 body=('Container name length of %d longer than %d' %
                       (len(container_name), maxlen)))
 

--- a/pfs_middleware/pfs_middleware/middleware.py
+++ b/pfs_middleware/pfs_middleware/middleware.py
@@ -102,7 +102,7 @@ from swift.proxy.controllers.base import (
 
 # Plain WSGI is annoying to work with, and nobody wants a dependency on
 # webob.
-from swift.common import swob
+from swift.common import swob, constraints
 
 # Our logs should go to the same place as everyone else's. Plus, this logger
 # works well in an eventlet-ified process, and SegmentedIterable needs one.
@@ -641,7 +641,7 @@ class PfsMiddleware(object):
     def __call__(self, req):
         vrs, acc, con, obj = utils.parse_path(req.path)
 
-        if not acc:
+        if not acc or not constraints.valid_api_version(vrs):
             # could be a GET /info request or something made up by some
             # other middleware; get out of the way.
             return self.app

--- a/pfs_middleware/pfs_middleware/middleware.py
+++ b/pfs_middleware/pfs_middleware/middleware.py
@@ -958,7 +958,8 @@ class PfsMiddleware(object):
                 self.rpc_call(ctx, rpc.put_container_request(
                     container_path,
                     "",
-                    serialize_metadata(new_metadata)))
+                    serialize_metadata({
+                        k: v for k, v in new_metadata.items() if v})))
                 return swob.HTTPCreated(request=req)
             else:
                 raise

--- a/pfs_middleware/pfs_middleware/middleware.py
+++ b/pfs_middleware/pfs_middleware/middleware.py
@@ -645,6 +645,9 @@ class PfsMiddleware(object):
             # could be a GET /info request or something made up by some
             # other middleware; get out of the way.
             return self.app
+        if not constraints.check_utf8(req.path_info):
+            return swob.HTTPPreconditionFailed(
+                body='Invalid UTF8 or contains NULL')
 
         try:
             # Check account to see if this is a bimodal-access account or


### PR DESCRIPTION
Before:
```
Ran 485 tests in 755.537s

FAILED (SKIP=79, errors=30, failures=74)
```

After:
```
Ran 485 tests in 663.889s

FAILED (SKIP=79, errors=30, failures=63)
```

Still needs unit tests.