### PR TITLE
Add tracing and Log with usec timestamps

### DIFF
--- a/fs/api_internal.go
+++ b/fs/api_internal.go
@@ -170,13 +170,15 @@ func (vS *volumeStruct) inFlightFileInodeDataFlusher(inodeNumber inode.InodeNumb
 }
 
 func (inFlightFileInodeData *inFlightFileInodeDataStruct) inFlightFileInodeDataTracker() {
+
+	logger.Tracef("fs.inFlightFileInodeDataTracker() entry: waiting to flush volume '%s' inode %d",
+		inFlightFileInodeData.volStruct.volumeName, inFlightFileInodeData.InodeNumber)
+	defer logger.Tracef("fs.inFlightFileInodeDataTracker() return: flush volume '%s' inode %d",
+		inFlightFileInodeData.volStruct.volumeName, inFlightFileInodeData.InodeNumber)
+
 	var (
 		flushFirst bool
 	)
-
-	logger.Tracef("fs.inFlightFileInodeDataTracker(): waiting to flush volume '%s' inode %d",
-		inFlightFileInodeData.volStruct.volumeName, inFlightFileInodeData.InodeNumber)
-
 	select {
 	case flushFirst = <-inFlightFileInodeData.control:
 		// All we needed was the value of flushFirst from control chan
@@ -310,6 +312,8 @@ func (mS *mountStruct) doInlineCheckpoint() {
 	var (
 		err error
 	)
+	logger.Tracef("fs.doInlineCheckpoint() entry: volume '%s'", mS.volStruct.volumeName)
+	defer logger.Tracef("fs.doInlineCheckpoint() return: volume '%s'", mS.volStruct.volumeName)
 
 	if nil == mS.headhunterVolumeHandle {
 		mS.headhunterVolumeHandle, err = headhunter.FetchVolumeHandle(mS.volStruct.volumeName)
@@ -325,6 +329,11 @@ func (mS *mountStruct) doInlineCheckpoint() {
 }
 
 func (mS *mountStruct) Flush(userID inode.InodeUserID, groupID inode.InodeGroupID, otherGroupIDs []inode.InodeGroupID, inodeNumber inode.InodeNumber) (err error) {
+
+	logger.Tracef("fs.Flush() entry: volume '%s' inode %d", mS.volStruct.volumeName, inodeNumber)
+	defer logger.Tracef("fs.Flush() return: volume '%s' inode %d", mS.volStruct.volumeName, inodeNumber)
+
+	// checkpoint after the flush completes
 	defer mS.doInlineCheckpoint()
 
 	inodeLock, err := mS.volStruct.initInodeLock(inodeNumber, nil)
@@ -338,9 +347,11 @@ func (mS *mountStruct) Flush(userID inode.InodeUserID, groupID inode.InodeGroupI
 	defer inodeLock.Unlock()
 
 	if !mS.volStruct.VolumeHandle.Access(inodeNumber, userID, groupID, otherGroupIDs, inode.F_OK) {
+		logger.Tracef("fs.Flush(): volume '%s' inode %d err ENOENT", mS.volStruct.volumeName, inodeNumber)
 		return blunder.NewError(blunder.NotFoundError, "ENOENT")
 	}
 	if !mS.volStruct.VolumeHandle.Access(inodeNumber, userID, groupID, otherGroupIDs, inode.W_OK) {
+		logger.Tracef("fs.Flush(): volume '%s' inode %d err EACCES", mS.volStruct.volumeName, inodeNumber)
 		return blunder.NewError(blunder.PermDeniedError, "EACCES")
 	}
 
@@ -2934,7 +2945,9 @@ func (mS *mountStruct) VolumeName() (volumeName string) {
 
 func (mS *mountStruct) Write(userID inode.InodeUserID, groupID inode.InodeGroupID, otherGroupIDs []inode.InodeGroupID, inodeNumber inode.InodeNumber, offset uint64, buf []byte, profiler *utils.Profiler) (size uint64, err error) {
 
-	logger.Tracef("fs.Write(): starting volume '%s' inode %d offset %d len %d",
+	logger.Tracef("fs.Write() entry: volume '%s' inode %d offset %d len %d",
+		mS.volStruct.volumeName, inodeNumber, offset, len(buf))
+	defer logger.Tracef("fs.Write() return: volume '%s' inode %d offset %d len %d",
 		mS.volStruct.volumeName, inodeNumber, offset, len(buf))
 
 	inodeLock, err := mS.volStruct.initInodeLock(inodeNumber, nil)
@@ -2949,10 +2962,14 @@ func (mS *mountStruct) Write(userID inode.InodeUserID, groupID inode.InodeGroupI
 
 	if !mS.volStruct.VolumeHandle.Access(inodeNumber, userID, groupID, otherGroupIDs, inode.F_OK) {
 		err = blunder.NewError(blunder.NotFoundError, "ENOENT")
+		logger.Tracef("fs.Write() error: volume '%s' inode %d offset %d len %d err %v",
+			mS.volStruct.volumeName, inodeNumber, offset, len(buf), err)
 		return
 	}
 	if !mS.volStruct.VolumeHandle.Access(inodeNumber, userID, groupID, otherGroupIDs, inode.W_OK) {
 		err = blunder.NewError(blunder.PermDeniedError, "EACCES")
+		logger.Tracef("fs.Write() error: volume '%s' inode %d offset %d len %d err %v",
+			mS.volStruct.volumeName, inodeNumber, offset, len(buf), err)
 		return
 	}
 
@@ -2961,13 +2978,16 @@ func (mS *mountStruct) Write(userID inode.InodeUserID, groupID inode.InodeGroupI
 	profiler.AddEventNow("after inode.Write()")
 	// write to Swift presumably succeeds or fails as a whole
 	if err != nil {
+		logger.Tracef("fs.Write() error: volume '%s' inode %d offset %d len %d err %v",
+			mS.volStruct.volumeName, inodeNumber, offset, len(buf), err)
 		return 0, err
 	}
 
-	logger.Tracef("fs.Write(): tracking write volume '%s' inode %d", mS.volStruct.volumeName, inodeNumber)
+	logger.Tracef("fs.Write(): tracking write to volume '%s' inode %d", mS.volStruct.volumeName, inodeNumber)
 	mS.volStruct.trackInFlightFileInodeData(inodeNumber)
 	size = uint64(len(buf))
 	stats.IncrementOperations(&stats.FsWriteOps)
+
 	return
 }
 

--- a/headhunter/api_internal.go
+++ b/headhunter/api_internal.go
@@ -1083,6 +1083,10 @@ func (volume *volumeStruct) FetchNonce() (nonce uint64, err error) {
 }
 
 func (volume *volumeStruct) GetInodeRec(inodeNumber uint64) (value []byte, ok bool, err error) {
+
+	logger.Tracef("headhunger.GetInodeRec() entry: volume '%s' inode %d", volume.volumeName, inodeNumber)
+	defer logger.Tracef("headhunger.GetInodeRec() return: volume '%s' inode %d", volume.volumeName, inodeNumber)
+
 	volume.Lock()
 	valueAsValue, ok, err := volume.inodeRecWrapper.bPlusTree.GetByKey(inodeNumber)
 	if nil != err {
@@ -1104,7 +1108,8 @@ func (volume *volumeStruct) GetInodeRec(inodeNumber uint64) (value []byte, ok bo
 
 func (volume *volumeStruct) PutInodeRec(inodeNumber uint64, value []byte) (err error) {
 
-	logger.Tracef("headhunger.PutInodeRec(): volume '%s' inode %d", volume.volumeName, inodeNumber)
+	logger.Tracef("headhunger.PutInodeRec() entry: volume '%s' inode %d", volume.volumeName, inodeNumber)
+	defer logger.Tracef("headhunger.PutInodeRec() return: volume '%s' inode %d", volume.volumeName, inodeNumber)
 
 	valueToTree := make([]byte, len(value))
 	copy(valueToTree, value)
@@ -1130,7 +1135,8 @@ func (volume *volumeStruct) PutInodeRec(inodeNumber uint64, value []byte) (err e
 
 func (volume *volumeStruct) PutInodeRecs(inodeNumbers []uint64, values [][]byte) (err error) {
 
-	logger.Tracef("headhunter.PutInodeRecs(): volume '%s' inodes %v", volume.volumeName, inodeNumbers)
+	logger.Tracef("headhunter.PutInodeRecs() entry: volume '%s' inodes %v", volume.volumeName, inodeNumbers)
+	defer logger.Tracef("headhunter.PutInodeRecs() return: volume '%s' inodes %v", volume.volumeName, inodeNumbers)
 
 	if len(inodeNumbers) != len(values) {
 		err = fmt.Errorf("InodeNumber and Values array don't match")
@@ -1196,6 +1202,12 @@ func (volume *volumeStruct) GetLogSegmentRec(logSegmentNumber uint64) (value []b
 }
 
 func (volume *volumeStruct) PutLogSegmentRec(logSegmentNumber uint64, value []byte) (err error) {
+
+	logger.Tracef("headhunter.PutLogSegmentRec() entry: volume '%s' Segment %v",
+		volume.volumeName, logSegmentNumber)
+	defer logger.Tracef("headhunter.PutLogSegmentRec() return: volume '%s' Segment %v",
+		volume.volumeName, logSegmentNumber)
+
 	valueToTree := make([]byte, len(value))
 	copy(valueToTree, value)
 

--- a/inode/file_flusher.go
+++ b/inode/file_flusher.go
@@ -321,6 +321,13 @@ func (vS *volumeStruct) doSendChunk(fileInode *inMemoryInodeStruct, buf []byte) 
 }
 
 func (vS *volumeStruct) doFileInodeDataFlush(fileInode *inMemoryInodeStruct) (err error) {
+
+	logger.Tracef("volumeStruct.doFileInodeDataFlush(): entry volume '%s'  inode %d  dirty %v  openSegment %p",
+		vS.volumeName, fileInode.onDiskInodeV1Struct.InodeNumber,
+		fileInode.dirty, fileInode.openLogSegment)
+	defer logger.Tracef("volumeStruct.doFileInodeDataFlush(): return volume '%s'  inode %d",
+		vS.volumeName, fileInode.onDiskInodeV1Struct.InodeNumber)
+
 	fileInode.Lock()
 
 	if nil != fileInode.openLogSegment {

--- a/logger/api_test.go
+++ b/logger/api_test.go
@@ -30,7 +30,7 @@ func TestAPI(t *testing.T) {
 		"Stats.UDPPort=52184",
 		"Stats.BufferLength=100",
 		"Stats.MaxLatency=1s",
-		"Logging.TraceLevelLogging=logger",
+		"Logging.TraceLevelLogging=logger fs headhunter",
 	}
 
 	confMap, err := conf.MakeConfMapFromStrings(confStrings)

--- a/logger/config.go
+++ b/logger/config.go
@@ -10,6 +10,10 @@ import (
 	"github.com/swiftstack/ProxyFS/conf"
 )
 
+// RFC3339 format with microsecond precision
+//
+const timeFormat = "2006-01-02T15:04:05.000000Z07:00"
+
 var logFile *os.File = nil
 
 // multiWriter groups multiple io.Writers into a single io.Writer. (Our
@@ -56,7 +60,7 @@ func addLogTarget(writer io.Writer) {
 }
 
 func up(confMap conf.ConfMap) (err error) {
-	log.SetFormatter(&log.TextFormatter{DisableColors: true})
+	log.SetFormatter(&log.TextFormatter{DisableColors: true, TimestampFormat: timeFormat})
 
 	// Fetch log file info, if provided
 	logFilePath, _ := confMap.FetchOptionValueString("Logging", "LogFilePath")

--- a/proxyfsd/default.conf
+++ b/proxyfsd/default.conf
@@ -97,9 +97,19 @@ Debug:           false
 # Log reporting parameters
 [Logging]
 LogFilePath:       proxyfsd.log
-LogToConsole:      false # when true, log to stderr even when LogFilePath is set
-TraceLevelLogging: none  # Enable trace logging on a per-package basis. Supported values: jrpcfs, inode, none (default)
-DebugLevelLogging: none  # Enable debug logging on a per-package basis. Supported values: ldlm, fs, jrpcfs, inode, none (default)
+
+# when true, log to stderr even when LogFilePath is set
+LogToConsole: false
+
+# Enable trace logging on a per-package basis. Trace logs are disabled by default unless enabled here.
+# Supported values: any combination of "dlm", "fs", "fuse", "headhunter", "inode", "jrpcfs", "logger",
+# and "swiftclient" or "none" (default).
+TraceLevelLogging: none
+
+# Enable debug logging on a per-package basis. Debug logs are disabled by default unless enabled here.
+# Supported values: any combination of "ldlm", "fs", "jrpcfs" and "inode" or "none" (default).
+DebugLevelLogging: none
+
 # NOTE: Log levels other than Trace and Debug are always on.
 
 # Stats reporting parameters (must contain either a UDPPort or TCPPort)

--- a/proxyfsd/logging.conf
+++ b/proxyfsd/logging.conf
@@ -4,7 +4,8 @@ LogFilePath: proxyfsd.log
 # NOTE: Log levels other than Trace and Debug are always on.
 
 # Enable trace logging on a per-package basis. Trace logs are disabled by default unless enabled here.
-# Supported values: jrpcfs, inode, none (default).
+# Supported values: any combination of "dlm", "fs", "fuse", "headhunter", "inode", "jrpcfs", "logger",
+# and "swiftclient" or "none" (default).
 TraceLevelLogging: none
 
 # Enable debug logging on a per-package basis. Debug logs are disabled by default unless enabled here.
@@ -13,4 +14,3 @@ DebugLevelLogging: none
 
 # when true, log to stderr even when LogFilePath is set
 LogToConsole: false
-

--- a/proxyfsd/saio_logging.conf
+++ b/proxyfsd/saio_logging.conf
@@ -4,7 +4,8 @@ LogFilePath: /var/log/proxyfsd/proxyfsd.log
 # NOTE: Log levels other than Trace and Debug are always on.
 
 # Enable trace logging on a per-package basis. Trace logs are disabled by default unless enabled here.
-# Supported values: jrpcfs, inode, none (default).
+# Supported values: any combination of "dlm", "fs", "fuse", "headhunter", "inode", "jrpcfs", "logger",
+# and "swiftclient" or "none" (default).
 TraceLevelLogging: none
 
 # Enable debug logging on a per-package basis. Debug logs are disabled by default unless enabled here.

--- a/swiftclient/api_test.go
+++ b/swiftclient/api_test.go
@@ -953,7 +953,7 @@ func parseRetryLogEntry(entry string) map[string]string {
 	)
 
 	var fieldRE = regexp.MustCompile(
-		`^time="([-:0-9A-Z]+)" level=([a-zA-Z]+) msg="([^"]+)" (error="([^"]+)")? ?function=(\w+) (.*)`)
+		`^time="([-:0-9.A-Z]+)" level=([a-zA-Z]+) msg="([^"]+)" (error="([^"]+)")? ?function=(\w+) (.*)`)
 
 	matches = fieldRE.FindStringSubmatch(entry)
 	if matches == nil {


### PR DESCRIPTION
This branch is mis-named since it doesn't fix any bugs in the sortedmap code, though that was its genesis.
Add tracing messages to parts of the swiftclient code and the file system code that updates the object map (extent map) and flushes both inodes and B+ trees. 