### PR TITLE
Work with new Swift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ test:
 	@set -e; \
 	for gosubdir in $(gosubdirs); do \
 		$(MAKE) --no-print-directory -C $$gosubdir test; \
-	done
+	done; \
+	cd pfs_middleware && tox -e py27,py27-old-swift,lint
 
 vet:
 	@set -e; \

--- a/Makefile
+++ b/Makefile
@@ -31,14 +31,14 @@ uname := $(shell uname)
 ifeq ($(uname),Linux)
     distro := $(shell python -c "import platform; print platform.linux_distribution()[0]")
 
-    all: fmt install stringer generate test vet c-clean c-build c-install c-test
+    all: fmt install stringer generate test python-test vet c-clean c-build c-install c-test
 
     all-deb-builder: fmt install stringer generate vet c-clean c-build c-install-deb-builder
 else
     all: fmt install stringer generate test vet
 endif
 
-.PHONY: all all-deb-builder bench c-build c-clean c-install c-install-deb-builder c-test clean cover fmt generate install stringer test vet
+.PHONY: all all-deb-builder bench c-build c-clean c-install c-install-deb-builder c-test clean cover fmt generate install python-test stringer test vet
 
 bench:
 	@set -e; \
@@ -105,6 +105,9 @@ install:
 		$(MAKE) --no-print-directory -C $$gosubdir install; \
 	done
 
+python-test:
+	cd pfs_middleware && tox -e py27,py27-old-swift,lint
+
 stringer:
 	go install github.com/swiftstack/ProxyFS/vendor/golang.org/x/tools/cmd/stringer
 
@@ -112,8 +115,7 @@ test:
 	@set -e; \
 	for gosubdir in $(gosubdirs); do \
 		$(MAKE) --no-print-directory -C $$gosubdir test; \
-	done; \
-	cd pfs_middleware && tox -e py27,py27-old-swift,lint
+	done;
 
 vet:
 	@set -e; \

--- a/cookbooks/pfs_middleware/recipes/default.rb
+++ b/cookbooks/pfs_middleware/recipes/default.rb
@@ -18,8 +18,8 @@ execute "Install PIP" do
   not_if { system("pip --version") }
 end
 
-execute "Check setuptools is installed" do
-  command "pip install setuptools"
+execute "Check setuptools & tox is installed" do
+  command "pip install setuptools tox"
 end
 
 # install middleware in development mode

--- a/pfs_middleware/tox.ini
+++ b/pfs_middleware/tox.ini
@@ -10,15 +10,9 @@ commands = flake8 {posargs:pfs_middleware tests setup.py}
 
 [testenv:py27]
 usedevelop = True
-
-# Swift's Pike release isn't on PyPI for some reason, so we have to
-# fetch a tarball. We use the latest stable release here so that some
-# random Swift checkin can't break CI for us. We still have to deal
-# with upstream Swift changes, but at least it will be on our own
-# schedule.
 deps =
   -r{toxinidir}/test-requirements.txt
-  http://tarballs.openstack.org/swift/swift-stable-pike.tar.gz
+  git+git://github.com/openstack/swift.git@5cf96230c82d4fcbac297775997a7e0abe3e9ff9
 
 commands = python -m unittest discover
 

--- a/pfs_middleware/tox.ini
+++ b/pfs_middleware/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27,lint
+envlist = py27,py27-old-swift,py27-swift-master,lint
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
+commands = python -m unittest discover
 
 [testenv:lint]
 basepython = python2.7
@@ -14,7 +15,18 @@ deps =
   -r{toxinidir}/test-requirements.txt
   git+git://github.com/openstack/swift.git@5cf96230c82d4fcbac297775997a7e0abe3e9ff9
 
-commands = python -m unittest discover
+[testenv:py27-old-swift]
+# This tests with the earliest version of Swift we support.
+usedevelop = True
+deps =
+  -r{toxinidir}/test-requirements.txt
+  http://tarballs.openstack.org/swift/swift-2.9.0.tar.gz
+
+[testenv:py27-swift-master]
+usedevelop = True
+deps =
+  -r{toxinidir}/test-requirements.txt
+  http://tarballs.openstack.org/swift/swift-master.tar.gz
 
 [flake8]
 # flake8 has opinions with which we agree, for the most part. However,

--- a/saio/vagrant_provision.sh
+++ b/saio/vagrant_provision.sh
@@ -118,6 +118,10 @@ else
 fi
 echo "export SAMBA_SOURCE=\$GOPATH/src/github.com/swiftstack/ProxyFS/vfs/samba" >> ~vagrant/.bash_profile
 
+# Install Python tox
+
+pip install tox
+
 # Setup Swift
 #
 # Guided by https://docs.openstack.org/swift/latest/development_saio.html


### PR DESCRIPTION
Here we

* Add `X-Timestamp` headers before calling `constraints.check_object_creation` (like the object controller had to do in https://github.com/openstack/swift/commit/31c294d),
* Update the version of Swift we use when running unit tests to demonstrate why the above is necessary,
* Add more tox envs to test with both older and newer versions of Swift as well, which highlights why we can't use things like `Timestamp.now()`, and
* Add the pfs_middleware unit tests to the project-wide `make test` target.