### PR TITLE
Upgrade of dev tool use of Go 1.10 (from 1.8.3)

### DIFF
--- a/ci/ansible/tasks/installer_without_chef.yml
+++ b/ci/ansible/tasks/installer_without_chef.yml
@@ -3,9 +3,9 @@
 - hosts: all
   name: Install and start ProxyFS
   vars:
-    tarfile_name: "go1.8.3.linux-amd64.tar.gz"
+    tarfile_name: "go1.10.linux-amd64.tar.gz"
     tarfile_path: "/tmp/{{ tarfile_name }}"
-    tarfile_url: "https://storage.googleapis.com/golang/{{ tarfile_name }}"
+    tarfile_url: "https://dl.google.com/go/{{ tarfile_name }}"
     source_root: "/home/swiftstack/provisioning"
     proxyfs_user: "swiftstack"
     proxyfs_group: "swiftstack"

--- a/cookbooks/proxyfs/recipes/default.rb
+++ b/cookbooks/proxyfs/recipes/default.rb
@@ -1,7 +1,7 @@
-tarfile_name = 'go1.8.3.linux-amd64.tar.gz'
+tarfile_name = 'go1.10.linux-amd64.tar.gz'
 
 tarfile_path = "/tmp/#{tarfile_name}"
-tarfile_url  = "https://storage.googleapis.com/golang/#{tarfile_name}"
+tarfile_url  = "https://dl.google.com/go/#{tarfile_name}"
 
 source_root = node['source_root']
 proxyfs_user = node['proxyfs_user']

--- a/logger/api.go
+++ b/logger/api.go
@@ -208,18 +208,18 @@ const DbgTesting string = "debug_test"
 
 var packageDebugSettings = map[string][]string{
 	"ldlm": []string{
-	//DbgInternal,
-	//DbgTesting,
+		//DbgInternal,
+		//DbgTesting,
 	},
 	"fs": []string{
-	//DbgInternal,
+		//DbgInternal,
 	},
 	"jrpcfs": []string{
-	//DbgInternal,
-	//DbgTesting,
+		//DbgInternal,
+		//DbgTesting,
 	},
 	"inode": []string{
-	//DbgInodeInternal,
+		//DbgInodeInternal,
 	},
 }
 

--- a/saio/vagrant_provision.sh
+++ b/saio/vagrant_provision.sh
@@ -13,9 +13,9 @@ yum -y install wget git nfs-utils vim
 
 yum -y --disableexcludes=all install gcc
 cd /tmp
-wget -q https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
-tar -C /usr/local -xf go1.8.3.linux-amd64.tar.gz
-rm go1.8.3.linux-amd64.tar.gz
+wget -q https://dl.google.com/go/go1.10.linux-amd64.tar.gz
+tar -C /usr/local -xf go1.10.linux-amd64.tar.gz
+rm go1.10.linux-amd64.tar.gz
 echo "export PATH=\$PATH:/usr/local/go/bin" >> ~vagrant/.bash_profile
 
 # Patch Golang's GDB runtime plug-in

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -56,9 +56,9 @@ RUN pip install requests tox
 
 # Install Golang
 RUN cd /tmp
-RUN wget -q https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
-RUN tar -C /usr/local -xf go1.8.3.linux-amd64.tar.gz
-RUN rm -rf go1.8.3.linux-amd64.tar.gz
+RUN wget -q https://dl.google.com/go/go1.10.linux-amd64.tar.gz
+RUN tar -C /usr/local -xf go1.10.linux-amd64.tar.gz
+RUN rm -rf go1.10.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Setup ProxyFS build environment


### PR DESCRIPTION
Curiously, golang.org/x/tools/cmd/getgo has been vendorized... and it
actually makes a reference to Go 1.8.3. More curiously, the glide.lock
file doesn't reference the vendorized code. Could be that it's garbage
left over from a previous state of `glide up`.