### PR TITLE
Start and stop Swift processes cleanly and FUSE hang

### DIFF
--- a/cookbooks/proxyfs/files/default/usr/bin/unmount_and_stop_pfs
+++ b/cookbooks/proxyfs/files/default/usr/bin/unmount_and_stop_pfs
@@ -55,7 +55,10 @@ if [ -f /usr/bin/systemctl ]; then
     # sudo /usr/bin/systemctl stop winbind
     sudo /usr/bin/systemctl stop proxyfsd
     await_proxyfsd_shutdown
-    sudo /usr/bin/swift-init main stop
+
+    # NOTE: We purposely stop Swift with "swift-init all stop" and not
+    # "swift-init main stop".   See start_and_stop_pfs for more details.
+    sudo /usr/bin/swift-init all stop
     # sudo /usr/bin/systemctl stop swift
     sudo /usr/bin/systemctl stop memcached
 else
@@ -69,7 +72,10 @@ else
     # sudo /usr/sbin/service winbindd stop
     sudo /usr/sbin/service proxyfsd stop
     await_proxyfsd_shutdown
-    sudo /usr/bin/swift-init main stop
+
+    # NOTE: We purposely stop Swift with "swift-init all stop" and not
+    # "swift-init main stop".   See start_and_stop_pfs for more details.
+    sudo /usr/bin/swift-init all stop
     # sudo /usr/sbin/service swift stop
     sudo /usr/sbin/service memcached stop
 fi

--- a/cookbooks/proxyfs/files/default/usr/bin/unmount_and_stop_pfs
+++ b/cookbooks/proxyfs/files/default/usr/bin/unmount_and_stop_pfs
@@ -59,7 +59,6 @@ if [ -f /usr/bin/systemctl ]; then
     # NOTE: We purposely stop Swift with "swift-init all stop" and not
     # "swift-init main stop".   See start_and_stop_pfs for more details.
     sudo /usr/bin/swift-init all stop
-    # sudo /usr/bin/systemctl stop swift
     sudo /usr/bin/systemctl stop memcached
 else
     # Ubuntu (not tested!)
@@ -76,6 +75,5 @@ else
     # NOTE: We purposely stop Swift with "swift-init all stop" and not
     # "swift-init main stop".   See start_and_stop_pfs for more details.
     sudo /usr/bin/swift-init all stop
-    # sudo /usr/sbin/service swift stop
     sudo /usr/sbin/service memcached stop
 fi

--- a/cookbooks/proxyfs/files/default/usr/bin/unmount_and_stop_pfs
+++ b/cookbooks/proxyfs/files/default/usr/bin/unmount_and_stop_pfs
@@ -56,9 +56,7 @@ if [ -f /usr/bin/systemctl ]; then
     sudo /usr/bin/systemctl stop proxyfsd
     await_proxyfsd_shutdown
 
-    # NOTE: We purposely stop Swift with "swift-init all stop" and not
-    # "swift-init main stop".   See start_and_stop_pfs for more details.
-    sudo /usr/bin/swift-init all stop
+    sudo /usr/bin/swift-init main stop
     sudo /usr/bin/systemctl stop memcached
 else
     # Ubuntu (not tested!)
@@ -72,8 +70,6 @@ else
     sudo /usr/sbin/service proxyfsd stop
     await_proxyfsd_shutdown
 
-    # NOTE: We purposely stop Swift with "swift-init all stop" and not
-    # "swift-init main stop".   See start_and_stop_pfs for more details.
-    sudo /usr/bin/swift-init all stop
+    sudo /usr/bin/swift-init main stop
     sudo /usr/sbin/service memcached stop
 fi

--- a/cookbooks/proxyfs/templates/default/usr/bin/start_and_mount_pfs.erb
+++ b/cookbooks/proxyfs/templates/default/usr/bin/start_and_mount_pfs.erb
@@ -122,15 +122,6 @@ if [ $MOUNT_TYPE != "keepmounts" ]; then
     fi
 fi
 
-# NOTE: We start and stop Swift by doing "swift-init all start" or "swift-init all stop".
-#
-# This is because "swift-init main" does not start/stop the reaper.  In addition, it does
-# not always stop all Swift processes.  In fact, "swift-init all stop" does not stop all
-# processes either but it does stop most.
-#
-# During functional-tests, we have a separate script called kill_proxyfs.sh which
-# pkills with a KILL signal all swift-* processes.
-
 if [ -f /usr/bin/systemctl ]; then
     # Centos
     MOUNT=/usr/bin/mount
@@ -143,11 +134,11 @@ if [ -f /usr/bin/systemctl ]; then
     # sudo /usr/bin/systemctl stop winbind
     sudo /usr/bin/systemctl stop proxyfsd
     await_proxyfsd_shutdown
-    sudo /usr/bin/swift-init all stop
+    sudo /usr/bin/swift-init main stop
     sudo /usr/bin/systemctl stop memcached
 
     sudo /usr/bin/systemctl start memcached
-    sudo /usr/bin/swift-init all start
+    sudo /usr/bin/swift-init main start
     await_swift_startup
     format_volume_if_necessary CommonVolume
     sudo /usr/bin/systemctl start proxyfsd
@@ -171,11 +162,11 @@ else
     # sudo /usr/sbin/service winbindd stop
     sudo /usr/sbin/service proxyfsd stop
     await_proxyfsd_shutdown
-    sudo /usr/bin/swift-init all stop
+    sudo /usr/bin/swift-init main stop
     sudo /usr/sbin/service memcached stop
 
     sudo /usr/sbin/service memcached start
-    sudo /usr/bin/swift-init all start
+    sudo /usr/bin/swift-init main start
     await_swift_startup
     format_volume_if_necessary CommonVolume
     sudo /usr/sbin/service proxyfsd start

--- a/cookbooks/proxyfs/templates/default/usr/bin/start_and_mount_pfs.erb
+++ b/cookbooks/proxyfs/templates/default/usr/bin/start_and_mount_pfs.erb
@@ -144,11 +144,9 @@ if [ -f /usr/bin/systemctl ]; then
     sudo /usr/bin/systemctl stop proxyfsd
     await_proxyfsd_shutdown
     sudo /usr/bin/swift-init all stop
-    # sudo /usr/bin/systemctl stop swift
     sudo /usr/bin/systemctl stop memcached
 
     sudo /usr/bin/systemctl start memcached
-    # sudo /usr/bin/systemctl start swift
     sudo /usr/bin/swift-init all start
     await_swift_startup
     format_volume_if_necessary CommonVolume
@@ -174,11 +172,9 @@ else
     sudo /usr/sbin/service proxyfsd stop
     await_proxyfsd_shutdown
     sudo /usr/bin/swift-init all stop
-    # sudo /usr/sbin/service swift stop
     sudo /usr/sbin/service memcached stop
 
     sudo /usr/sbin/service memcached start
-    # sudo /usr/sbin/service swift start
     sudo /usr/bin/swift-init all start
     await_swift_startup
     format_volume_if_necessary CommonVolume

--- a/cookbooks/proxyfs/templates/default/usr/bin/start_and_mount_pfs.erb
+++ b/cookbooks/proxyfs/templates/default/usr/bin/start_and_mount_pfs.erb
@@ -122,6 +122,15 @@ if [ $MOUNT_TYPE != "keepmounts" ]; then
     fi
 fi
 
+# NOTE: We start and stop Swift by doing "swift-init all start" or "swift-init all stop".
+#
+# This is because "swift-init main" does not start/stop the reaper.  In addition, it does
+# not always stop all Swift processes.  In fact, "swift-init all stop" does not stop all
+# processes either but it does stop most.
+#
+# During functional-tests, we have a separate script called kill_proxyfs.sh which
+# pkills with a KILL signal all swift-* processes.
+
 if [ -f /usr/bin/systemctl ]; then
     # Centos
     MOUNT=/usr/bin/mount
@@ -134,13 +143,13 @@ if [ -f /usr/bin/systemctl ]; then
     # sudo /usr/bin/systemctl stop winbind
     sudo /usr/bin/systemctl stop proxyfsd
     await_proxyfsd_shutdown
-    sudo /usr/bin/swift-init main stop
+    sudo /usr/bin/swift-init all stop
     # sudo /usr/bin/systemctl stop swift
     sudo /usr/bin/systemctl stop memcached
 
     sudo /usr/bin/systemctl start memcached
     # sudo /usr/bin/systemctl start swift
-    sudo /usr/bin/swift-init main start
+    sudo /usr/bin/swift-init all start
     await_swift_startup
     format_volume_if_necessary CommonVolume
     sudo /usr/bin/systemctl start proxyfsd
@@ -164,13 +173,13 @@ else
     # sudo /usr/sbin/service winbindd stop
     sudo /usr/sbin/service proxyfsd stop
     await_proxyfsd_shutdown
-    sudo /usr/bin/swift-init main stop
+    sudo /usr/bin/swift-init all stop
     # sudo /usr/sbin/service swift stop
     sudo /usr/sbin/service memcached stop
 
     sudo /usr/sbin/service memcached start
     # sudo /usr/sbin/service swift start
-    sudo /usr/bin/swift-init main start
+    sudo /usr/bin/swift-init all start
     await_swift_startup
     format_volume_if_necessary CommonVolume
     sudo /usr/sbin/service proxyfsd start


### PR DESCRIPTION
During CHO testing, we noticed that Swift processes were not always
started and stopped as expected when using start_and_mount_pfs or
unmount_and_stop_pfs.  Even though we stopped Swift there were Swift
processes which were still running.  Additionally, the Swift reaper
process was not enabled and therefore the checkpoint container
was not being cleaned up.

The first part of the fix is to do "swift-init all start" and
"swift-init all stop" for starting and stopping Swift.  This also
starts the Swift reaper.

The second part of the fix is in the functional-tests repository.  It is
to have the kill_proxyfs.sh script do a pkill and kill remaining Swift
processes which exist.