### PR TITLE
Tolerate single-character container names

### DIFF
--- a/swiftclient/api_test.go
+++ b/swiftclient/api_test.go
@@ -323,7 +323,14 @@ func testOps(t *testing.T) {
 		t.Fatalf(tErr)
 	}
 
-	// Send a GET for account "TestAccount" expecting header Cat: Dog and containerList []string{"TestContainer"}
+	// Send a PUT for container "Z"
+
+	err = ContainerPut("TestAccount", "Z", map[string][]string{})
+	if nil != err {
+		t.Fatalf("ContainerPut(\"TestAccount\", \"Z\", nil) failed: %v", err)
+	}
+
+	// Send a GET for account "TestAccount" expecting header Cat: Dog and containerList []string{"TestContainer", "Z"}
 
 	accountHeaders, containerList, err = AccountGet("TestAccount")
 	if nil != err {
@@ -337,7 +344,7 @@ func testOps(t *testing.T) {
 	if (1 != len(accountCatHeader)) || ("Dog" != accountCatHeader[0]) {
 		t.Fatalf("AccountGet(\"TestAccount\") didn't return Header \"Cat\" having value []string{\"Dog\"}")
 	}
-	if (1 != len(containerList)) || ("TestContainer" != containerList[0]) {
+	if (2 != len(containerList)) || ("TestContainer" != containerList[0]) || ("Z" != containerList[1]) {
 		t.Fatalf("AccountGet(\"TestAccount\") didn't return expected containerList")
 	}
 
@@ -734,6 +741,13 @@ func testOps(t *testing.T) {
 	if nil != err {
 		tErr := fmt.Sprintf("ContainerDelete(\"TestAccount\", \"TestContainer\") failed: %v", err)
 		t.Fatalf(tErr)
+	}
+
+	// Send a DELETE for container "Z"
+
+	err = ContainerDelete("TestAccount", "Z")
+	if nil != err {
+		t.Fatalf("ContainerDelete(\"TestAccount\", \"Z\") failed: %v", err)
 	}
 
 	// create and delete container "TestContainer" again so we're sure the retry code is hit

--- a/swiftclient/utils.go
+++ b/swiftclient/utils.go
@@ -609,7 +609,7 @@ func readHTTPPayloadLines(tcpConn *net.TCPConn, headers map[string][]string) (li
 
 		for bufCurrentPosition < contentLength {
 			if '\n' == buf[bufCurrentPosition] {
-				if 2 > (bufCurrentPosition - bufLineStartPosition) {
+				if bufCurrentPosition == bufLineStartPosition {
 					err = fmt.Errorf("readHTTPPayloadLines() unexpectedly found an empty line in Payload")
 					return
 				}


### PR DESCRIPTION
Previously, this would erroneously report

    readHTTPPayloadLines() unexpectedly found an empty line in Payload