### PR TITLE
Feature layoutreport

### DIFF
--- a/headhunter/api.go
+++ b/headhunter/api.go
@@ -4,6 +4,16 @@ package headhunter
 import (
 	"fmt"
 	"sync"
+
+	"github.com/swiftstack/sortedmap"
+)
+
+type BPlusTreeType uint32
+
+const (
+	InodeRecBPlusTree BPlusTreeType = iota
+	LogSegmentRecBPlusTree
+	BPlusTreeObjectBPlusTree
 )
 
 // VolumeHandle is used to operate on a given volume's database
@@ -21,6 +31,7 @@ type VolumeHandle interface {
 	PutBPlusTreeObject(objectNumber uint64, value []byte) (err error)
 	DeleteBPlusTreeObject(objectNumber uint64) (err error)
 	DoCheckpoint() (err error)
+	FetchLayoutReport(treeType BPlusTreeType) (layoutReport sortedmap.LayoutReport, err error)
 }
 
 // FetchVolumeHandle is used to fetch a VolumeHandle to use when operating on a given volume's database

--- a/headhunter/sortedmap_helper.go
+++ b/headhunter/sortedmap_helper.go
@@ -135,6 +135,8 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) DiscardNode(objectNumber uint64,
 	switch bPlusTreeWrapper.wrapperType {
 
 	case inodeRecBPlusTreeWrapperType:
+		logger.Tracef("headhunter.DiscardNode(): InodeRec Tree Object %016X  offset %d  length %d",
+			objectNumber, objectOffset, objectLength)
 		bytesUsed, ok = bPlusTreeWrapper.volume.inodeRecBPlusTreeLayout[objectNumber]
 		if ok {
 			if bytesUsed < objectLength {
@@ -150,6 +152,8 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) DiscardNode(objectNumber uint64,
 		}
 
 	case logSegmentRecBPlusTreeWrapperType:
+		logger.Tracef("headhunter.DiscardNode(): LogSegment Tree Object %016X  offset %d  length %d",
+			objectNumber, objectOffset, objectLength)
 		bytesUsed, ok = bPlusTreeWrapper.volume.logSegmentRecBPlusTreeLayout[objectNumber]
 		if ok {
 			if bytesUsed < objectLength {
@@ -165,6 +169,8 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) DiscardNode(objectNumber uint64,
 		}
 
 	case bPlusTreeObjectBPlusTreeWrapperType:
+		logger.Tracef("headhunter.DiscardNode(): BPlusObject Tree Object %016X  offset %d  length %d",
+			objectNumber, objectOffset, objectLength)
 		bytesUsed, ok = bPlusTreeWrapper.volume.bPlusTreeObjectBPlusTreeLayout[objectNumber]
 		if ok {
 			if bytesUsed < objectLength {
@@ -178,6 +184,7 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) DiscardNode(objectNumber uint64,
 			err = fmt.Errorf("Logic error: [bPlusTreeObjectBPlusTreeWrapperType] bPlusTreeWrapper.DiscardNode() called referencing invalid objectNumber: 0x%016X", objectNumber)
 			logger.ErrorfWithError(err, "disk corruption or logic error")
 		}
+
 	default:
 		err = fmt.Errorf("Logic error: bPlusTreeWrapper.DiscardNode() called for invalid wrapperType: %v", bPlusTreeWrapper.wrapperType)
 		logger.ErrorfWithError(err, "this is BIG error ...")

--- a/headhunter/sortedmap_helper.go
+++ b/headhunter/sortedmap_helper.go
@@ -3,6 +3,7 @@ package headhunter
 import (
 	"fmt"
 
+	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/swiftclient"
 	"github.com/swiftstack/ProxyFS/utils"
 	"github.com/swiftstack/sortedmap"
@@ -90,6 +91,7 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) PutNode(nodeByteSlice []byte) (o
 	bPlusTreeWrapper.volume.checkpointFlushedData = true
 
 	switch bPlusTreeWrapper.wrapperType {
+
 	case inodeRecBPlusTreeWrapperType:
 		bytesUsed, ok = bPlusTreeWrapper.volume.inodeRecBPlusTreeLayout[objectNumber]
 		if ok {
@@ -97,6 +99,7 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) PutNode(nodeByteSlice []byte) (o
 		} else {
 			bPlusTreeWrapper.volume.inodeRecBPlusTreeLayout[objectNumber] = uint64(len(nodeByteSlice))
 		}
+
 	case logSegmentRecBPlusTreeWrapperType:
 		bytesUsed, ok = bPlusTreeWrapper.volume.logSegmentRecBPlusTreeLayout[objectNumber]
 		if ok {
@@ -104,6 +107,7 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) PutNode(nodeByteSlice []byte) (o
 		} else {
 			bPlusTreeWrapper.volume.logSegmentRecBPlusTreeLayout[objectNumber] = uint64(len(nodeByteSlice))
 		}
+
 	case bPlusTreeObjectBPlusTreeWrapperType:
 		bytesUsed, ok = bPlusTreeWrapper.volume.bPlusTreeObjectBPlusTreeLayout[objectNumber]
 		if ok {
@@ -111,6 +115,7 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) PutNode(nodeByteSlice []byte) (o
 		} else {
 			bPlusTreeWrapper.volume.bPlusTreeObjectBPlusTreeLayout[objectNumber] = uint64(len(nodeByteSlice))
 		}
+
 	default:
 		err = fmt.Errorf("Logic error: bPlusTreeWrapper.PutNode() called for invalid wrapperType: %v", bPlusTreeWrapper.wrapperType)
 		panic(err)
@@ -128,44 +133,54 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) DiscardNode(objectNumber uint64,
 	)
 
 	switch bPlusTreeWrapper.wrapperType {
+
 	case inodeRecBPlusTreeWrapperType:
 		bytesUsed, ok = bPlusTreeWrapper.volume.inodeRecBPlusTreeLayout[objectNumber]
 		if ok {
 			if bytesUsed < objectLength {
 				err = fmt.Errorf("Logic error: [inodeRecBPlusTreeWrapperType] bPlusTreeWrapper.DiscardNode() called to dereference too many bytes in objectNumber 0x%016X", objectNumber)
+				logger.ErrorWithError(err, "bad error")
 			} else {
 				err = nil
 				bPlusTreeWrapper.volume.inodeRecBPlusTreeLayout[objectNumber] = bytesUsed - objectLength
 			}
 		} else {
 			err = fmt.Errorf("Logic error: [inodeRecBPlusTreeWrapperType] bPlusTreeWrapper.DiscardNode() called referencing invalid objectNumber: 0x%016X", objectNumber)
+			logger.ErrorfWithError(err, "disk corruption or logic error")
 		}
+
 	case logSegmentRecBPlusTreeWrapperType:
 		bytesUsed, ok = bPlusTreeWrapper.volume.logSegmentRecBPlusTreeLayout[objectNumber]
 		if ok {
 			if bytesUsed < objectLength {
 				err = fmt.Errorf("Logic error: [logSegmentRecBPlusTreeWrapperType] bPlusTreeWrapper.DiscardNode() called to dereference too many bytes in objectNumber 0x%016X", objectNumber)
+				logger.ErrorWithError(err, "bad error")
 			} else {
 				err = nil
 				bPlusTreeWrapper.volume.logSegmentRecBPlusTreeLayout[objectNumber] = bytesUsed - objectLength
 			}
 		} else {
 			err = fmt.Errorf("Logic error: [logSegmentRecBPlusTreeWrapperType] bPlusTreeWrapper.DiscardNode() called referencing invalid objectNumber: 0x%016X", objectNumber)
+			logger.ErrorfWithError(err, "disk corruption or logic error")
 		}
+
 	case bPlusTreeObjectBPlusTreeWrapperType:
 		bytesUsed, ok = bPlusTreeWrapper.volume.bPlusTreeObjectBPlusTreeLayout[objectNumber]
 		if ok {
 			if bytesUsed < objectLength {
 				err = fmt.Errorf("Logic error: [bPlusTreeObjectBPlusTreeWrapperType] bPlusTreeWrapper.DiscardNode() called to dereference too many bytes in objectNumber 0x%016X", objectNumber)
+				logger.ErrorWithError(err, "bad error")
 			} else {
 				err = nil
 				bPlusTreeWrapper.volume.bPlusTreeObjectBPlusTreeLayout[objectNumber] = bytesUsed - objectLength
 			}
 		} else {
 			err = fmt.Errorf("Logic error: [bPlusTreeObjectBPlusTreeWrapperType] bPlusTreeWrapper.DiscardNode() called referencing invalid objectNumber: 0x%016X", objectNumber)
+			logger.ErrorfWithError(err, "disk corruption or logic error")
 		}
 	default:
 		err = fmt.Errorf("Logic error: bPlusTreeWrapper.DiscardNode() called for invalid wrapperType: %v", bPlusTreeWrapper.wrapperType)
+		logger.ErrorfWithError(err, "this is BIG error ...")
 	}
 
 	return // err set as appropriate regardless of path

--- a/inode/inode.go
+++ b/inode/inode.go
@@ -423,6 +423,13 @@ func (vS *volumeStruct) flushInodes(inodes []*inMemoryInodeStruct) (err error) {
 				// REVIEW TODO: What if cache pressure flushed before we got here?
 				//              Is it possible that Number doesn't get updated?
 
+				if inode.PayloadObjectNumber != 0 {
+					logger.Tracef("flushInodes(): updating Payload from ObjNum %d to %d"+
+						" bytes %d to %d for %v inode %d",
+						inode.PayloadObjectNumber, payloadObjectNumber,
+						inode.PayloadObjectLength, payloadObjectLength,
+						inode.InodeType, inode.InodeNumber)
+				}
 				inode.PayloadObjectNumber = payloadObjectNumber
 				inode.PayloadObjectLength = payloadObjectLength
 

--- a/logger/config.go
+++ b/logger/config.go
@@ -10,6 +10,10 @@ import (
 	"github.com/swiftstack/ProxyFS/conf"
 )
 
+// RFC3339 format with microsecond precision
+//
+const timeFormat = "2006-01-02T15:04:05.000000Z07:00"
+
 var logFile *os.File = nil
 
 // multiWriter groups multiple io.Writers into a single io.Writer. (Our
@@ -56,7 +60,8 @@ func addLogTarget(writer io.Writer) {
 }
 
 func up(confMap conf.ConfMap) (err error) {
-	log.SetFormatter(&log.TextFormatter{DisableColors: true})
+
+	log.SetFormatter(&log.TextFormatter{DisableColors: true, TimestampFormat: timeFormat})
 
 	// Fetch log file info, if provided
 	logFilePath, _ := confMap.FetchOptionValueString("Logging", "LogFilePath")

--- a/swiftclient/api_test.go
+++ b/swiftclient/api_test.go
@@ -1002,7 +1002,7 @@ func parseRetryLogEntry(entry string) map[string]string {
 	)
 
 	var fieldRE = regexp.MustCompile(
-		`^time="([-:0-9A-Z]+)" level=([a-zA-Z]+) msg="([^"]+)" (error="([^"]+)")? ?function=(\w+) (.*)`)
+		`^time="([-:0-9.A-Z]+)" level=([a-zA-Z]+) msg="([^"]+)" (error="([^"]+)")? ?function=(\w+) (.*)`)
 
 	matches = fieldRE.FindStringSubmatch(entry)
 	if matches == nil {


### PR DESCRIPTION
Add a new query for the ProxyFS internal http server "layout-report".

The URL for the query is "http:/localhost:15346/volume/<volume-name>/layout-report" and it reacts by calling FetchLayoutReport() on each of the ProxyFS sortedmap's and returning the results.  In addition it compares the returned layout reports with the "cached" layout reports maintained by ProxyFS and logs any inconsistencies.  It does not include the inconsistencies in the returned HTML.

i have not verified that the returned HTML is correct or can be displayed by a browser.  In addition, i have not written the code to return the results encoded in JSON instead of HTML.  nevertheless, i've found the code useful to try and debug an issue with the cached layout maps.