### PR TITLE
Bug fixes for permission checking

### DIFF
--- a/fs/api_internal.go
+++ b/fs/api_internal.go
@@ -155,7 +155,7 @@ func (vS *volumeStruct) inFlightFileInodeDataFlusher(inodeNumber inode.InodeNumb
 		logger.PanicfWithError(err, "dlm.Writelock() for volume '%s' inode %d failed", vS.volumeName, inodeNumber)
 	}
 
-	stillExists = vS.VolumeHandle.Access(inodeNumber, inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.F_OK)
+	stillExists = vS.VolumeHandle.Access(inodeNumber, inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.F_OK)
 	if stillExists {
 		err = vS.VolumeHandle.Flush(inodeNumber, false)
 		if nil != err {
@@ -1192,7 +1192,7 @@ func (mS *mountStruct) MiddlewareCoalesce(destPath string, elementPaths []string
 		pathComponent := destDirPathComponents[0]
 		// can't use Mkdir since it wants to take its own lock, so we make and link the dir ourselves
 
-		newDirInodeNumber, err1 := mS.volStruct.VolumeHandle.CreateDir(inode.InodeMode(0755), inode.InodeRootUserID, inode.InodeRootGroupID)
+		newDirInodeNumber, err1 := mS.volStruct.VolumeHandle.CreateDir(inode.InodeMode(0755), inode.InodeRootUserID, inode.InodeGroupID(0))
 		if err1 != nil {
 			logger.ErrorWithError(err1)
 			err = err1
@@ -1374,7 +1374,7 @@ func (mS *mountStruct) MiddlewareGetAccount(maxEntries uint64, marker string) (a
 	lastBasename := marker
 	for areMoreEntries && uint64(len(accountEnts)) < maxEntries {
 		var dirEnts []inode.DirEntry
-		dirEnts, _, areMoreEntries, err = mS.Readdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.RootDirInodeNumber, lastBasename, maxEntries-uint64(len(accountEnts)), 0)
+		dirEnts, _, areMoreEntries, err = mS.Readdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.RootDirInodeNumber, lastBasename, maxEntries-uint64(len(accountEnts)), 0)
 		if err != nil {
 			if blunder.Is(err, blunder.NotFoundError) {
 				// Readdir gives you a NotFoundError if you ask for a
@@ -1400,7 +1400,7 @@ func (mS *mountStruct) MiddlewareGetAccount(maxEntries uint64, marker string) (a
 				continue
 			}
 
-			statResult, err1 := mS.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, dirEnt.InodeNumber)
+			statResult, err1 := mS.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, dirEnt.InodeNumber)
 			if err1 != nil {
 				err = err1
 				return
@@ -1458,7 +1458,7 @@ func (mS *mountStruct) MiddlewareGetContainer(vContainerName string, maxEntries 
 		for (areMoreEntries || len(dirEnts) > 0 || len(recursiveDescents) > 0) && uint64(len(containerEnts)) < maxEntries {
 			// If we've run out of real directory entries, load some more.
 			if areMoreEntries && len(dirEnts) == 0 {
-				dirEnts, _, areMoreEntries, err = mS.Readdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, dirInode, lastBasename, maxEntries-uint64(len(containerEnts)), 0)
+				dirEnts, _, areMoreEntries, err = mS.Readdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, dirInode, lastBasename, maxEntries-uint64(len(containerEnts)), 0)
 				if err != nil {
 					logger.ErrorfWithError(err, "MiddlewareGetContainer: error reading directory %s (inode %v)", dirName, dirInode)
 					return err
@@ -1540,7 +1540,7 @@ func (mS *mountStruct) MiddlewareGetContainer(vContainerName string, maxEntries 
 				continue
 			}
 
-			statResult, err := mS.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, dirEnt.InodeNumber) // TODO: fix this
+			statResult, err := mS.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, dirEnt.InodeNumber) // TODO: fix this
 			if err != nil {
 				logger.ErrorfWithError(err, "MiddlewareGetContainer: error in Getstat of %s", fileName)
 				return err
@@ -1773,7 +1773,7 @@ func (mS *mountStruct) MiddlewarePost(parentDir string, baseName string, newMeta
 func putObjectHelper(mS *mountStruct, vContainerName string, vObjectPath string, makeInodeFunc func() (inode.InodeNumber, error)) (mtime uint64, fileInodeNumber inode.InodeNumber, numWrites uint64, err error) {
 
 	// Find the inode of the directory corresponding to the container
-	dirInodeNumber, err := mS.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.RootDirInodeNumber, vContainerName)
+	dirInodeNumber, err := mS.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.RootDirInodeNumber, vContainerName)
 	if err != nil {
 		return
 	}

--- a/fs/api_test.go
+++ b/fs/api_test.go
@@ -255,7 +255,7 @@ func createTestDirectory(t *testing.T, dirname string) (dirInode inode.InodeNumb
 	// Get root dir inode number
 	rootDirInodeNumber := inode.RootDirInodeNumber
 
-	dirInode, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, dirname, inode.PosixModePerm)
+	dirInode, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, dirname, inode.PosixModePerm)
 	if nil != err {
 		t.Fatalf("Mkdir() returned error: %v", err)
 	}
@@ -297,12 +297,12 @@ func TestCreateAndLookup(t *testing.T) {
 	rootDirInodeNumber := inode.RootDirInodeNumber
 	basename := "create_lookup.test"
 
-	createdFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename, inode.PosixModePerm)
+	createdFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename, inode.PosixModePerm)
 	if err != nil {
 		t.Fatalf("Unexpectedly couldn't create file: %v", err)
 	}
 
-	foundFileInodeNumber, err := mS.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename)
+	foundFileInodeNumber, err := mS.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename)
 	if err != nil {
 		t.Fatalf("Unexpectedly failed to look up %v", basename)
 	}
@@ -311,7 +311,7 @@ func TestCreateAndLookup(t *testing.T) {
 		t.Fatalf("Expected created inode number %v to equal found inode number %v", createdFileInodeNumber, foundFileInodeNumber)
 	}
 
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename)
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename)
 	if nil != err {
 		t.Fatalf("Unlink() returned error: %v", err)
 	}
@@ -322,12 +322,12 @@ func TestGetstat(t *testing.T) {
 	basename := "getstat.test"
 	timeBeforeCreation := uint64(time.Now().UnixNano())
 
-	inodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename, inode.PosixModePerm)
+	inodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename, inode.PosixModePerm)
 	if err != nil {
 		t.Fatalf("couldn't create file: %v", err)
 	}
 
-	stat, err := mS.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inodeNumber)
+	stat, err := mS.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inodeNumber)
 	if err != nil {
 		t.Fatalf("couldn't stat inode %v: %v", inodeNumber, err)
 	}
@@ -348,7 +348,7 @@ func TestGetstat(t *testing.T) {
 	// TODO: perform a write, check that size has changed accordingly
 	// TODO: make and delete hardlinks, check that link count has changed accordingly
 
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename)
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename)
 	if nil != err {
 		t.Fatalf("Unlink() returned error: %v", err)
 	}
@@ -391,21 +391,21 @@ func TestAllAPIPositiveCases(t *testing.T) {
 	rootDirInodeNumber := inode.RootDirInodeNumber
 
 	//    Mkdir          A/B/                                 : create a subdirectory within Volume directory
-	_, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, "TestSubDirectory", inode.PosixModePerm)
-	//	newDirInodeNum, err := mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, "TestSubDirectory")
+	_, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, "TestSubDirectory", inode.PosixModePerm)
+	//	newDirInodeNum, err := mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, "TestSubDirectory")
 	if nil != err {
 		t.Fatalf("Mkdir() returned error: %v", err)
 	}
 
 	//    Create      #1 A/C                                  : create and open a normal file within Volume directory
 	basename := "TestNormalFile"
-	createdFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename, inode.PosixModePerm)
+	createdFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename, inode.PosixModePerm)
 	if err != nil {
 		t.Fatalf("Create() [#1] returned error: %v", err)
 	}
 
 	//    Lookup      #1 A/C                                  : fetch the inode name of the just created normal file
-	foundFileInodeNumber, err := mS.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename)
+	foundFileInodeNumber, err := mS.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename)
 	if err != nil {
 		t.Fatalf("Lookup() [#1] returned error: %v", err)
 	}
@@ -415,7 +415,7 @@ func TestAllAPIPositiveCases(t *testing.T) {
 
 	//    Write          A/C                                  : write something to normal file
 	bufToWrite := []byte{0x41, 0x42, 0x43}
-	write_rspSize, err := mS.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, createdFileInodeNumber, 0, bufToWrite, nil)
+	write_rspSize, err := mS.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, createdFileInodeNumber, 0, bufToWrite, nil)
 	if nil != err {
 		t.Fatalf("Write() returned error: %v", err)
 	}
@@ -424,13 +424,13 @@ func TestAllAPIPositiveCases(t *testing.T) {
 	}
 
 	// don't forget to flush
-	err = mS.Flush(inode.InodeRootUserID, inode.InodeRootGroupID, nil, createdFileInodeNumber)
+	err = mS.Flush(inode.InodeRootUserID, inode.InodeGroupID(0), nil, createdFileInodeNumber)
 	if err != nil {
 		t.Fatalf("Flush() returned error: %v", err)
 	}
 
 	//    Read           A/C                                  : read back what was just written to normal file
-	read_buf, err := mS.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, createdFileInodeNumber, 0, uint64(len(bufToWrite)), nil)
+	read_buf, err := mS.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, createdFileInodeNumber, 0, uint64(len(bufToWrite)), nil)
 	if nil != err {
 		t.Fatalf("Read() returned error: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestAllAPIPositiveCases(t *testing.T) {
 	}
 
 	//    Getstat     #1 A/C                                  : check the current size of the normal file
-	getstat_1_rspStat, err := mS.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, foundFileInodeNumber)
+	getstat_1_rspStat, err := mS.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, foundFileInodeNumber)
 	if nil != err {
 		t.Fatalf("Getstat() returned error: %v", err)
 	}
@@ -455,13 +455,13 @@ func TestAllAPIPositiveCases(t *testing.T) {
 	}
 
 	//    Resize         A/C                                  : truncate the file
-	err = mS.Resize(inode.InodeRootUserID, inode.InodeRootGroupID, nil, foundFileInodeNumber, 0)
+	err = mS.Resize(inode.InodeRootUserID, inode.InodeGroupID(0), nil, foundFileInodeNumber, 0)
 	if nil != err {
 		t.Fatalf("Resize() returned error: %v", err)
 	}
 
 	//    Getstat     #2 A/C                                  : verify the size of the normal file is now zero
-	getstat_2_rspStat, err := mS.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, foundFileInodeNumber)
+	getstat_2_rspStat, err := mS.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, foundFileInodeNumber)
 	if nil != err {
 		t.Fatalf("Getstat() [#2] returned error: %v", err)
 	}
@@ -474,13 +474,13 @@ func TestAllAPIPositiveCases(t *testing.T) {
 	}
 
 	//    Symlink        A/D->A/C                             : create a symlink to the normal file
-	createdSymlinkInodeNumber, err := mS.Symlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, "TestSymlink", "TestNormalFile")
+	createdSymlinkInodeNumber, err := mS.Symlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, "TestSymlink", "TestNormalFile")
 	if nil != err {
 		t.Fatalf("Symlink() returned error: %v", err)
 	}
 
 	//    Lookup      #2 A/D                                  : fetch the inode name of the just created symlink
-	lookup_2_inodeHandle, err := mS.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, "TestSymlink")
+	lookup_2_inodeHandle, err := mS.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, "TestSymlink")
 	if nil != err {
 		t.Fatalf("Lookup() [#2] returned error: %v", err)
 	}
@@ -489,7 +489,7 @@ func TestAllAPIPositiveCases(t *testing.T) {
 	}
 
 	//    Readsymlink    A/D                                  : read the symlink to ensure it points to the normal file
-	readsymlink_target, err := mS.Readsymlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lookup_2_inodeHandle)
+	readsymlink_target, err := mS.Readsymlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lookup_2_inodeHandle)
 	if nil != err {
 		t.Fatalf("Readsymlink() returned error: %v", err)
 	}
@@ -498,69 +498,69 @@ func TestAllAPIPositiveCases(t *testing.T) {
 	}
 
 	//    Lookup      #3 A/B/                                 : fetch the inode name of the subdirectory
-	lookup_3_inodeHandle, err := mS.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, "TestSubDirectory")
+	lookup_3_inodeHandle, err := mS.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, "TestSubDirectory")
 	if nil != err {
 		t.Fatalf("Lookup() [#3] returned error: %v", err)
 	}
 
 	//    Create      #2 A/B/E                                : create a normal file within subdirectory
-	testSubDirectoryFileInode, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lookup_3_inodeHandle, "TestSubDirectoryFile", inode.PosixModePerm)
+	testSubDirectoryFileInode, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lookup_3_inodeHandle, "TestSubDirectoryFile", inode.PosixModePerm)
 	if nil != err {
 		t.Fatalf("Create() [#2] returned error: %v", err)
 	}
 
 	//    Readdir and examine contents
 	entriesExpected := []string{".", "..", "TestSubDirectoryFile"}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, lookup_3_inodeHandle, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), lookup_3_inodeHandle, entriesExpected)
 
 	//    Link A/B/E
-	err = mS.Link(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lookup_3_inodeHandle, "TestSubDirectoryFileHardLink", testSubDirectoryFileInode)
+	err = mS.Link(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lookup_3_inodeHandle, "TestSubDirectoryFileHardLink", testSubDirectoryFileInode)
 	if nil != err {
 		t.Fatalf("Link() returned error: %v", err)
 	}
 
 	entriesExpected = []string{".", "..", "TestSubDirectoryFile", "TestSubDirectoryFileHardLink"}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, lookup_3_inodeHandle, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), lookup_3_inodeHandle, entriesExpected)
 
 	//    Unlink      #1 A/B/E                                : delete the normal file within the subdirectory
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lookup_3_inodeHandle, "TestSubDirectoryFile")
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lookup_3_inodeHandle, "TestSubDirectoryFile")
 	if nil != err {
 		t.Fatalf("Unlink() [#1] returned error: %v", err)
 	}
 
 	entriesExpected = []string{".", "..", "TestSubDirectoryFileHardLink"}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, lookup_3_inodeHandle, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), lookup_3_inodeHandle, entriesExpected)
 
 	//    Unlink      #1.5 A/B/E                                : delete the normal file within the subdirectory
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lookup_3_inodeHandle, "TestSubDirectoryFileHardLink")
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lookup_3_inodeHandle, "TestSubDirectoryFileHardLink")
 	if nil != err {
 		t.Fatalf("Unlink() [#1.5] returned error: %v", err)
 	}
 
 	entriesExpected = []string{".", "..", "TestSymlink", "TestNormalFile", "TestSubDirectory"}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, rootDirInodeNumber, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), rootDirInodeNumber, entriesExpected)
 
 	//    Unlink      #2 A/D                                  : delete the symlink
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, "TestSymlink")
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, "TestSymlink")
 
 	if nil != err {
 		t.Fatalf("Unlink() [#2] returned error: %v", err)
 	}
 
 	//    Unlink      #3 A/C                                  : delete the normal file
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, "TestNormalFile")
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, "TestNormalFile")
 	if nil != err {
 		t.Fatalf("Unlink() [#3] returned error: %v", err)
 	}
 
 	//    Rmdir       #4 A/B                                  : delete the subdirectory
-	err = mS.Rmdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, "TestSubDirectory")
+	err = mS.Rmdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, "TestSubDirectory")
 	if nil != err {
 		t.Fatalf("Unlink() [#4] returned error: %v", err)
 	}
 
 	entriesExpected = []string{".", ".."}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, rootDirInodeNumber, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), rootDirInodeNumber, entriesExpected)
 }
 
 // TODO: flesh this out with other boundary condition testing for Link
@@ -568,13 +568,13 @@ func TestBadLinks(t *testing.T) {
 	testDirInode := createTestDirectory(t, "BadLinks")
 
 	validFile := "PerfectlyValidFile"
-	validFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testDirInode, validFile, inode.PosixModePerm)
+	validFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testDirInode, validFile, inode.PosixModePerm)
 	if err != nil {
 		t.Fatalf("Create() returned error: %v", err)
 	}
 
 	nameTooLong := strings.Repeat("x", FileNameMax+1)
-	err = mS.Link(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testDirInode, nameTooLong, validFileInodeNumber)
+	err = mS.Link(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testDirInode, nameTooLong, validFileInodeNumber)
 	if nil != err {
 		if blunder.IsNot(err, blunder.NameTooLongError) {
 			t.Fatalf("Link() returned error %v, expected %v(%d).", blunder.Errno(err), blunder.NameTooLongError, blunder.NameTooLongError.Value())
@@ -584,7 +584,7 @@ func TestBadLinks(t *testing.T) {
 	}
 
 	entriesExpected := []string{".", "..", validFile}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, testDirInode, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), testDirInode, entriesExpected)
 }
 
 func TestMkdir(t *testing.T) {
@@ -592,7 +592,7 @@ func TestMkdir(t *testing.T) {
 	longButLegalFilename := strings.Repeat("x", FileNameMax)
 	nameTooLong := strings.Repeat("x", FileNameMax+1)
 
-	_, err := mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testDirInode, nameTooLong, inode.PosixModePerm)
+	_, err := mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testDirInode, nameTooLong, inode.PosixModePerm)
 	if nil != err {
 		if blunder.IsNot(err, blunder.NameTooLongError) {
 			t.Fatalf("Mkdir() returned error %v, expected %v(%d).", blunder.Errno(err), blunder.NameTooLongError, blunder.NameTooLongError.Value())
@@ -601,21 +601,21 @@ func TestMkdir(t *testing.T) {
 		t.Fatal("Mkdir() unexpectedly succeeded on too-long filename!")
 	}
 
-	_, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testDirInode, longButLegalFilename, inode.PosixModePerm)
+	_, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testDirInode, longButLegalFilename, inode.PosixModePerm)
 	if err != nil {
 		t.Fatalf("Mkdir() returned error: %v", err)
 	}
 
 	entriesExpected := []string{".", "..", longButLegalFilename}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, testDirInode, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), testDirInode, entriesExpected)
 
 	longButLegalFullPath := "/Mkdir/" + longButLegalFilename
-	ino, err := mS.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, longButLegalFullPath)
+	ino, err := mS.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, longButLegalFullPath)
 	if err != nil {
 		t.Fatalf("LookupPath() returned error: %v", err)
 	}
 
-	_, err = mS.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.InodeNumber(ino))
+	_, err = mS.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(ino))
 	if err != nil {
 		t.Fatalf("GetStat() returned error: %v", err)
 	}
@@ -627,13 +627,13 @@ func TestBadRename(t *testing.T) {
 	nameTooLong := strings.Repeat("x", FileNameMax+1)
 
 	validFile := "PerfectlyValidFile"
-	_, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testDirInode, validFile, inode.PosixModePerm)
+	_, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testDirInode, validFile, inode.PosixModePerm)
 	if nil != err {
 		t.Fatalf("Create() returned error: %v", err)
 	}
 
 	// Try to rename a valid file to a name that is too long
-	err = mS.Rename(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testDirInode, validFile, testDirInode, nameTooLong)
+	err = mS.Rename(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testDirInode, validFile, testDirInode, nameTooLong)
 	if nil != err {
 		if blunder.IsNot(err, blunder.NameTooLongError) {
 			t.Fatalf("Link() returned error %v, expected %v(%d).", blunder.Errno(err), blunder.NameTooLongError, blunder.NameTooLongError.Value())
@@ -643,10 +643,10 @@ func TestBadRename(t *testing.T) {
 	}
 
 	entriesExpected := []string{".", "..", validFile}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, testDirInode, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), testDirInode, entriesExpected)
 
 	// Try to rename a nonexistent file with a name that is too long
-	err = mS.Rename(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testDirInode, nameTooLong, testDirInode, "AlsoAGoodFilename")
+	err = mS.Rename(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testDirInode, nameTooLong, testDirInode, "AlsoAGoodFilename")
 	if nil != err {
 		if blunder.IsNot(err, blunder.NameTooLongError) {
 			t.Fatalf("Link() returned error %v, expected %v(%d).", blunder.Errno(err), blunder.NameTooLongError, blunder.NameTooLongError.Value())
@@ -656,7 +656,7 @@ func TestBadRename(t *testing.T) {
 	}
 
 	entriesExpected = []string{".", "..", validFile}
-	expectDirectory(t, inode.InodeRootUserID, inode.InodeRootGroupID, testDirInode, entriesExpected)
+	expectDirectory(t, inode.InodeRootUserID, inode.InodeGroupID(0), testDirInode, entriesExpected)
 }
 
 func TestBadChownChmod(t *testing.T) {
@@ -667,7 +667,7 @@ func TestBadChownChmod(t *testing.T) {
 
 	// Create file to play with
 	basename := "TestFile"
-	createdFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename, inode.PosixModePerm)
+	createdFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename, inode.PosixModePerm)
 	if err != nil {
 		t.Fatalf("Create() %v returned error: %v", basename, err)
 	}
@@ -679,7 +679,7 @@ func TestBadChownChmod(t *testing.T) {
 	// Validate too-big Mode
 	stat := make(Stat)
 	stat[StatMode] = tooBigForUint32
-	err = mS.Setstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, createdFileInodeNumber, stat)
+	err = mS.Setstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, createdFileInodeNumber, stat)
 	if blunder.IsNot(err, blunder.InvalidFileModeError) {
 		t.Fatalf("Setstat() %v returned error %v, expected %v(%d).", basename, blunder.Errno(err), blunder.InvalidFileModeError, blunder.InvalidFileModeError.Value())
 	}
@@ -687,7 +687,7 @@ func TestBadChownChmod(t *testing.T) {
 
 	// Validate too-big UserID
 	stat[StatUserID] = tooBigForUint32
-	err = mS.Setstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, createdFileInodeNumber, stat)
+	err = mS.Setstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, createdFileInodeNumber, stat)
 	if blunder.Errno(err) != int(blunder.InvalidFileModeError) {
 		t.Fatalf("Setstat() %v returned error %v, expected %v(%d).", basename, blunder.Errno(err), blunder.InvalidFileModeError, blunder.InvalidFileModeError.Value())
 	}
@@ -695,7 +695,7 @@ func TestBadChownChmod(t *testing.T) {
 
 	// Validate too-big GroupID
 	stat[StatGroupID] = tooBigForUint32
-	err = mS.Setstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, createdFileInodeNumber, stat)
+	err = mS.Setstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, createdFileInodeNumber, stat)
 	if blunder.Errno(err) != int(blunder.InvalidFileModeError) {
 		t.Fatalf("Setstat() %v returned error %v, expected %v(%d).", basename, blunder.Errno(err), blunder.InvalidFileModeError, blunder.InvalidFileModeError.Value())
 	}
@@ -709,13 +709,13 @@ func TestFlock(t *testing.T) {
 
 	// Create file to play with
 	basename := "TestLockFile"
-	lockFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename, inode.PosixModePerm)
+	lockFileInodeNumber, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename, inode.PosixModePerm)
 	if err != nil {
 		t.Fatalf("Create() %v returned error: %v", basename, err)
 	}
 
 	// Resize the file to a 1M so that we can apply byte range locks:
-	err = mS.Resize(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, 1024*1024)
+	err = mS.Resize(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, 1024*1024)
 	if err != nil {
 		t.Fatalf("Resize() %v returned error: %v", basename, err)
 	}
@@ -727,20 +727,20 @@ func TestFlock(t *testing.T) {
 	lock.Len = 0
 	lock.Pid = 1
 
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
 	if err != nil {
 		t.Fatalf("Write lock on file failed: %v", err)
 	}
 
 	lock.Type = syscall.F_UNLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
 	if err != nil {
 		t.Fatalf("Unlock on file failed: %v", blunder.Errno(err))
 	}
 
 	lock.Type = syscall.F_WRLCK
 	lock.Pid = 1
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
 	if err != nil {
 		t.Fatalf("Write lock on file failed: %v", err)
 	}
@@ -749,32 +749,32 @@ func TestFlock(t *testing.T) {
 	var lock1 FlockStruct
 	lock1 = lock
 	lock1.Pid = 2
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock1)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock1)
 	if blunder.Errno(err) != int(blunder.TryAgainError) {
 		t.Fatalf("Write lock on a locked file should fail with EAGAIN instead got : %v", err)
 	}
 
 	// Lock again from pid1, it should succeed:
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
 	if err != nil {
 		t.Fatalf("Relocking from same PID on file failed: %v", err)
 	}
 
 	lock.Type = syscall.F_UNLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
 	if err != nil {
 		t.Fatalf("Unlock failed : %v", err)
 	}
 
 	// Read lock test:
 	lock.Type = syscall.F_RDLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock)
 	if err != nil {
 		t.Fatalf("Read lock pid - 1 failed: %v", err)
 	}
 
 	lock1.Type = syscall.F_RDLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock1)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock1)
 	if err != nil {
 		t.Fatalf("Read lock pid - 2 failed: %v", err)
 	}
@@ -783,32 +783,32 @@ func TestFlock(t *testing.T) {
 	lock3 := lock
 	lock3.Type = syscall.F_WRLCK
 	lock3.Pid = 3
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock3)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock3)
 	if blunder.Errno(err) != int(blunder.TryAgainError) {
 		t.Fatalf("Write lock should have failed with EAGAIN instead got - %v", err)
 	}
 
 	lock11 := lock1
 	lock11.Type = syscall.F_UNLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock11)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock11)
 	if err != nil {
 		t.Fatalf("Unlock of (readlock) - 2 failed: %v", err)
 	}
 
 	lock01 := lock
 	lock01.Type = syscall.F_UNLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock01)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock01)
 	if err != nil {
 		t.Fatalf("Unlock of (readlock) - 1 failed: %v", err)
 	}
 
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock3)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock3)
 	if err != nil {
 		t.Fatalf("Write lock should have succeeded instead got - %v", err.Error())
 	}
 
 	lock3.Type = syscall.F_UNLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock3)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock3)
 	if err != nil {
 		t.Fatalf("Unlock of (write after read) failed: %v", err)
 	}
@@ -822,7 +822,7 @@ func TestFlock(t *testing.T) {
 	lock10.Type = syscall.F_WRLCK
 	lock10.Whence = 0
 
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock10)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock10)
 	if err != nil {
 		t.Fatalf("Range test failed to lock range (100 - 200), err %v", err)
 	}
@@ -832,7 +832,7 @@ func TestFlock(t *testing.T) {
 	lock201.Type = syscall.F_RDLCK
 	lock201.Start = 10
 	lock201.Len = 10
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock201)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock201)
 	if err != nil {
 		t.Fatalf("Range test failed to read lock range (10 - 20) by pid2, err %v", err)
 	}
@@ -840,7 +840,7 @@ func TestFlock(t *testing.T) {
 	lock202 := lock201
 	lock202.Start = 90
 	lock202.Len = 10
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock202)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock202)
 	if err != nil {
 		t.Fatalf("Range test failed to read lock range (90 - 100) by pid2, err %v", err)
 	}
@@ -848,14 +848,14 @@ func TestFlock(t *testing.T) {
 	lock203 := lock202
 	lock203.Start = 80
 	lock203.Len = 40
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock203)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock203)
 	if err == nil {
 		t.Fatalf("Range test read lock of range (80 - 120) should have failed for pid2  err %v", err)
 	}
 
 	lock204 := lock203
 	lock204.Start = 180
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock204)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock204)
 	if err == nil {
 		t.Fatalf("Range test read lock of range (180 - 220) should have failed for pid2  err %v", err)
 	}
@@ -863,7 +863,7 @@ func TestFlock(t *testing.T) {
 	lock205 := lock204
 	lock205.Start = 200
 	lock205.Len = 10
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock205)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock205)
 	if err != nil {
 		t.Fatalf("Range test read lock of range (200 - 210) should have succeeded for pid2  err %v", err)
 	}
@@ -871,44 +871,44 @@ func TestFlock(t *testing.T) {
 	lock206 := lock205
 	lock206.Start = 240
 	lock206.Len = 10
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock206)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock206)
 	if err != nil {
 		t.Fatalf("Range test read lock of range (240 - 250) should have succeeded for pid2  err %v", err)
 	}
 
 	lock101 := lock10
 	lock101.Type = syscall.F_RDLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock101)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock101)
 	if err != nil {
 		t.Fatalf("Range test converting write lock to read lock of pid1 range 100 - 200 failed, err %v", err)
 	}
 
 	// Now, lock 203 and 204 should succceed.
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock203)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock203)
 	if err != nil {
 		t.Fatalf("Range test read lock of range (80 - 120) should have succeeded for pid2  err %v", err)
 	}
 
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock204)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock204)
 	if err != nil {
 		t.Fatalf("Range test read lock of range (180 - 220) should have succeeded for pid2  err %v", err)
 	}
 
 	lock30 := lock10
 	lock30.Pid = 3
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock30)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock30)
 	if err == nil {
 		t.Fatalf("Range test write lock of range 100 - 200 should have failed for pid3 err %v", err)
 	}
 
 	lock102 := lock10
 	lock102.Type = syscall.F_UNLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock102)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock102)
 	if err != nil {
 		t.Fatalf("Range test unlock of range 100 - 200 for pid1 should have succeeded, err - %v", err)
 	}
 
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock30)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock30)
 	if err == nil {
 		t.Fatalf("Range test write lock of range 100 - 200 should have failed for pid3 err %v", err)
 	}
@@ -916,19 +916,19 @@ func TestFlock(t *testing.T) {
 	lock207 := lock10
 	lock207.Type = syscall.F_UNLCK
 	lock207.Pid = 2
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock207)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock207)
 	if err != nil {
 		t.Fatalf("Range test unlock of range 100 - 200 for pid2 should have succeeded, err - %v", err)
 	}
 
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock30)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock30)
 	if err != nil {
 		t.Fatalf("Range test write lock of range 100 - 200 should have succeeded for pid3 err %v", err)
 	}
 
 	lock301 := lock30
 	lock301.Type = syscall.F_UNLCK
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock301)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock301)
 	if err != nil {
 		t.Fatalf("Range test unlock of range 100 - 200 should have succeeded for pid3 err %v", err)
 	}
@@ -937,7 +937,7 @@ func TestFlock(t *testing.T) {
 	lock2u1.Type = syscall.F_UNLCK
 	lock2u1.Start = 0
 	lock2u1.Len = 150
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock2u1)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock2u1)
 	if err != nil {
 		t.Fatalf("Range test unlock of range 0 - 150 should have succeeded for pid2 err %v", err)
 	}
@@ -945,7 +945,7 @@ func TestFlock(t *testing.T) {
 	lock2u2 := lock2u1
 	lock2u2.Start = 150
 	lock2u2.Len = 150
-	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_SETLK, &lock2u2)
+	_, err = mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_SETLK, &lock2u2)
 	if err != nil {
 		t.Fatalf("Range test unlock of range 150 - 300 should have succeeded for pid2 err %v", err)
 	}
@@ -953,7 +953,7 @@ func TestFlock(t *testing.T) {
 	lock30.Start = 0
 	lock30.Len = 250
 	lock30.Type = syscall.F_WRLCK
-	lockHeld, err := mS.Flock(inode.InodeRootUserID, inode.InodeRootGroupID, nil, lockFileInodeNumber, syscall.F_GETLK, &lock30)
+	lockHeld, err := mS.Flock(inode.InodeRootUserID, inode.InodeGroupID(0), nil, lockFileInodeNumber, syscall.F_GETLK, &lock30)
 	if err != nil {
 		t.Fatalf("Range test GET write lock of range 0 - 250 should have succeeded for pid3 err %v lockHeld %+v", err, lockHeld)
 	}
@@ -962,7 +962,7 @@ func TestFlock(t *testing.T) {
 		t.Fatalf("GetLock should have succeeded for range 0 - 250 for pid 3, err %v", err)
 	}
 
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, rootDirInodeNumber, basename)
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, rootDirInodeNumber, basename)
 	if err != nil {
 		t.Fatalf("Unlink() %v returned error: %v", basename, err)
 	}
@@ -986,31 +986,31 @@ func TestStaleInodes(t *testing.T) {
 	)
 
 	// scratchpad directory for testing
-	testDirInodeNumber, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	testDirInodeNumber, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		rootDirInodeNumber, testDirname, 0755)
 	if nil != err {
 		t.Fatalf("Mkdir() '%s' returned error: %v", testDirname, err)
 	}
 
 	// create a valid test file
-	testFileInodeNumber, err = mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	testFileInodeNumber, err = mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, testFileName, 0644)
 	if nil != err {
 		t.Fatalf("Create() '%s' returned error: %v", testFileName, err)
 	}
 
 	// get an inode number that used to belong to a dirctory
-	_, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, staleDirName, 0755)
 	if nil != err {
 		t.Fatalf("Mkdir() '%s' returned error: %v", testDirname, err)
 	}
-	staleDirInodeNumber, err = mS.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	staleDirInodeNumber, err = mS.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, staleDirName)
 	if err != nil {
 		t.Fatalf("Unexpectedly failed to look up of '%s': %v", testDirname, err)
 	}
-	err = mS.Rmdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Rmdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, staleDirName)
 	if nil != err {
 		t.Fatalf("Rmdir() of '%s' returned error: %v", staleDirName, err)
@@ -1019,24 +1019,24 @@ func TestStaleInodes(t *testing.T) {
 	// get an inode number that used to belong to a file (it shouldn't
 	// really matter which type of file the inode used to be, but it doesn't
 	// hurt to have two to play with)
-	_, err = mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, err = mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, staleFileName, 0644)
 	if nil != err {
 		t.Fatalf("Mkdir() '%s' returned error: %v", testDirname, err)
 	}
-	staleFileInodeNumber, err = mS.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	staleFileInodeNumber, err = mS.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, staleFileName)
 	if err != nil {
 		t.Fatalf("Unexpectedly failed to look up of '%s': %v", testDirname, err)
 	}
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, staleFileName)
 	if nil != err {
 		t.Fatalf("Unlink() of '%s' returned error: %v", staleFileName, err)
 	}
 
 	// Stat
-	_, err = mS.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, staleFileInodeNumber)
+	_, err = mS.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, staleFileInodeNumber)
 	if nil == err {
 		t.Fatalf("Getstat() should not have returned success")
 	}
@@ -1045,7 +1045,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Mkdir
-	_, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, err = mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "TestSubDirectory", 0755)
 	if nil == err {
 		t.Fatalf("Mkdir() should not have returned success")
@@ -1055,7 +1055,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Rmdir
-	err = mS.Rmdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Rmdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "fubar")
 	if nil == err {
 		t.Fatalf("Rmdir() should not have returned success")
@@ -1065,7 +1065,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Create
-	_, err = mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, err = mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "fubar", 0644)
 	if nil == err {
 		t.Fatalf("Create() should not have returned success")
@@ -1075,7 +1075,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Lookup
-	_, err = mS.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, err = mS.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "fubar")
 	if nil == err {
 		t.Fatalf("Lookup() should not have returned success")
@@ -1086,7 +1086,7 @@ func TestStaleInodes(t *testing.T) {
 
 	// Write
 	bufToWrite := []byte{0x41, 0x42, 0x43}
-	_, err = mS.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, err = mS.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleFileInodeNumber, 0, bufToWrite, nil)
 	if nil == err {
 		t.Fatalf("Write() should not have returned success")
@@ -1096,7 +1096,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Read
-	_, err = mS.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, err = mS.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleFileInodeNumber, 0, uint64(len(bufToWrite)), nil)
 	if nil == err {
 		t.Fatalf("Read() should not have returned success")
@@ -1106,7 +1106,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Trunc
-	err = mS.Resize(inode.InodeRootUserID, inode.InodeRootGroupID, nil, staleFileInodeNumber, 77)
+	err = mS.Resize(inode.InodeRootUserID, inode.InodeGroupID(0), nil, staleFileInodeNumber, 77)
 	if nil == err {
 		t.Fatalf("Resize() should not have returned success")
 	}
@@ -1115,7 +1115,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Symlink
-	_, err = mS.Symlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, err = mS.Symlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "TestSymlink", "fubar")
 	if nil == err {
 		t.Fatalf("Symlink() should not have returned success")
@@ -1125,7 +1125,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Readsymlink (that we didn't create)
-	_, err = mS.Readsymlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, staleFileInodeNumber)
+	_, err = mS.Readsymlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, staleFileInodeNumber)
 	if nil == err {
 		t.Fatalf("Readsymlink() should not have returned success")
 	}
@@ -1134,7 +1134,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Readdir
-	_, _, _, err = mS.Readdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	_, _, _, err = mS.Readdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "", 0, 0)
 	if nil == err {
 		t.Fatalf("Readdir() should not have returned success")
@@ -1144,7 +1144,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Link -- two cases, one with stale directory and one with stale file
-	err = mS.Link(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Link(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "fubar", testFileInodeNumber)
 	if nil == err {
 		t.Fatalf("Link(1) should not have returned success")
@@ -1153,7 +1153,7 @@ func TestStaleInodes(t *testing.T) {
 		t.Fatalf("Link(1) should have failed with NotFoundError, instead got: %v", err)
 	}
 
-	err = mS.Link(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Link(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, testFileName, staleFileInodeNumber)
 	if nil == err {
 		t.Fatalf("Link(2) should not have returned success")
@@ -1163,7 +1163,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Unlink
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "fubar")
 	if nil == err {
 		t.Fatalf("Unlink() should not have returned success")
@@ -1173,7 +1173,7 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// Rename -- two cases, one with stale src directory and one with stale dest
-	err = mS.Rename(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Rename(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, "fubar", staleDirInodeNumber, "barfu")
 	if nil == err {
 		t.Fatalf("Rename(1) should not have returned success")
@@ -1182,7 +1182,7 @@ func TestStaleInodes(t *testing.T) {
 		t.Fatalf("Rename(1) should have failed with NotFoundError, instead got: %v", err)
 	}
 
-	err = mS.Rename(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Rename(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		staleDirInodeNumber, "fubar", testDirInodeNumber, "barfu")
 	if nil == err {
 		t.Fatalf("Rename(2) should not have returned success")
@@ -1192,12 +1192,12 @@ func TestStaleInodes(t *testing.T) {
 	}
 
 	// cleanup test file and directory
-	err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		testDirInodeNumber, testFileName)
 	if nil != err {
 		t.Fatalf("Unlink() of '%s' returned error: %v", testFileName, err)
 	}
-	err = mS.Rmdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil,
+	err = mS.Rmdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil,
 		rootDirInodeNumber, testDirname)
 	if nil != err {
 		t.Fatalf("Rmdir() of '%s' returned error: %v", testDirname, err)

--- a/fs/threads_test.go
+++ b/fs/threads_test.go
@@ -113,23 +113,23 @@ func loopOp(fileRequest *testRequest, threadID int, inodeNumber inode.InodeNumbe
 		fName := name1 + "-" + strconv.Itoa(localLoopCount)
 		switch fileRequest.opType {
 		case createLoopTestOp:
-			_, err = mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inodeNumber, fName, inode.PosixModePerm)
+			_, err = mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inodeNumber, fName, inode.PosixModePerm)
 		case lookupPathLoopTestOp:
-			_, err = mS.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fName)
+			_, err = mS.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fName)
 		case readdirLoopTestOp:
 			areMoreEntries := true
 			lastBasename := ""
 			var maxEntries uint64 = 10
 			var totalEntriesRead uint64 // Useful for debugging
 			for areMoreEntries {
-				dirEnts, numEntries, more, errShadow := mS.Readdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inodeNumber, lastBasename, maxEntries, 0)
+				dirEnts, numEntries, more, errShadow := mS.Readdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inodeNumber, lastBasename, maxEntries, 0)
 				lastBasename = dirEnts[len(dirEnts)-1].Basename
 				areMoreEntries = more
 				err = errShadow
 				totalEntriesRead = totalEntriesRead + numEntries
 			}
 		case unlinkLoopTestOp:
-			err = mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inodeNumber, fName)
+			err = mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inodeNumber, fName)
 		}
 		localLoopCount++
 		infiniteLoopCount++
@@ -171,7 +171,7 @@ func threadNode(threadID int) {
 			return
 
 		case createTestOp:
-			_, err := mS.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inodeNumber, name1, inode.PosixModePerm)
+			_, err := mS.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inodeNumber, name1, inode.PosixModePerm)
 			response := &testResponse{err: err}
 			threadMap[threadID].operationStatus <- response
 
@@ -188,7 +188,7 @@ func threadNode(threadID int) {
 			threadMap[threadID].operationStatus <- response
 
 		case mkdirTestOp:
-			newInodeNumber, err := mS.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inodeNumber, name1, inode.PosixModePerm)
+			newInodeNumber, err := mS.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inodeNumber, name1, inode.PosixModePerm)
 			response := &testResponse{err: err, inodeNumber: newInodeNumber}
 			threadMap[threadID].operationStatus <- response
 
@@ -199,12 +199,12 @@ func threadNode(threadID int) {
 			threadMap[threadID].operationStatus <- response
 
 		case rmdirTestOp:
-			err := mS.Rmdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inodeNumber, name1)
+			err := mS.Rmdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inodeNumber, name1)
 			response := &testResponse{err: err}
 			threadMap[threadID].operationStatus <- response
 
 		case unlinkTestOp:
-			err := mS.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inodeNumber, name1)
+			err := mS.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inodeNumber, name1)
 			response := &testResponse{err: err}
 			threadMap[threadID].operationStatus <- response
 

--- a/fsworkout/main.go
+++ b/fsworkout/main.go
@@ -342,13 +342,13 @@ func fsWorkout(threadIndex uint64) {
 	if perThreadDir {
 		dirInodeName = fmt.Sprintf("%s%016X", dirInodeNamePrefix, threadIndex)
 		if measureCreate {
-			dirInodeNumber, err = mountHandle.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.RootDirInodeNumber, dirInodeName, inode.PosixModePerm)
+			dirInodeNumber, err = mountHandle.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.RootDirInodeNumber, dirInodeName, inode.PosixModePerm)
 			if nil != err {
 				stepErrChan <- err
 				runtime.Goexit()
 			}
 		} else { // measureStat || measureDestroy
-			dirInodeNumber, err = mountHandle.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.RootDirInodeNumber, dirInodeName)
+			dirInodeNumber, err = mountHandle.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.RootDirInodeNumber, dirInodeName)
 			if nil != err {
 				stepErrChan <- err
 				runtime.Goexit()
@@ -371,24 +371,24 @@ func fsWorkout(threadIndex uint64) {
 	// Do measured operations
 	for i = 0; i < inodesPerThread; i++ {
 		if measureCreate {
-			fileInodeNumber, err = mountHandle.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, dirInodeNumber, fileInodeName[i], inode.PosixModePerm)
+			fileInodeNumber, err = mountHandle.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, dirInodeNumber, fileInodeName[i], inode.PosixModePerm)
 			if nil != err {
 				stepErrChan <- err
 				runtime.Goexit()
 			}
 		} else if measureStat {
-			fileInodeNumber, err = mountHandle.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil, dirInodeNumber, fileInodeName[i])
+			fileInodeNumber, err = mountHandle.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, dirInodeNumber, fileInodeName[i])
 			if nil != err {
 				stepErrChan <- err
 				runtime.Goexit()
 			}
-			_, err = mountHandle.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInodeNumber)
+			_, err = mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInodeNumber)
 			if nil != err {
 				stepErrChan <- err
 				runtime.Goexit()
 			}
 		} else { // measureDestroy
-			err = mountHandle.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, dirInodeNumber, fileInodeName[i])
+			err = mountHandle.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, dirInodeNumber, fileInodeName[i])
 			if nil != err {
 				stepErrChan <- err
 				runtime.Goexit()
@@ -404,7 +404,7 @@ func fsWorkout(threadIndex uint64) {
 
 	// Do shutdown step
 	if perThreadDir && measureDestroy {
-		err = mountHandle.Rmdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.RootDirInodeNumber, dirInodeName)
+		err = mountHandle.Rmdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.RootDirInodeNumber, dirInodeName)
 		if nil != err {
 			stepErrChan <- err
 			runtime.Goexit()

--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -33,7 +33,7 @@ func (d Dir) Attr(ctx context.Context, attr *fuselib.Attr) (err error) {
 		stat fs.Stat
 	)
 
-	stat, err = d.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, d.inodeNumber)
+	stat, err = d.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, d.inodeNumber)
 	if nil != err {
 		err = newFuseError(err)
 		return
@@ -113,12 +113,12 @@ func (d Dir) Setattr(ctx context.Context, req *fuselib.SetattrRequest, resp *fus
 }
 
 func (d Dir) Lookup(ctx context.Context, name string) (fusefslib.Node, error) {
-	childInodeNumber, err := d.mountHandle.Lookup(inode.InodeRootUserID, inode.InodeRootGroupID, nil, d.inodeNumber, name)
+	childInodeNumber, err := d.mountHandle.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, d.inodeNumber, name)
 	if err != nil {
 		return nil, fuselib.ENOENT
 	}
 
-	isDir, err := d.mountHandle.IsDir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, childInodeNumber)
+	isDir, err := d.mountHandle.IsDir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, childInodeNumber)
 	if isDir {
 		return Dir{mountHandle: d.mountHandle, inodeNumber: childInodeNumber}, nil
 	} else if err != nil {
@@ -126,7 +126,7 @@ func (d Dir) Lookup(ctx context.Context, name string) (fusefslib.Node, error) {
 		return nil, err
 	}
 
-	isFile, err := d.mountHandle.IsFile(inode.InodeRootUserID, inode.InodeRootGroupID, nil, childInodeNumber)
+	isFile, err := d.mountHandle.IsFile(inode.InodeRootUserID, inode.InodeGroupID(0), nil, childInodeNumber)
 	if isFile {
 		return File{mountHandle: d.mountHandle, inodeNumber: childInodeNumber}, nil
 	} else if err != nil {
@@ -134,7 +134,7 @@ func (d Dir) Lookup(ctx context.Context, name string) (fusefslib.Node, error) {
 		return nil, err
 	}
 
-	isSymlink, err := d.mountHandle.IsSymlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, childInodeNumber)
+	isSymlink, err := d.mountHandle.IsSymlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, childInodeNumber)
 	if isSymlink {
 		return Symlink{mountHandle: d.mountHandle, inodeNumber: childInodeNumber}, nil
 	} else if err != nil {
@@ -142,7 +142,7 @@ func (d Dir) Lookup(ctx context.Context, name string) (fusefslib.Node, error) {
 		return nil, err
 	}
 
-	actualType, err := d.mountHandle.GetType(inode.InodeRootUserID, inode.InodeRootGroupID, nil, childInodeNumber)
+	actualType, err := d.mountHandle.GetType(inode.InodeRootUserID, inode.InodeGroupID(0), nil, childInodeNumber)
 	if err != nil {
 		err = newFuseError(err)
 		return nil, err
@@ -178,7 +178,7 @@ func (d Dir) ReadDirAll(ctx context.Context) ([]fuselib.Dirent, error) {
 		var readCount uint64
 		var err error
 
-		readEntries, readCount, more, err = d.mountHandle.Readdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, d.inodeNumber, lastEntryName, 1024, 4096)
+		readEntries, readCount, more, err = d.mountHandle.Readdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, d.inodeNumber, lastEntryName, 1024, 4096)
 		if err != nil {
 			logger.ErrorfWithError(err, "Error in ReadDirAll")
 			return nil, fuselib.EIO
@@ -191,7 +191,7 @@ func (d Dir) ReadDirAll(ctx context.Context) ([]fuselib.Dirent, error) {
 	fuseEntries := make([]fuselib.Dirent, entryCount)
 
 	for i, entry := range entries {
-		inodeType, _ := d.mountHandle.GetType(inode.InodeRootUserID, inode.InodeRootGroupID, nil, entry.InodeNumber)
+		inodeType, _ := d.mountHandle.GetType(inode.InodeRootUserID, inode.InodeGroupID(0), nil, entry.InodeNumber)
 		fuseEntries[i] = fuselib.Dirent{
 			Inode: uint64(entry.InodeNumber),
 			Type:  inodeTypeToDirentType(inodeType),

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -32,7 +32,7 @@ func (f File) Attr(ctx context.Context, attr *fuselib.Attr) (err error) {
 		stat fs.Stat
 	)
 
-	stat, err = f.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, f.inodeNumber)
+	stat, err = f.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, f.inodeNumber)
 	if nil != err {
 		err = newFuseError(err)
 		return

--- a/fuse/symlink.go
+++ b/fuse/symlink.go
@@ -23,7 +23,7 @@ func (s Symlink) Attr(ctx context.Context, attr *fuselib.Attr) (err error) {
 		stat fs.Stat
 	)
 
-	stat, err = s.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, s.inodeNumber)
+	stat, err = s.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, s.inodeNumber)
 	if nil != err {
 		err = newFuseError(err)
 		return

--- a/inode/api.go
+++ b/inode/api.go
@@ -30,13 +30,21 @@ const (
 )
 
 // The following are used in calls to Access()... either F_OK or bitwise or of R_OK, W_OK, and X_OK
-
 const (
 	F_OK = InodeMode(unix.F_OK)                               //         check for existence
 	R_OK = InodeMode(unix.R_OK)                               // UID:GID check for read    permission
 	W_OK = InodeMode(unix.W_OK)                               // UID:GID check for write   permission
 	X_OK = InodeMode(unix.X_OK)                               // UID:GID check for execute permission
-	P_OK = InodeMode((unix.R_OK | unix.W_OK | unix.X_OK) + 1) //         check for ownership
+	P_OK = InodeMode((unix.R_OK | unix.W_OK | unix.X_OK) + 1) //         check for ownership permissions
+)
+
+// AccessOverride.Owner means Access() grants permission to the owner of the
+// file even if the permission bits disallow it.
+type AccessOverride uint32
+
+const (
+	NoOverride AccessOverride = iota
+	OwnerOverride
 )
 
 // The following line of code is a directive to go generate that tells it to create a
@@ -124,7 +132,7 @@ type VolumeHandle interface {
 
 	// Common Inode methods, implemented in inode.go
 
-	Access(inodeNumber InodeNumber, userID InodeUserID, groupID InodeGroupID, otherGroupIDs []InodeGroupID, accessMode InodeMode) (accessReturn bool)
+	Access(inodeNumber InodeNumber, userID InodeUserID, groupID InodeGroupID, otherGroupIDs []InodeGroupID, accessMode InodeMode, override AccessOverride) (accessReturn bool)
 	Purge(inodeNumber InodeNumber) (err error)
 	Destroy(inodeNumber InodeNumber) (err error)
 	GetMetadata(inodeNumber InodeNumber) (metadata *MetadataStruct, err error)

--- a/inode/api.go
+++ b/inode/api.go
@@ -18,8 +18,7 @@ type InodeGroupID uint32
 type InodeDirLocation int64
 
 const (
-	InodeRootUserID  = InodeUserID(0)
-	InodeRootGroupID = InodeGroupID(0)
+	InodeRootUserID = InodeUserID(0)
 )
 
 // NOTE: Using unix.DT_* constants for these types makes it easier

--- a/inode/api_test.go
+++ b/inode/api_test.go
@@ -453,19 +453,28 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("CreateFile() failed: %v", err)
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, F_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, F_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,,F_OK) after CreateFile() should not have failed")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(456), nil, R_OK|W_OK|X_OK) {
-		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK|W_OK|X_OK) should have returned true")
+	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(456), nil,
+		R_OK|W_OK, NoOverride) {
+		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK|W_OK) should have returned true")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(0), nil, R_OK|W_OK|X_OK) {
-		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK|W_OK|X_OK) should have returned true")
+	// not even root can execute a file without any execute bits set
+	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(456), nil,
+		X_OK, NoOverride) {
+		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK|W_OK|X_OK) should have returned false")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, R_OK|P_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(0), nil,
+		R_OK|W_OK|X_OK, NoOverride) {
+		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),InodeGroupID(0),,R_OK|W_OK|X_OK) should have returned false")
+	}
+
+	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil,
+		R_OK|P_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,,R_OK|X_OK) should have returned false")
 	}
 
@@ -474,16 +483,20 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("SetOwnerUserID(,InodeUserID(123)) failed: %v", err)
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, P_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, P_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,InodeRootUserID,,,P_OK should have returned true")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(0), nil, P_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(0), nil, P_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,P_OK should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(789), InodeGroupID(0), nil, P_OK) {
-		t.Fatalf("Access(fileInodeNumber,InodeUserID(789),,,P_OK should have returned true")
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(0), nil, P_OK, OwnerOverride) {
+		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,P_OK,UserOveride should have returned true")
+	}
+
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(789), InodeGroupID(0), nil, P_OK, NoOverride) {
+		t.Fatalf("Access(fileInodeNumber,InodeUserID(789),,,P_OK should have returned false")
 	}
 
 	err = testVolumeHandle.SetPermMode(fileInodeNumber, InodeMode(0600))
@@ -491,24 +504,30 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("SetPermMode(,InodeMode(0600)) failed: %v", err)
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK) should have returned true")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, W_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, W_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,W_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, X_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, X_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,X_OK) should have returned false")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK|W_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK|W_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK|W_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK|W_OK|X_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil,
+		R_OK|W_OK|X_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK|W_OK|X_OK) should have returned false")
+	}
+
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil,
+		R_OK|W_OK|X_OK, OwnerOverride) {
+		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),OwnerOverride,,R_OK|W_OK|X_OK) should have returned false")
 	}
 
 	err = testVolumeHandle.SetOwnerUserIDGroupID(fileInodeNumber, InodeRootUserID, InodeGroupID(456))
@@ -521,43 +540,54 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("SetPermMode(,InodeMode(0060)) failed: %v", err)
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,InodeGroupID(456),,R_OK) should have returned true")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, W_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, W_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,InodeGroupID(456),,W_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, X_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, X_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,InodeGroupID(456),,X_OK) should have returned false")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK|W_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, X_OK, OwnerOverride) {
+		t.Fatalf("Access(fileInodeNumber,,InodeGroupID(456),,X_OK,OwnerOverride) should have returned false")
+	}
+
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil,
+		R_OK|W_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,InodeGroupID(456),,R_OK|W_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK|W_OK|X_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil,
+		R_OK|W_OK|X_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,InodeGroupID(456),,R_OK|W_OK|X_OK) should have returned false")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789), []InodeGroupID{InodeGroupID(456)}, R_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789),
+		[]InodeGroupID{InodeGroupID(456)}, R_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,[]InodeGroupID{InodeGroupID(456)},R_OK) should have returned true")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789), []InodeGroupID{InodeGroupID(456)}, W_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789),
+		[]InodeGroupID{InodeGroupID(456)}, W_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,[]InodeGroupID{InodeGroupID(456)},W_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789), []InodeGroupID{InodeGroupID(456)}, X_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789),
+		[]InodeGroupID{InodeGroupID(456)}, X_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,[]InodeGroupID{InodeGroupID(456)},X_OK) should have returned false")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789), []InodeGroupID{InodeGroupID(456)}, R_OK|W_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789),
+		[]InodeGroupID{InodeGroupID(456)}, R_OK|W_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,[]InodeGroupID{InodeGroupID(456)},R_OK|W_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789), []InodeGroupID{InodeGroupID(456)}, R_OK|W_OK|X_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(789),
+		[]InodeGroupID{InodeGroupID(456)}, R_OK|W_OK|X_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,[]InodeGroupID{InodeGroupID(456)},R_OK|W_OK|X_OK) should have returned false")
 	}
 
@@ -565,29 +595,53 @@ func TestAPI(t *testing.T) {
 	if nil != err {
 		t.Fatalf("SetPermMode(,InodeMode(0006)) failed: %v", err)
 	}
-	err = testVolumeHandle.SetOwnerUserIDGroupID(fileInodeNumber, InodeRootUserID, InodeGroupID(0))
+	err = testVolumeHandle.SetOwnerUserIDGroupID(fileInodeNumber, InodeUserID(456), InodeGroupID(0))
 	if nil != err {
 		t.Fatalf("SetOwnerUserIDGroupID(,InodeRootUserID,InodeGroupID(0)) failed: %v", err)
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,,R_OK) should have returned true")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, W_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, W_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,,W_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, X_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, X_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,,X_OK) should have returned false")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK|W_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil,
+		R_OK|W_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,,R_OK|W_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK|W_OK|X_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil,
+		R_OK|W_OK|X_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,,R_OK|W_OK|X_OK) should have returned false")
+	}
+
+	// Test the ability of OwnerOverride to override permissions checks for owner (except for exec)
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(456), InodeGroupID(456), nil, R_OK, NoOverride) {
+		t.Fatalf("Access(fileInodeNumber,,,,R_OK) should have returned false")
+	}
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(456), InodeGroupID(456), nil, R_OK, OwnerOverride) {
+		t.Fatalf("Access(fileInodeNumber,,,,R_OK) should have returned true")
+	}
+
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(456), InodeGroupID(456), nil, W_OK, NoOverride) {
+		t.Fatalf("Access(fileInodeNumber,,,,W_OK) should have returned false")
+	}
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(456), InodeGroupID(456), nil, W_OK, OwnerOverride) {
+		t.Fatalf("Access(fileInodeNumber,,,,W_OK) should have returned true")
+	}
+
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(456), InodeGroupID(456), nil, X_OK, NoOverride) {
+		t.Fatalf("Access(fileInodeNumber,,,,X_OK) should have returned false")
+	}
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(456), InodeGroupID(456), nil, X_OK, OwnerOverride) {
+		t.Fatalf("Access(fileInodeNumber,,,,X_OK) should have returned false")
 	}
 
 	err = testVolumeHandle.Destroy(fileInodeNumber)
@@ -595,7 +649,7 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("Destroy(fileInodeNumber) failed: %v", err)
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, F_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, F_OK, NoOverride) {
 		t.Fatalf("Access(fileInodeNumber,,,,F_OK) after Destroy() should have failed")
 	}
 

--- a/inode/api_test.go
+++ b/inode/api_test.go
@@ -448,12 +448,12 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("GetFSID() returned unexpected FSID")
 	}
 
-	fileInodeNumber, err := testVolumeHandle.CreateFile(InodeMode(0000), InodeRootUserID, InodeRootGroupID)
+	fileInodeNumber, err := testVolumeHandle.CreateFile(InodeMode(0000), InodeRootUserID, InodeGroupID(0))
 	if nil != err {
 		t.Fatalf("CreateFile() failed: %v", err)
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeRootGroupID, nil, F_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, F_OK) {
 		t.Fatalf("Access(fileInodeNumber,,,,F_OK) after CreateFile() should not have failed")
 	}
 
@@ -461,11 +461,11 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK|W_OK|X_OK) should have returned true")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeRootGroupID, nil, R_OK|W_OK|X_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(0), nil, R_OK|W_OK|X_OK) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,R_OK|W_OK|X_OK) should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeRootGroupID, nil, R_OK|P_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, R_OK|P_OK) {
 		t.Fatalf("Access(fileInodeNumber,,,,R_OK|X_OK) should have returned false")
 	}
 
@@ -474,15 +474,15 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("SetOwnerUserID(,InodeUserID(123)) failed: %v", err)
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeRootGroupID, nil, P_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, P_OK) {
 		t.Fatalf("Access(fileInodeNumber,InodeRootUserID,,,P_OK should have returned true")
 	}
 
-	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeRootGroupID, nil, P_OK) {
+	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(0), nil, P_OK) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(123),,,P_OK should have returned true")
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(789), InodeRootGroupID, nil, P_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeUserID(789), InodeGroupID(0), nil, P_OK) {
 		t.Fatalf("Access(fileInodeNumber,InodeUserID(789),,,P_OK should have returned true")
 	}
 
@@ -565,9 +565,9 @@ func TestAPI(t *testing.T) {
 	if nil != err {
 		t.Fatalf("SetPermMode(,InodeMode(0006)) failed: %v", err)
 	}
-	err = testVolumeHandle.SetOwnerUserIDGroupID(fileInodeNumber, InodeRootUserID, InodeRootGroupID)
+	err = testVolumeHandle.SetOwnerUserIDGroupID(fileInodeNumber, InodeRootUserID, InodeGroupID(0))
 	if nil != err {
-		t.Fatalf("SetOwnerUserIDGroupID(,InodeRootUserID,InodeRootGroupID) failed: %v", err)
+		t.Fatalf("SetOwnerUserIDGroupID(,InodeRootUserID,InodeGroupID(0)) failed: %v", err)
 	}
 
 	if !testVolumeHandle.Access(fileInodeNumber, InodeUserID(123), InodeGroupID(456), nil, R_OK) {
@@ -595,7 +595,7 @@ func TestAPI(t *testing.T) {
 		t.Fatalf("Destroy(fileInodeNumber) failed: %v", err)
 	}
 
-	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeRootGroupID, nil, F_OK) {
+	if testVolumeHandle.Access(fileInodeNumber, InodeRootUserID, InodeGroupID(0), nil, F_OK) {
 		t.Fatalf("Access(fileInodeNumber,,,,F_OK) after Destroy() should have failed")
 	}
 

--- a/inode/file.go
+++ b/inode/file.go
@@ -586,6 +586,11 @@ func (vS *volumeStruct) Write(fileInodeNumber InodeNumber, offset uint64, buf []
 		return
 	}
 
+	// writes of length 0 succeed but do not change mtime
+	if len(buf) == 0 {
+		return
+	}
+
 	fileInode.dirty = true
 
 	logSegmentNumber, logSegmentOffset, err := vS.doSendChunk(fileInode, buf)

--- a/inode/inode.go
+++ b/inode/inode.go
@@ -703,7 +703,7 @@ func (vS *volumeStruct) Access(inodeNumber InodeNumber, userID InodeUserID, grou
 	// open state (there's no file descriptor that tracks if the file was
 	// opened with write permission).  But I'm not sure that other operations
 	// that require write permission, like truncate(2) work the same way.
-	if (InodeRootUserID == userID) || (InodeRootGroupID == groupID) {
+	if (InodeRootUserID == userID) || (InodeGroupID(0) == groupID) {
 		accessReturn = true
 		return
 	}
@@ -717,7 +717,7 @@ func (vS *volumeStruct) Access(inodeNumber InodeNumber, userID InodeUserID, grou
 
 	if !groupIDCheck {
 		for _, otherGroupID := range otherGroupIDs {
-			if InodeRootGroupID == otherGroupID {
+			if InodeGroupID(0) == otherGroupID {
 				accessReturn = true
 				return
 			}

--- a/inode/inode.go
+++ b/inode/inode.go
@@ -658,7 +658,7 @@ func (vS *volumeStruct) provisionObject() (containerName string, objectNumber ui
 	return
 }
 
-func (vS *volumeStruct) Access(inodeNumber InodeNumber, userID InodeUserID, groupID InodeGroupID, otherGroupIDs []InodeGroupID, accessMode InodeMode) (accessReturn bool) {
+func (vS *volumeStruct) Access(inodeNumber InodeNumber, userID InodeUserID, groupID InodeGroupID, otherGroupIDs []InodeGroupID, accessMode InodeMode, override AccessOverride) (accessReturn bool) {
 
 	ourInode, ok, err := vS.fetchInode(inodeNumber)
 	if nil != err {
@@ -697,44 +697,70 @@ func (vS *volumeStruct) Access(inodeNumber InodeNumber, userID InodeUserID, grou
 		return
 	}
 
-	// On a local file system, the owner of a file can *not* write to the
-	// file unless the permission bits say so.  However, NFS relaxes this to
-	// allow the owner of a file to write to it because NFS does not have an
-	// open state (there's no file descriptor that tracks if the file was
-	// opened with write permission).  But I'm not sure that other operations
-	// that require write permission, like truncate(2) work the same way.
-	if (InodeRootUserID == userID) || (InodeGroupID(0) == groupID) {
-		accessReturn = true
+	// The root user (if not squashed) can do anything except exec files
+	// that are not executable by any user
+	if userID == InodeRootUserID {
+		if (accessMode&X_OK != 0) && (ourInode.Mode&(X_OK<<6|X_OK<<3|X_OK) == 0) {
+			accessReturn = false
+		} else {
+			accessReturn = true
+		}
 		return
 	}
 
-	if (userID == ourInode.UserID) && (((ourInode.Mode >> 6) & accessMode) == accessMode) {
-		accessReturn = true
+	// We check against permissions for the user, group, and other.  The
+	// first match wins (not the first permission granted).  If the user is
+	// the owner of the file then those permission bits determine what
+	// happens.  In other words, if the permission bits deny read permission
+	// to the owner of a file but allow read permission for group and other,
+	// then everyone except the owner of the file can read it.
+	//
+	// On a local file system, the owner of a file is *not* allowed to write
+	// to the file unless it was opened for writing and the permission bits
+	// allowed it *or* the process created the file and opened it for
+	// writing at the same time.  However, NFS does not have an open state
+	// (there's no file descriptor that tracks permissions when the the file
+	// was opened) so we check for write permission on every write.  This
+	// breaks things like tar when it tries to unpack a file which has
+	// permission 0444 (read only).  On a local file system that works, but
+	// it doesn't work for NFS unless we bend the rules a bit for the owner
+	// of the file and allow the owner to write to the file even if
+	// appropriate permissions are lacking.  (This is only done for the user
+	// that owns the file, not the group that owns the file. Note that the
+	// owner can always change the permissions to allow writing so its not a
+	// security risk, but the owning group cannot).
+	//
+	// Note that the NFS client will typically call Access() when an app
+	// wants to open the file and fail an open request for writing that if
+	// the permission bits do not allow it.
+	//
+	// Similar rules apply to Read() and Truncate() (for ftruncate(2)), but
+	// not for execute permission.  Also, this only applies to regular files
+	// but we'll rely on the caller for that.
+	if userID == ourInode.UserID {
+		if override == OwnerOverride && (accessMode&X_OK == 0) {
+			accessReturn = true
+		} else {
+			accessReturn = (((ourInode.Mode >> 6) & accessMode) == accessMode)
+		}
 		return
 	}
 
 	groupIDCheck := (groupID == ourInode.GroupID)
-
 	if !groupIDCheck {
 		for _, otherGroupID := range otherGroupIDs {
-			if InodeGroupID(0) == otherGroupID {
-				accessReturn = true
-				return
-			}
 			if otherGroupID == ourInode.GroupID {
 				groupIDCheck = true
 				break
 			}
 		}
 	}
-
-	if groupIDCheck && ((((ourInode.Mode >> 3) & 07) & accessMode) == accessMode) {
-		accessReturn = true
+	if groupIDCheck {
+		accessReturn = ((((ourInode.Mode >> 3) & 07) & accessMode) == accessMode)
 		return
 	}
 
 	accessReturn = ((((ourInode.Mode >> 0) & 07) & accessMode) == accessMode)
-
 	return
 }
 

--- a/jrpcfs/filesystem.go
+++ b/jrpcfs/filesystem.go
@@ -743,8 +743,10 @@ func (s *Server) RpcChmod(in *ChmodRequest, reply *Reply) (err error) {
 		return
 	}
 
+	// Samba includes the file mode in in.FileMode, but only the permssion
+	// bits can be changed by SetStat().
 	stat := make(fs.Stat)
-	stat[fs.StatMode] = uint64(in.FileMode)
+	stat[fs.StatMode] = uint64(in.FileMode) & 07777
 	err = mountHandle.Setstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(in.InodeNumber), stat)
 	return
 }
@@ -772,8 +774,11 @@ func (s *Server) RpcChmodPath(in *ChmodPathRequest, reply *Reply) (err error) {
 	}
 
 	// Do the Setstat
+	//
+	// Samba includes the file mode in in.FileMode, but only the permssion
+	// bits can be changed by SetStat().
 	stat := make(fs.Stat)
-	stat[fs.StatMode] = uint64(in.FileMode)
+	stat[fs.StatMode] = uint64(in.FileMode) & 07777
 	err = mountHandle.Setstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, ino, stat)
 	return
 }

--- a/jrpcfs/io.go
+++ b/jrpcfs/io.go
@@ -410,7 +410,7 @@ func ioHandle(conn net.Conn) {
 			profiler.AddEventNow("before fs.Write()")
 			mountHandle, err = lookupMountHandle(ctx.req.mountID)
 			if err == nil {
-				ctx.resp.ioSize, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.InodeNumber(ctx.req.inodeID), ctx.req.offset, ctx.data, profiler)
+				ctx.resp.ioSize, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(ctx.req.inodeID), ctx.req.offset, ctx.data, profiler)
 			}
 			profiler.AddEventNow("after fs.Write()")
 
@@ -428,7 +428,7 @@ func ioHandle(conn net.Conn) {
 			profiler.AddEventNow("before fs.Read()")
 			mountHandle, err = lookupMountHandle(ctx.req.mountID)
 			if err == nil {
-				ctx.data, err = mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.InodeNumber(ctx.req.inodeID), ctx.req.offset, ctx.req.length, profiler)
+				ctx.data, err = mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(ctx.req.inodeID), ctx.req.offset, ctx.req.length, profiler)
 			}
 			profiler.AddEventNow("after fs.Read()")
 

--- a/jrpcfs/middleware.go
+++ b/jrpcfs/middleware.go
@@ -87,7 +87,7 @@ func (s *Server) RpcCreateContainer(in *CreateContainerRequest, reply *CreateCon
 	}
 
 	// Make the directory
-	_, err = mountHandle.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.RootDirInodeNumber, containerName, inode.PosixModePerm)
+	_, err = mountHandle.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.RootDirInodeNumber, containerName, inode.PosixModePerm)
 
 	if err != nil {
 		logger.DebugfIDWithError(internalDebug, err, "fs.Mkdir() of acct: %v vContainerName: %v failed!", accountName, containerName)

--- a/jrpcfs/middleware_test.go
+++ b/jrpcfs/middleware_test.go
@@ -195,11 +195,11 @@ func fsStatPath(accountName string, path string) fs.Stat {
 	if err != nil {
 		panic(err)
 	}
-	ino, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, path)
+	ino, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, path)
 	if err != nil {
 		panic(err)
 	}
-	stats, err := mountHandle.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, ino)
+	stats, err := mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, ino)
 	if err != nil {
 		panic(err)
 	}
@@ -207,7 +207,7 @@ func fsStatPath(accountName string, path string) fs.Stat {
 }
 
 func fsMkDir(mountHandle fs.MountHandle, parentDirInode inode.InodeNumber, newDirName string) (createdInode inode.InodeNumber) {
-	createdInode, err := mountHandle.Mkdir(inode.InodeRootUserID, inode.InodeRootGroupID, nil, parentDirInode, newDirName, inode.PosixModePerm)
+	createdInode, err := mountHandle.Mkdir(inode.InodeRootUserID, inode.InodeGroupID(0), nil, parentDirInode, newDirName, inode.PosixModePerm)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create %v: %v", newDirName, err))
 	}
@@ -215,7 +215,7 @@ func fsMkDir(mountHandle fs.MountHandle, parentDirInode inode.InodeNumber, newDi
 }
 
 func fsCreateFile(mountHandle fs.MountHandle, parentDirInode inode.InodeNumber, newFileName string) (createdInode inode.InodeNumber) {
-	createdInode, err := mountHandle.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, parentDirInode, newFileName, inode.PosixModePerm)
+	createdInode, err := mountHandle.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, parentDirInode, newFileName, inode.PosixModePerm)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create file %v: %v", newFileName, err))
 	}
@@ -223,7 +223,7 @@ func fsCreateFile(mountHandle fs.MountHandle, parentDirInode inode.InodeNumber, 
 }
 
 func fsCreateSymlink(mountHandle fs.MountHandle, parentDirInode inode.InodeNumber, symlinkName string, symlinkTarget string) {
-	_, err := mountHandle.Symlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, parentDirInode, symlinkName, symlinkTarget)
+	_, err := mountHandle.Symlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, parentDirInode, symlinkName, symlinkTarget)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create symlink %s -> %s: %v", symlinkName, symlinkTarget, err))
 	}
@@ -295,7 +295,7 @@ func makeSomeFilesAndSuch() {
 	_ = fsMkDir(mountHandle, cInode, "empty-directory")
 
 	readmeInode := fsCreateFile(mountHandle, cInode, "README")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, readmeInode, 0, []byte("who am I kidding? nobody reads these."), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, readmeInode, 0, []byte("who am I kidding? nobody reads these."), nil)
 	err = mountHandle.MiddlewarePost("", "c/README", []byte("metadata for c/README"), []byte{})
 	if err != nil {
 		panic(err)
@@ -314,7 +314,7 @@ func makeSomeFilesAndSuch() {
 	for fileName, fileContents := range files {
 		fileInode := fsCreateFile(mountHandle, animalsInode, fileName)
 
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileContents), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileContents), nil)
 		if err != nil {
 			panic(fmt.Sprintf("failed to write file %s: %v", fileName, err))
 		}
@@ -322,7 +322,7 @@ func makeSomeFilesAndSuch() {
 
 	plantsInode := fsMkDir(mountHandle, cInode, "plants")
 	ino := fsCreateFile(mountHandle, cInode, "plants-README")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, ino, 0, []byte("nah"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, ino, 0, []byte("nah"), nil)
 	if err != nil {
 		panic(fmt.Sprintf("failed to write file plants-README: %v", err))
 	}
@@ -338,7 +338,7 @@ func makeSomeFilesAndSuch() {
 	for fileName, fileContents := range files {
 		fileInode := fsCreateFile(mountHandle, plantsInode, fileName)
 
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileContents), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileContents), nil)
 		if err != nil {
 			panic(fmt.Sprintf("failed to write file %s: %v", fileName, err))
 		}
@@ -895,7 +895,7 @@ func testRpcDelete(t *testing.T, server *Server) {
 	_, _, _, _, mountHandle, err := mountIfNotMounted(testVerAccountName)
 	assert.Nil(err)
 
-	cInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testContainerName)
+	cInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testContainerName)
 	assert.Nil(err)
 
 	var emptyDir string = "empty-directory"
@@ -904,7 +904,7 @@ func testRpcDelete(t *testing.T, server *Server) {
 	err = middlewareDeleteObject(server, emptyDir)
 	assert.Nil(err)
 
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, emptyDir)
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, emptyDir)
 	assert.NotNil(err)
 
 	// Now create an object which is a file and see if we can delete it via bimodal.
@@ -914,7 +914,7 @@ func testRpcDelete(t *testing.T, server *Server) {
 	err = middlewareDeleteObject(server, emptyFile)
 	assert.Nil(err)
 
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, emptyFile)
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, emptyFile)
 	assert.NotNil(err)
 
 	// Now create a directory with one file in it and prove we can remove file and
@@ -926,13 +926,13 @@ func testRpcDelete(t *testing.T, server *Server) {
 	err = middlewareDeleteObject(server, aDir+"/"+emptyFile)
 	assert.Nil(err)
 
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, "/"+aDir+"/"+emptyFile)
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, "/"+aDir+"/"+emptyFile)
 	assert.NotNil(err)
 
 	err = middlewareDeleteObject(server, aDir)
 	assert.Nil(err)
 
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, "/"+aDir)
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, "/"+aDir)
 	assert.NotNil(err)
 
 	// Now delete the container
@@ -971,7 +971,7 @@ func TestRpcDeleteSymlinks(t *testing.T) {
 	containerInode := fsMkDir(mountHandle, inode.RootDirInodeNumber, containerName)
 
 	tlInode := fsCreateFile(mountHandle, containerInode, "top-level.txt")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, tlInode, 0, []byte("conusance-callboy"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, tlInode, 0, []byte("conusance-callboy"), nil)
 
 	d1Inode := fsMkDir(mountHandle, containerInode, "d1")
 	files := map[string]string{
@@ -981,7 +981,7 @@ func TestRpcDeleteSymlinks(t *testing.T) {
 	}
 	for fileName, fileContents := range files {
 		fileInode := fsCreateFile(mountHandle, d1Inode, fileName)
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileContents), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileContents), nil)
 		if err != nil {
 			panic(fmt.Sprintf("failed to write file %s: %v", fileName, err))
 		}
@@ -1001,7 +1001,7 @@ func TestRpcDeleteSymlinks(t *testing.T) {
 	err = s.RpcDelete(&deleteRequest, &deleteResponse)
 	assert.Nil(err)
 
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/d1/crackle")
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/d1/crackle")
 	assert.NotNil(err)
 	assert.True(blunder.Is(err, blunder.NotFoundError))
 
@@ -1014,9 +1014,9 @@ func TestRpcDeleteSymlinks(t *testing.T) {
 	err = s.RpcDelete(&deleteRequest, &deleteResponse)
 	assert.Nil(err)
 
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/d1/snap")
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/d1/snap")
 	assert.Nil(err)
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/d1/snap-symlink")
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/d1/snap-symlink")
 	assert.NotNil(err)
 	assert.True(blunder.Is(err, blunder.NotFoundError))
 
@@ -1028,9 +1028,9 @@ func TestRpcDeleteSymlinks(t *testing.T) {
 	err = s.RpcDelete(&deleteRequest, &deleteResponse)
 	assert.Nil(err)
 
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/d1/pop")
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/d1/pop")
 	assert.Nil(err)
-	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/d1/pop-symlink")
+	_, err = mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/d1/pop-symlink")
 	assert.NotNil(err)
 	assert.True(blunder.Is(err, blunder.NotFoundError))
 }
@@ -1081,7 +1081,7 @@ func testRpcPost(t *testing.T, server *Server) {
 
 	// Now POST to account/container/object after creating an object which
 	// is a directory and one which is a file.
-	cInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, testContainerName)
+	cInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, testContainerName)
 	assert.Nil(err)
 	var emptyDir string = "empty-directory"
 	_ = fsMkDir(mountHandle, cInode, emptyDir)
@@ -1225,9 +1225,9 @@ func TestPutObjectSimple(t *testing.T) {
 	assert.Nil(err) // sanity check
 
 	// The file should exist now, so we can verify its attributes
-	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/"+objName)
+	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/"+objName)
 	assert.Nil(err)
-	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, theInode, 0, 99999, nil)
+	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, theInode, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal(objData, contents)
 
@@ -1248,9 +1248,9 @@ func TestPutObjectInAllNewSubdirs(t *testing.T) {
 	assert.Nil(err) // sanity check
 
 	// The file should exist now, so we can verify its attributes
-	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/"+objName)
+	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/"+objName)
 	assert.Nil(err)
-	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, theInode, 0, 99999, nil)
+	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, theInode, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal(objData, contents)
 }
@@ -1259,7 +1259,7 @@ func TestPutObjectInSomeNewSubdirs(t *testing.T) {
 	assert, server, containerName, mountHandle := testPutObjectSetup(t)
 
 	// make d1 and d1/d2, but leave creation of the rest to the RPC call
-	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName)
+	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName)
 	if err != nil {
 		panic(err)
 	}
@@ -1275,9 +1275,9 @@ func TestPutObjectInSomeNewSubdirs(t *testing.T) {
 	assert.Nil(err) // sanity check
 
 	// The file should exist now, so we can verify its attributes
-	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/"+objName)
+	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/"+objName)
 	assert.Nil(err)
-	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, theInode, 0, 99999, nil)
+	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, theInode, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal(objData, contents)
 }
@@ -1296,9 +1296,9 @@ func TestPutObjectOverwriteFile(t *testing.T) {
 	err = putFileInSwift(server, objVirtPath, objData2, objMetadata)
 	assert.Nil(err)
 
-	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/"+objName)
+	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/"+objName)
 	assert.Nil(err)
-	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, theInode, 0, 99999, nil)
+	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, theInode, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal(objData2, contents)
 }
@@ -1311,7 +1311,7 @@ func TestPutObjectOverwriteEmptyDirectory(t *testing.T) {
 	objMetadata := []byte("I'm So Meta, Even This Acronym")
 	objVirtPath := testVerAccountName + "/" + containerName + "/" + objName
 
-	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName)
+	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName)
 	if err != nil {
 		panic(err)
 	}
@@ -1329,14 +1329,14 @@ func TestPutObjectOverwriteNonEmptyDirectory(t *testing.T) {
 	objMetadata := []byte("won't get written")
 	objVirtPath := testVerAccountName + "/" + containerName + "/" + objName
 
-	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName)
+	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName)
 	if err != nil {
 		panic(err)
 	}
 	dirInodeNumber := fsMkDir(mountHandle, containerInode, "dir-with-stuff-in-it")
 
 	fileInodeNumber := fsCreateFile(mountHandle, dirInodeNumber, "stuff.txt")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInodeNumber, 0, []byte("churches, lead, small rocks, apples"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInodeNumber, 0, []byte("churches, lead, small rocks, apples"), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1349,7 +1349,7 @@ func TestPutObjectOverwriteNonEmptyDirectory(t *testing.T) {
 func TestPutObjectSymlinkedDir(t *testing.T) {
 	assert, server, containerName, mountHandle := testPutObjectSetup(t)
 
-	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName)
+	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName)
 	if err != nil {
 		panic(err)
 	}
@@ -1368,9 +1368,9 @@ func TestPutObjectSymlinkedDir(t *testing.T) {
 	assert.Nil(err) // sanity check
 
 	// The file should exist now, so we can verify its attributes
-	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/"+"d1/d2/d3/thing.dat")
+	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/"+"d1/d2/d3/thing.dat")
 	assert.Nil(err)
-	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, theInode, 0, 99999, nil)
+	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, theInode, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal(objData, contents)
 }
@@ -1378,7 +1378,7 @@ func TestPutObjectSymlinkedDir(t *testing.T) {
 func TestPutObjectOverwriteSymlink(t *testing.T) {
 	assert, server, containerName, mountHandle := testPutObjectSetup(t)
 
-	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName)
+	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName)
 	if err != nil {
 		panic(err)
 	}
@@ -1393,9 +1393,9 @@ func TestPutObjectOverwriteSymlink(t *testing.T) {
 	assert.Nil(err) // sanity check
 
 	// The file should exist now, so we can verify its attributes
-	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/"+"thing.dat")
+	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/"+"thing.dat")
 	assert.Nil(err)
-	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, theInode, 0, 99999, nil)
+	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, theInode, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal(objData, contents)
 }
@@ -1408,7 +1408,7 @@ func TestPutObjectFileInDirPath(t *testing.T) {
 	objMetadata := []byte("won't get written")
 	objVirtPath := testVerAccountName + "/" + containerName + "/" + objName
 
-	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName)
+	containerInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName)
 	if err != nil {
 		panic(err)
 	}
@@ -1416,7 +1416,7 @@ func TestPutObjectFileInDirPath(t *testing.T) {
 	d2InodeNumber := fsMkDir(mountHandle, d1InodeNumber, "d2")
 
 	fileInodeNumber := fsCreateFile(mountHandle, d2InodeNumber, "actually-a-file")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInodeNumber, 0, []byte("not a directory"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInodeNumber, 0, []byte("not a directory"), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1518,9 +1518,9 @@ func TestPutObjectCompound(t *testing.T) {
 	}
 
 	// The file should exist now, so we can verify its attributes
-	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/"+objName)
+	theInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/"+objName)
 	assert.Nil(err)
-	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, theInode, 0, 99999, nil)
+	contents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, theInode, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal([]byte("hello world!"), contents)
 	assert.Equal(uint64(theInode), putCompleteResp.InodeNumber)
@@ -1531,7 +1531,7 @@ func TestPutObjectCompound(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal([]byte(objMetadata), headResponse.Metadata)
 
-	statResult, err := mountHandle.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, theInode)
+	statResult, err := mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, theInode)
 	assert.Nil(err)
 	assert.Equal(statResult[fs.StatMTime], putCompleteResp.ModificationTime)
 }
@@ -1574,12 +1574,12 @@ func TestRpcGetObjectMetadata(t *testing.T) {
 	cInode := fsMkDir(mountHandle, inode.RootDirInodeNumber, containerName)
 	readmeInode := fsCreateFile(mountHandle, cInode, "README")
 
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, readmeInode, 0, []byte("unsurpassably-Rigelian"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, readmeInode, 0, []byte("unsurpassably-Rigelian"), nil)
 	if err != nil {
 		panic(err)
 	}
 
-	statResult, err := mountHandle.Getstat(inode.InodeRootUserID, inode.InodeRootGroupID, nil, readmeInode)
+	statResult, err := mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, readmeInode)
 	if err != nil {
 		panic(err)
 	}
@@ -1639,7 +1639,7 @@ func TestRpcGetObjectSymlinkFollowing(t *testing.T) {
 	c4Inode := fsMkDir(mountHandle, inode.RootDirInodeNumber, "c4")
 
 	fileInode := fsCreateFile(mountHandle, c1Inode, "kitten.png")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte("if this were a real kitten, it would be cute"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte("if this were a real kitten, it would be cute"), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1655,7 +1655,7 @@ func TestRpcGetObjectSymlinkFollowing(t *testing.T) {
 	fsCreateSymlink(mountHandle, c1Inode, "symlink-9", "symlink-8")
 
 	fileInode = fsCreateFile(mountHandle, c2Inode, "10-bytes")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte("abcdefghij"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte("abcdefghij"), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1665,7 +1665,7 @@ func TestRpcGetObjectSymlinkFollowing(t *testing.T) {
 	fsCreateSymlink(mountHandle, c2Inode, "symlink-20-bytes-indirect", "symlink-20-bytes")
 
 	fileInode = fsCreateFile(mountHandle, c3Inode, "20-bytes")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte("abcdefghijklmnopqrst"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte("abcdefghijklmnopqrst"), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1933,7 +1933,7 @@ func TestRpcCoalesce(t *testing.T) {
 
 	fileA1Path := "/" + containerAName + "/dir1/dir2/a1"
 	fileA1Inode := fsCreateFile(mountHandle, containerADir1Dir2Inode, "a1")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileA1Inode, 0, []byte("red "), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileA1Inode, 0, []byte("red "), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1942,14 +1942,14 @@ func TestRpcCoalesce(t *testing.T) {
 	// means we don't have to worry about element paths pointing to different accounts.
 	fileA2Path := "/" + containerAName + "/dir1/dir2/a2"
 	fileA2Inode := fsCreateFile(mountHandle, containerADir1Dir2Inode, "a2")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileA2Inode, 0, []byte("orange "), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileA2Inode, 0, []byte("orange "), nil)
 	if err != nil {
 		panic(err)
 	}
 
 	fileBPath := "/" + containerBName + "/b"
 	fileBInode := fsCreateFile(mountHandle, containerBInode, "b")
-	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileBInode, 0, []byte("yellow"), nil)
+	_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileBInode, 0, []byte("yellow"), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -1968,14 +1968,14 @@ func TestRpcCoalesce(t *testing.T) {
 	err = server.RpcCoalesce(&coalesceRequest, &coalesceReply)
 	assert.Nil(err)
 
-	combinedInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerAName+"/combined-file")
+	combinedInode, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerAName+"/combined-file")
 	assert.Nil(err)
 	assert.Equal(uint64(combinedInode), coalesceReply.InodeNumber)
 	assert.True(coalesceReply.NumWrites > 0)
 	assert.True(coalesceReply.ModificationTime > 0)
 	assert.True(coalesceReply.ModificationTime > timeBeforeRequest)
 
-	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, combinedInode, 0, 99999, nil)
+	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, combinedInode, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal([]byte("red orange yellow"), combinedContents)
 }
@@ -1997,7 +1997,7 @@ func TestRpcCoalesceOverwrite(t *testing.T) {
 	filesToWrite := []string{"red", "orange", "yellow", "green", "blue", "indigo", "violet"}
 	for _, fileName := range filesToWrite {
 		fileInode := fsCreateFile(mountHandle, containerInode, fileName)
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileName+" "), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileName+" "), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -2015,7 +2015,7 @@ func TestRpcCoalesceOverwrite(t *testing.T) {
 	coalesceReply := CoalesceReply{}
 	err = server.RpcCoalesce(&coalesceRequest, &coalesceReply)
 	assert.Nil(err)
-	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.InodeNumber(coalesceReply.InodeNumber), 0, 99999, nil)
+	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(coalesceReply.InodeNumber), 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal([]byte("red orange yellow "), combinedContents) // sanity check
 
@@ -2033,7 +2033,7 @@ func TestRpcCoalesceOverwrite(t *testing.T) {
 	err = server.RpcCoalesce(&coalesceRequest, &coalesceReply)
 	assert.Nil(err)
 
-	combinedContents, err = mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.InodeNumber(coalesceReply.InodeNumber), 0, 99999, nil)
+	combinedContents, err = mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(coalesceReply.InodeNumber), 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal([]byte("green blue indigo violet "), combinedContents)
 
@@ -2056,7 +2056,7 @@ func TestRpcCoalesceOverwriteEmptyDir(t *testing.T) {
 	filesToWrite := []string{"red", "orange", "yellow", "green", "blue", "indigo", "violet"}
 	for _, fileName := range filesToWrite {
 		fileInode := fsCreateFile(mountHandle, containerInode, fileName)
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileName+" "), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileName+" "), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -2076,7 +2076,7 @@ func TestRpcCoalesceOverwriteEmptyDir(t *testing.T) {
 	coalesceReply := CoalesceReply{}
 	err = server.RpcCoalesce(&coalesceRequest, &coalesceReply)
 	assert.Nil(err)
-	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.InodeNumber(coalesceReply.InodeNumber), 0, 99999, nil)
+	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(coalesceReply.InodeNumber), 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal([]byte("red orange yellow "), combinedContents) // sanity check
 }
@@ -2098,7 +2098,7 @@ func TestRpcCoalesceOverwriteNonEmptyDir(t *testing.T) {
 	filesToWrite := []string{"red", "orange", "yellow", "green", "blue", "indigo", "violet"}
 	for _, fileName := range filesToWrite {
 		fileInode := fsCreateFile(mountHandle, containerInode, fileName)
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileName+" "), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileName+" "), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -2121,7 +2121,7 @@ func TestRpcCoalesceOverwriteNonEmptyDir(t *testing.T) {
 	assert.NotNil(err)
 
 	// The old dir is still there
-	ino, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/combined")
+	ino, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/combined")
 	assert.Equal(combinedInode, ino)
 }
 
@@ -2147,7 +2147,7 @@ func TestRpcCoalesceMakesDirs(t *testing.T) {
 	filesToWrite := []string{"red", "orange", "yellow", "green", "blue", "indigo", "violet"}
 	for _, fileName := range filesToWrite {
 		fileInode := fsCreateFile(mountHandle, containerInode, fileName)
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileName+" "), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileName+" "), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -2166,11 +2166,11 @@ func TestRpcCoalesceMakesDirs(t *testing.T) {
 	err = server.RpcCoalesce(&coalesceRequest, &coalesceReply)
 	assert.Nil(err)
 
-	ino, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/a/b/c/d/e/f/combined")
+	ino, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/a/b/c/d/e/f/combined")
 	assert.Nil(err)
 	assert.Equal(inode.InodeNumber(coalesceReply.InodeNumber), ino)
 
-	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, ino, 0, 99999, nil)
+	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, ino, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal([]byte("red orange yellow "), combinedContents) // sanity check
 }
@@ -2199,7 +2199,7 @@ func TestRpcCoalesceSymlinks(t *testing.T) {
 	filesToWrite := []string{"red", "orange", "yellow", "green", "blue", "indigo", "violet"}
 	for _, fileName := range filesToWrite {
 		fileInode := fsCreateFile(mountHandle, containerInode, fileName)
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileName+" "), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileName+" "), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -2218,11 +2218,11 @@ func TestRpcCoalesceSymlinks(t *testing.T) {
 	err = server.RpcCoalesce(&coalesceRequest, &coalesceReply)
 	assert.Nil(err)
 
-	ino, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeRootGroupID, nil, containerName+"/a/b/c/combined")
+	ino, err := mountHandle.LookupPath(inode.InodeRootUserID, inode.InodeGroupID(0), nil, containerName+"/a/b/c/combined")
 	assert.Nil(err)
 	assert.Equal(inode.InodeNumber(coalesceReply.InodeNumber), ino)
 
-	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, ino, 0, 99999, nil)
+	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, ino, 0, 99999, nil)
 	assert.Nil(err)
 	assert.Equal([]byte("red orange yellow "), combinedContents) // sanity check
 }
@@ -2250,7 +2250,7 @@ func TestRpcCoalesceBrokenSymlink(t *testing.T) {
 	filesToWrite := []string{"red", "orange", "yellow", "green", "blue", "indigo", "violet"}
 	for _, fileName := range filesToWrite {
 		fileInode := fsCreateFile(mountHandle, containerInode, fileName)
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileName+" "), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileName+" "), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -2292,7 +2292,7 @@ func TestRpcCoalesceSubdirOfAFile(t *testing.T) {
 	filesToWrite := []string{"red", "orange", "yellow"}
 	for _, fileName := range filesToWrite {
 		fileInode := fsCreateFile(mountHandle, containerInode, fileName)
-		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInode, 0, []byte(fileName+" "), nil)
+		_, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInode, 0, []byte(fileName+" "), nil)
 		if err != nil {
 			panic(err)
 		}

--- a/pfsworkout/main.go
+++ b/pfsworkout/main.go
@@ -931,7 +931,7 @@ func createFsFile() (err error, mountHandle fs.MountHandle, fileInodeNumber inod
 
 	fileName = fmt.Sprintf("%s%016X", basenamePrefix, nonce)
 
-	fileInodeNumber, err = mountHandle.Create(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.RootDirInodeNumber, fileName, inode.PosixModePerm)
+	fileInodeNumber, err = mountHandle.Create(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.RootDirInodeNumber, fileName, inode.PosixModePerm)
 	if nil != err {
 		stepErrChan <- fmt.Errorf("fs.Create(,,,, fileName==\"%s\", inode.PosixModePerm) failed: %v\n", fileName, err)
 		return
@@ -940,7 +940,7 @@ func createFsFile() (err error, mountHandle fs.MountHandle, fileInodeNumber inod
 }
 
 func unlinkFsFile(mountHandle fs.MountHandle, fileName string) (err error) {
-	err = mountHandle.Unlink(inode.InodeRootUserID, inode.InodeRootGroupID, nil, inode.RootDirInodeNumber, fileName)
+	err = mountHandle.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.RootDirInodeNumber, fileName)
 	if nil != err {
 		stepErrChan <- fmt.Errorf("fs.Unlink(,,,, rootInodeNumber, \"%v\") failed: %v\n", fileName, err)
 		return
@@ -991,7 +991,7 @@ func fsWorkout(rwSizeEach *rwSizeEachStruct, threadIndex uint64, doSameFile bool
 				// to make sure we do not go past end of file.
 				rwOffset = rand.Int63n(int64(rwSizeTotal - rwSizeRequested))
 			}
-			rwSizeDelivered, err := mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInodeNumber, uint64(rwOffset), bufWritten, nil)
+			rwSizeDelivered, err := mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInodeNumber, uint64(rwOffset), bufWritten, nil)
 			if nil != err {
 				stepErrChan <- fmt.Errorf("fs.Write(,,,, fileInodeNumber, rwOffset, bufWritten) failed: %v\n", err)
 				return
@@ -1004,7 +1004,7 @@ func fsWorkout(rwSizeEach *rwSizeEachStruct, threadIndex uint64, doSameFile bool
 	} else {
 
 		for rwOffset := uint64(0); rwOffset < rwSizeTotal; rwOffset += rwSizeRequested {
-			rwSizeDelivered, err := mountHandle.Write(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInodeNumber, rwOffset, bufWritten, nil)
+			rwSizeDelivered, err := mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInodeNumber, rwOffset, bufWritten, nil)
 			if nil != err {
 				stepErrChan <- fmt.Errorf("fs.Write(,,,, fileInodeNumber, rwOffset, bufWritten) failed: %v\n", err)
 				return
@@ -1016,7 +1016,7 @@ func fsWorkout(rwSizeEach *rwSizeEachStruct, threadIndex uint64, doSameFile bool
 		}
 	}
 
-	err = mountHandle.Flush(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInodeNumber)
+	err = mountHandle.Flush(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInodeNumber)
 	if nil != err {
 		stepErrChan <- fmt.Errorf("fs.Flush(,,,, fileInodeNumber) failed: %v\n", err)
 		return
@@ -1033,7 +1033,7 @@ func fsWorkout(rwSizeEach *rwSizeEachStruct, threadIndex uint64, doSameFile bool
 			// Calculate random offset
 			rwOffset := uint64(rand.Int63n(int64(rwSizeTotal - rwSizeRequested)))
 
-			bufRead, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInodeNumber, rwOffset, rwSizeRequested, nil)
+			bufRead, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInodeNumber, rwOffset, rwSizeRequested, nil)
 			if nil != err {
 				stepErrChan <- fmt.Errorf("fs.Read(,,,, fileInodeNumber, rwOffset, rwSizeRequested) failed: %v\n", err)
 				return
@@ -1045,7 +1045,7 @@ func fsWorkout(rwSizeEach *rwSizeEachStruct, threadIndex uint64, doSameFile bool
 		}
 	} else {
 		for rwOffset := uint64(0); rwOffset < rwSizeTotal; rwOffset += rwSizeRequested {
-			bufRead, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeRootGroupID, nil, fileInodeNumber, rwOffset, rwSizeRequested, nil)
+			bufRead, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, fileInodeNumber, rwOffset, rwSizeRequested, nil)
 			if nil != err {
 				stepErrChan <- fmt.Errorf("fs.Read(,,,, fileInodeNumber, rwOffset, rwSizeRequested) failed: %v\n", err)
 				return

--- a/proxyfsd/daemon_test.go
+++ b/proxyfsd/daemon_test.go
@@ -262,7 +262,7 @@ func TestDaemon(t *testing.T) {
 
 	createdFileInodeNumber, err = mountHandle.Create(
 		inode.InodeRootUserID,
-		inode.InodeRootGroupID,
+		inode.InodeGroupID(0),
 		nil,
 		inode.RootDirInodeNumber,
 		"TestFile",
@@ -274,7 +274,7 @@ func TestDaemon(t *testing.T) {
 
 	bytesWritten, err = mountHandle.Write(
 		inode.InodeRootUserID,
-		inode.InodeRootGroupID,
+		inode.InodeGroupID(0),
 		nil,
 		createdFileInodeNumber,
 		0,
@@ -292,7 +292,7 @@ func TestDaemon(t *testing.T) {
 
 	toReadFileInodeNumber, err = mountHandle.Lookup(
 		inode.InodeRootUserID,
-		inode.InodeRootGroupID,
+		inode.InodeGroupID(0),
 		nil,
 		inode.RootDirInodeNumber,
 		"TestFile",
@@ -303,7 +303,7 @@ func TestDaemon(t *testing.T) {
 
 	readData, err = mountHandle.Read(
 		inode.InodeRootUserID,
-		inode.InodeRootGroupID,
+		inode.InodeGroupID(0),
 		nil,
 		toReadFileInodeNumber,
 		0,
@@ -358,7 +358,7 @@ func TestDaemon(t *testing.T) {
 
 	toReadFileInodeNumber, err = mountHandle.Lookup(
 		inode.InodeRootUserID,
-		inode.InodeRootGroupID,
+		inode.InodeGroupID(0),
 		nil,
 		inode.RootDirInodeNumber,
 		"TestFile",
@@ -369,7 +369,7 @@ func TestDaemon(t *testing.T) {
 
 	readData, err = mountHandle.Read(
 		inode.InodeRootUserID,
-		inode.InodeRootGroupID,
+		inode.InodeGroupID(0),
 		nil,
 		toReadFileInodeNumber,
 		0,


### PR DESCRIPTION
Fix sundry errors or omissions in permission checking.  The specific problem is that a tar archive failed to unpack because some of the files were read-only (0400) and tar sets the permission on the files before it writes the content.  This works on a local file system (where tar has a filehandle that is open for writing), but not over NFS.
Allow the owner of a file to write to it even the permission bits deny it.  Do the same for other requests, like Flush(), GetXAttr(), Resize() (i.e. Trunc()), Flock(), etc. (see the ones with `inode.OwnerOverride`.
Fix other issues: only the owner of the file can change the permissions on the file, eXecute (search) permission is not required to read the contents of a directory, etc.
Get rid of `inode.InodeRootGroupID` because there is no such as a "root group".
See the comments in the commits for more info.