### PR TITLE
FSCK now uses async delete and new "exhaustive" ContainerGet

### DIFF
--- a/fs/api_test.go
+++ b/fs/api_test.go
@@ -100,6 +100,8 @@ func testSetup() (err error) {
 		"RamSwiftInfo.MaxAccountNameLength=256",
 		"RamSwiftInfo.MaxContainerNameLength=256",
 		"RamSwiftInfo.MaxObjectNameLength=1024",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
 	}
 
 	testConfMap, err := conf.MakeConfMapFromStrings(testConfMapStrings)

--- a/headhunter/api_test.go
+++ b/headhunter/api_test.go
@@ -130,6 +130,8 @@ func TestHeadHunterAPI(t *testing.T) {
 		"RamSwiftInfo.MaxAccountNameLength=256",
 		"RamSwiftInfo.MaxContainerNameLength=256",
 		"RamSwiftInfo.MaxObjectNameLength=1024",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
 	}
 
 	// Construct replayLogFileName to use as Volume:TestVolume.ReplayLogFileName

--- a/headhunter/stress_test.go
+++ b/headhunter/stress_test.go
@@ -189,6 +189,8 @@ func TestHeadHunterStress(t *testing.T) {
 		"RamSwiftInfo.MaxAccountNameLength=256",
 		"RamSwiftInfo.MaxContainerNameLength=256",
 		"RamSwiftInfo.MaxObjectNameLength=1024",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
 	}
 
 	// Launch a ramswift instance

--- a/inode/api_test.go
+++ b/inode/api_test.go
@@ -109,6 +109,8 @@ func testSetup() (err error) {
 		"RamSwiftInfo.MaxAccountNameLength=256",
 		"RamSwiftInfo.MaxContainerNameLength=256",
 		"RamSwiftInfo.MaxObjectNameLength=1024",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
 	}
 
 	testConfMap, err := conf.MakeConfMapFromStrings(testConfStrings)

--- a/jrpcfs/middleware_test.go
+++ b/jrpcfs/middleware_test.go
@@ -68,6 +68,8 @@ func testSetup() []func() {
 		"RamSwiftInfo.MaxAccountNameLength=256",
 		"RamSwiftInfo.MaxContainerNameLength=256",
 		"RamSwiftInfo.MaxObjectNameLength=256",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
 		"Peer:Peer0.PrivateIPAddr=localhost",
 		"Peer:Peer0.ReadCacheQuotaFraction=0.20",
 		"Cluster.Peers=Peer0",

--- a/logger/api.go
+++ b/logger/api.go
@@ -208,18 +208,18 @@ const DbgTesting string = "debug_test"
 
 var packageDebugSettings = map[string][]string{
 	"ldlm": []string{
-		//DbgInternal,
-		//DbgTesting,
+	//DbgInternal,
+	//DbgTesting,
 	},
 	"fs": []string{
-		//DbgInternal,
+	//DbgInternal,
 	},
 	"jrpcfs": []string{
-		//DbgInternal,
-		//DbgTesting,
+	//DbgInternal,
+	//DbgTesting,
 	},
 	"inode": []string{
-		//DbgInodeInternal,
+	//DbgInodeInternal,
 	},
 }
 

--- a/pfs-crash/b_tree_load.sh
+++ b/pfs-crash/b_tree_load.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-for i in `seq 100`;do
-  echo "Iteration $i"
-  for j in `seq 10`;do
-    for k in `seq 100`;do
-      echo "Hi" >> CommonMountPoint/f_$k
+while true
+do
+    for j in `seq 10`
+    do
+        for k in `seq 100`
+        do
+            echo "Hi" >> $1/f_$k
+        done
     done
-  done
-    for k in `seq 100`;do
-      rm CommonMountPoint/f_$k
+    for k in `seq 100`
+    do
+        rm $1/f_$k
     done
 done

--- a/proxyfsd/daemon_test.go
+++ b/proxyfsd/daemon_test.go
@@ -143,6 +143,8 @@ func TestDaemon(t *testing.T) {
 		"RamSwiftInfo.MaxAccountNameLength=256",
 		"RamSwiftInfo.MaxContainerNameLength=256",
 		"RamSwiftInfo.MaxObjectNameLength=1024",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
 	}
 
 	testVersionConfFile, err = ioutil.TempFile(os.TempDir(), "proxyfsdTest_")

--- a/ramswift/swift_info.conf
+++ b/ramswift/swift_info.conf
@@ -13,6 +13,8 @@
 #   }
 
 [RamSwiftInfo]
-MaxAccountNameLength:    256
-MaxContainerNameLength:  256
-MaxObjectNameLength:    1024
+MaxAccountNameLength:     256
+MaxContainerNameLength:   256
+MaxObjectNameLength:     1024
+AccountListingLimit:    10000
+ContainerListingLimit:  10000

--- a/statslogger/config_test.go
+++ b/statslogger/config_test.go
@@ -72,6 +72,8 @@ func TestAPI(t *testing.T) {
 		"RamSwiftInfo.MaxAccountNameLength=256",
 		"RamSwiftInfo.MaxContainerNameLength=256",
 		"RamSwiftInfo.MaxObjectNameLength=1024",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
 	}
 
 	confMap, err := conf.MakeConfMapFromStrings(confStrings)

--- a/swiftclient/api_test.go
+++ b/swiftclient/api_test.go
@@ -62,6 +62,8 @@ func TestAPI(t *testing.T) {
 		"RamSwiftInfo.MaxAccountNameLength=256",
 		"RamSwiftInfo.MaxContainerNameLength=256",
 		"RamSwiftInfo.MaxObjectNameLength=1024",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
 
 		"RamSwiftChaos.AccountDeleteFailureRate=2",
 		"RamSwiftChaos.AccountGetFailureRate=2",

--- a/swiftclient/utils_test.go
+++ b/swiftclient/utils_test.go
@@ -1,0 +1,129 @@
+package swiftclient
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUtils(t *testing.T) {
+	masterHeaders := make(map[string][]string)
+	masterList := make([]string, 0)
+
+	toAddHeaders1 := make(map[string][]string)
+	toAddList1 := make([]string, 0)
+
+	toAddHeaders2 := make(map[string][]string)
+	toAddList2 := make([]string, 0)
+
+	toAddHeaders3 := make(map[string][]string)
+	toAddList3 := make([]string, 0)
+
+	toAddHeaders1["Content-Length"] = []string{"4"}
+	toAddHeaders1["Dummy-Header-W"] = []string{"W"}
+	toAddHeaders1["Dummy-Header-X"] = []string{"XA"}
+	toAddHeaders1["Dummy-Header-Z"] = []string{}
+	toAddList1 = []string{"A", "B"}
+
+	toAddHeaders2["Content-Length"] = []string{"6"}
+	toAddHeaders2["Dummy-Header-W"] = []string{"W"}
+	toAddHeaders2["Dummy-Header-X"] = []string{"XB", "XC"}
+	toAddHeaders2["Dummy-Header-Y"] = []string{"Y"}
+	toAddList2 = []string{"C", "D", "E"}
+
+	toAddHeaders3["Content-Length"] = []string{"8"}
+	toAddHeaders3["Dummy-Header-W"] = []string{"W"}
+	toAddHeaders3["Dummy-Header-Z"] = []string{"ZA", "ZB"}
+	toAddList3 = []string{}
+
+	mergeHeadersAndList(masterHeaders, &masterList, toAddHeaders1, &toAddList1)
+	mergeHeadersAndList(masterHeaders, &masterList, toAddHeaders2, &toAddList2)
+	mergeHeadersAndList(masterHeaders, &masterList, toAddHeaders3, &toAddList3)
+
+	if 5 != len(masterHeaders) {
+		t.Fatalf("masterHeaders had unexpected len (%v)", len(masterHeaders))
+	}
+
+	masterContentLength, ok := masterHeaders["Content-Length"]
+	if !ok {
+		t.Fatalf("masterHeaders[\"Content-Length\"] returned !ok")
+	}
+	if 1 != len(masterContentLength) {
+		t.Fatalf("masterHeaders[\"Content-Length\"] had unexpected len (%v)", len(masterContentLength))
+	}
+	if "18" != masterContentLength[0] {
+		t.Fatalf("masterHeaders[\"Content-Length\"] returned unexpected value ([\"%v\"])", masterContentLength[0])
+	}
+
+	masterDummyHeaderW, ok := masterHeaders["Dummy-Header-W"]
+	if !ok {
+		t.Fatalf("masterHeaders[\"Dummy-Header-W\"] returned !ok")
+	}
+	if 1 != len(masterDummyHeaderW) {
+		fmt.Println(masterDummyHeaderW)
+		t.Fatalf("masterHeaders[\"Dummy-Header-W\"] had unexpected len (%v)", len(masterDummyHeaderW))
+	}
+	if "W" != masterDummyHeaderW[0] {
+		t.Fatalf("masterHeaders[\"Dummy-Header-W\"] had unexpected value ([\"%v\"])", masterDummyHeaderW[0])
+	}
+
+	masterDummyHeaderX, ok := masterHeaders["Dummy-Header-X"]
+	if !ok {
+		t.Fatalf("masterHeaders[\"Dummy-Header-X\"] returned !ok")
+	}
+	if 3 != len(masterDummyHeaderX) {
+		t.Fatalf("masterHeaders[\"Dummy-Header-X\"] had unexpected len (%v)", len(masterDummyHeaderX))
+	}
+	if "XA" != masterDummyHeaderX[0] {
+		t.Fatalf("masterHeaders[\"Dummy-Header-X\"][0] had unexpected value (\"%v\")", masterDummyHeaderX[0])
+	}
+	if "XB" != masterDummyHeaderX[1] {
+		t.Fatalf("masterHeaders[\"Dummy-Header-X\"][1] had unexpected value (\"%v\")", masterDummyHeaderX[1])
+	}
+	if "XC" != masterDummyHeaderX[2] {
+		t.Fatalf("masterHeaders[\"Dummy-Header-X\"][2] had unexpected value (\"%v\")", masterDummyHeaderX[2])
+	}
+
+	masterDummyHeaderY, ok := masterHeaders["Dummy-Header-Y"]
+	if !ok {
+		t.Fatalf("masterHeaders[\"Dummy-Header-Y\"] returned !ok")
+	}
+	if 1 != len(masterDummyHeaderY) {
+		t.Fatalf("masterHeaders[\"Dummy-Header-Y\"] had unexpected len (%v)", len(masterDummyHeaderY))
+	}
+	if "Y" != masterDummyHeaderY[0] {
+		t.Fatalf("masterHeaders[\"Dummy-Header-Y\"] had unexpected value ([\"%v\"])", masterDummyHeaderY[0])
+	}
+
+	masterDummyHeaderZ, ok := masterHeaders["Dummy-Header-Z"]
+	if !ok {
+		t.Fatalf("masterHeaders[\"Dummy-Header-Z\"] returned !ok")
+	}
+	if 2 != len(masterDummyHeaderZ) {
+		t.Fatalf("masterHeaders[\"Dummy-Header-Z\"] had unexpected len (%v)", len(masterDummyHeaderZ))
+	}
+	if "ZA" != masterDummyHeaderZ[0] {
+		t.Fatalf("masterHeaders[\"Dummy-Header-Z\"][0] had unexpected value (\"%v\")", masterDummyHeaderZ[0])
+	}
+	if "ZB" != masterDummyHeaderZ[1] {
+		t.Fatalf("masterHeaders[\"Dummy-Header-Z\"][1] had unexpected value (\"%v\")", masterDummyHeaderZ[1])
+	}
+
+	if 5 != len(masterList) {
+		t.Fatalf("masterList had unexpected len (%v)", len(masterContentLength))
+	}
+	if "A" != masterList[0] {
+		t.Fatalf("masterList[0] had unexpected value (\"%v\")", masterList[0])
+	}
+	if "B" != masterList[1] {
+		t.Fatalf("masterList[1] had unexpected value (\"%v\")", masterList[1])
+	}
+	if "C" != masterList[2] {
+		t.Fatalf("masterList[2] had unexpected value (\"%v\")", masterList[2])
+	}
+	if "D" != masterList[3] {
+		t.Fatalf("masterList[3] had unexpected value (\"%v\")", masterList[3])
+	}
+	if "E" != masterList[4] {
+		t.Fatalf("masterList[4] had unexpected value (\"%v\")", masterList[4])
+	}
+}


### PR DESCRIPTION
SwiftClient now loops through the entire Account or Container assembling
the exhaustive list of Containers/Objects using the "?marker=" Query
String on GETs issued to Swift. As such, RamSwift was also updated to
support this Query String.

The Object Deletes in the Checkpoint Container are now
done in parallel (to the extent the non-chunked connection pool allows).

Fixed pfs-crash/b_tree_load.sh to follow the pattern
of other pfs-crash trafficScript's.