### PR TITLE
Added "SkipRetry" option for Object DELETEs in package swiftclient

### DIFF
--- a/fs/treewalk.go
+++ b/fs/treewalk.go
@@ -1102,7 +1102,7 @@ func (vVS *validateVolumeStruct) validateVolume() {
 		if uint64(0) == checkpointContainerObjectNumber {
 			vVS.validateVolumeLogInfo("Removing unreferenced checkpointContainerObject %v", checkpointContainerObjectName)
 			asyncDeleteWaitGroup.Add(1)
-			swiftclient.ObjectDeleteAsync(vVS.accountName, vVS.checkpointContainerName, checkpointContainerObjectName, nil, &asyncDeleteWaitGroup)
+			swiftclient.ObjectDeleteAsync(vVS.accountName, vVS.checkpointContainerName, checkpointContainerObjectName, swiftclient.SkipRetry, nil, &asyncDeleteWaitGroup)
 		}
 
 		if vVS.stopFlag {

--- a/headhunter/checkpoint.go
+++ b/headhunter/checkpoint.go
@@ -1286,6 +1286,7 @@ func (volume *volumeStruct) putCheckpoint() (err error) {
 				volume.accountName,
 				volume.checkpointContainerName,
 				utils.Uint64ToHexStr(objectNumber),
+				swiftclient.SkipRetry,
 				volume.fetchNextCheckPointDoneWaitGroupWhileLocked(),
 				nil)
 		}

--- a/inode/file.go
+++ b/inode/file.go
@@ -1012,6 +1012,6 @@ func (vS *volumeStruct) deleteLogSegmentAsync(logSegmentNumber uint64, checkpoin
 	if nil != err {
 		return
 	}
-	swiftclient.ObjectDeleteAsync(vS.accountName, containerName, objectName, checkpointDoneWaitGroup, nil)
+	swiftclient.ObjectDeleteAsync(vS.accountName, containerName, objectName, swiftclient.SkipRetry, checkpointDoneWaitGroup, nil)
 	return
 }

--- a/inode/validate_test.go
+++ b/inode/validate_test.go
@@ -120,7 +120,7 @@ func TestValidateFileExtents(t *testing.T) {
 
 	readPlanStep := readPlan[0]
 
-	deleteErr := swiftclient.ObjectDeleteSync(readPlanStep.AccountName, readPlanStep.ContainerName, readPlanStep.ObjectName)
+	deleteErr := swiftclient.ObjectDeleteSync(readPlanStep.AccountName, readPlanStep.ContainerName, readPlanStep.ObjectName, 0)
 	if nil != deleteErr {
 		t.Fatalf("HTTP DELETE %v should have worked... failed: %v", readPlanStep.ObjectPath, deleteErr)
 	}

--- a/mkproxyfs/api.go
+++ b/mkproxyfs/api.go
@@ -160,7 +160,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 
 					for !isEmpty {
 						for _, objectName = range objectList {
-							err = swiftclient.ObjectDeleteSync(accountName, containerName, objectName)
+							err = swiftclient.ObjectDeleteSync(accountName, containerName, objectName, 0)
 							if nil != err {
 								err = fmt.Errorf("failed to DELETE %v/%v/%v: %v", accountName, containerName, objectName, err)
 								return

--- a/pfsworkout/main.go
+++ b/pfsworkout/main.go
@@ -1248,9 +1248,9 @@ func deleteObject(objectPath string) (err error) {
 		return
 	}
 
-	err = swiftclient.ObjectDeleteSync(accountName, containerName, objectName)
+	err = swiftclient.ObjectDeleteSync(accountName, containerName, objectName, swiftclient.SkipRetry)
 	if nil != err {
-		stepErrChan <- fmt.Errorf("swiftclient.ObjectDeleteSync(\"%v\", \"%v\", \"%v\") failed: %v\n", accountName, containerName, objectName, err)
+		stepErrChan <- fmt.Errorf("swiftclient.ObjectDeleteSync(\"%v\", \"%v\", \"%v\", swiftclient.SkipRetry) failed: %v\n", accountName, containerName, objectName, err)
 		return
 	}
 	return

--- a/statslogger/config_test.go
+++ b/statslogger/config_test.go
@@ -721,9 +721,9 @@ func testOps(t *testing.T) {
 
 	// Send a Synchronous DELETE for object "FooBar"
 
-	err = swiftclient.ObjectDeleteSync("TestAccount", "TestContainer", "FooBar")
+	err = swiftclient.ObjectDeleteSync("TestAccount", "TestContainer", "FooBar", 0)
 	if nil != err {
-		tErr := fmt.Sprintf("ObjectDeleteSync(\"TestAccount\", \"TestContainer\". \"FooBar\") failed: %v", err)
+		tErr := fmt.Sprintf("ObjectDeleteSync(\"TestAccount\", \"TestContainer\". \"FooBar\", 0) failed: %v", err)
 		t.Fatalf(tErr)
 	}
 
@@ -753,7 +753,7 @@ func testOps(t *testing.T) {
 	wgPreCondition.Add(1)
 	wgPostSignal.Add(1)
 
-	swiftclient.ObjectDeleteAsync("TestAccount", "TestContainer", "FooBarCopy", wgPreCondition, wgPostSignal)
+	swiftclient.ObjectDeleteAsync("TestAccount", "TestContainer", "FooBarCopy", 0, wgPreCondition, wgPostSignal)
 
 	wgPreCondition.Done()
 	wgPostSignal.Wait()
@@ -882,7 +882,7 @@ func testChunkedPut(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		objName = fmt.Sprintf(objNameFmt, i)
 
-		err = swiftclient.ObjectDeleteSync(accountName, containerName, objName)
+		err = swiftclient.ObjectDeleteSync(accountName, containerName, objName, 0)
 		if nil != err {
 			tErr := fmt.Sprintf("ObjectDelete('%s', '%s', '%s') failed: %v",
 				accountName, containerName, objName, err)

--- a/swiftclient/api.go
+++ b/swiftclient/api.go
@@ -5,6 +5,12 @@ import (
 	"sync"
 )
 
+type OperationOptions uint64
+
+const (
+	SkipRetry OperationOptions = 1 << iota
+)
+
 // ChunkedCopyContext provides a callback context to use for Object Copies.
 //
 // A returned chunkSize == 0 says to stop copying
@@ -105,13 +111,13 @@ func ObjectCopy(srcAccountName string, srcContainerName string, srcObjectName st
 //
 // If wgPreCondition is not nil, the HTTP DELETE will proceed only after wgPreCondition.Done() returns.
 // If wgPostSignal is not nil, following the HTTP DELETE, wgPostSignal.Done() will be called.
-func ObjectDeleteAsync(accountName string, containerName string, objectName string, wgPreCondition *sync.WaitGroup, wgPostSignal *sync.WaitGroup) {
-	objectDeleteAsync(accountName, containerName, objectName, wgPreCondition, wgPostSignal)
+func ObjectDeleteAsync(accountName string, containerName string, objectName string, operationOptions OperationOptions, wgPreCondition *sync.WaitGroup, wgPostSignal *sync.WaitGroup) {
+	objectDeleteAsync(accountName, containerName, objectName, operationOptions, wgPreCondition, wgPostSignal)
 }
 
 // ObjectDeleteSync synchronously invokes HTTP DELETE on the named Swift Object.
-func ObjectDeleteSync(accountName string, containerName string, objectName string) (err error) {
-	return objectDeleteSyncWithRetry(accountName, containerName, objectName)
+func ObjectDeleteSync(accountName string, containerName string, objectName string, operationOptions OperationOptions) (err error) {
+	return objectDeleteSync(accountName, containerName, objectName, operationOptions)
 }
 
 // ObjectFetchChunkedPutContext provisions a context to use for an HTTP PUT using "chunked" Transfer-Encoding on the named Swift Object.

--- a/swiftclient/api_test.go
+++ b/swiftclient/api_test.go
@@ -717,9 +717,9 @@ func testOps(t *testing.T) {
 
 	// Send a Synchronous DELETE for object "FooBar"
 
-	err = ObjectDeleteSync("TestAccount", "TestContainer", "FooBar")
+	err = ObjectDeleteSync("TestAccount", "TestContainer", "FooBar", 0)
 	if nil != err {
-		tErr := fmt.Sprintf("ObjectDeleteSync(\"TestAccount\", \"TestContainer\". \"FooBar\") failed: %v", err)
+		tErr := fmt.Sprintf("ObjectDeleteSync(\"TestAccount\", \"TestContainer\". \"FooBar\", 0) failed: %v", err)
 		t.Fatalf(tErr)
 	}
 
@@ -749,7 +749,7 @@ func testOps(t *testing.T) {
 	wgPreCondition.Add(1)
 	wgPostSignal.Add(1)
 
-	ObjectDeleteAsync("TestAccount", "TestContainer", "FooBarCopy", wgPreCondition, wgPostSignal)
+	ObjectDeleteAsync("TestAccount", "TestContainer", "FooBarCopy", 0, wgPreCondition, wgPostSignal)
 
 	wgPreCondition.Done()
 	wgPostSignal.Wait()
@@ -900,7 +900,7 @@ func testChunkedPut(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		objName = fmt.Sprintf(objNameFmt, i)
 
-		err = ObjectDeleteSync(accountName, containerName, objName)
+		err = ObjectDeleteSync(accountName, containerName, objName, 0)
 		if nil != err {
 			tErr := fmt.Sprintf("ObjectDelete('%s', '%s', '%s') failed: %v",
 				accountName, containerName, objName, err)

--- a/swiftclient/config.go
+++ b/swiftclient/config.go
@@ -35,12 +35,13 @@ type connectionPoolStruct struct {
 }
 
 type pendingDeleteStruct struct {
-	next           *pendingDeleteStruct
-	accountName    string
-	containerName  string
-	objectName     string
-	wgPreCondition *sync.WaitGroup
-	wgPostSignal   *sync.WaitGroup
+	next             *pendingDeleteStruct
+	accountName      string
+	containerName    string
+	objectName       string
+	operationOptions OperationOptions
+	wgPreCondition   *sync.WaitGroup
+	wgPostSignal     *sync.WaitGroup
 }
 
 type pendingDeletesStruct struct {


### PR DESCRIPTION
In particular, now that we have a garbage collection step in FSCK
(admittedly, not yet fulfilling this promise for File Inode LogSegment
objects), we can move to no-retry on object DELETEs thus significantly
speeding up that very FSCK operation that may find a need to DELETE
objects that are already deleted. Should the lack of retry end up
missing a DELETE on an existing object, the subsequent FSCK would
catch it and retry then.