### PR TITLE
Added pfs-crash script to exercise B+Trees heavily

### DIFF
--- a/pfs-crash/b_tree_load.sh
+++ b/pfs-crash/b_tree_load.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+for i in `seq 100`;do
+  echo "Iteration $i"
+  for j in `seq 10`;do
+    for k in `seq 100`;do
+      echo "Hi" >> CommonMountPoint/f_$k
+    done
+  done
+    for k in `seq 100`;do
+      rm CommonMountPoint/f_$k
+    done
+done


### PR DESCRIPTION
Note that this script may be used along with FSCK
to verify whether or not the B+Tree-based logic is
completely garbage collecting.