### PR TITLE
Pickup fixes in sortedmap 1.4.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b6ba0bfb563ee21e2874a5cf5b0b3c5da5d0bb1a0f3fb20c4ad23f0ba40e4d22
-updated: 2018-03-09T23:48:40.244827-08:00
+hash: a1d2db2a3bf34d213fce5b49f3e17d0fd49deccb0a0ebe98180a77bf0a9b5b90
+updated: 2018-03-29T09:41:59.823181-07:00
 imports:
 - name: bazil.org/fuse
   version: 371fbbdaa8987b715bdd21d6adc4c9b20155f748
@@ -23,7 +23,7 @@ imports:
 - name: github.com/swiftstack/cstruct
   version: 5f7d9b06c7662151d3a3c20cecf0ed5eaae3582f
 - name: github.com/swiftstack/sortedmap
-  version: 9923ec9d6f562e4868442632e024314110ed54ae
+  version: 991296d0552b4a762914a57089701b3ed5704f34
 - name: golang.org/x/crypto
   version: bd6f299fb381e4c3393d1c4b1f0b94f5e77650c8
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/swiftstack/cstruct
   version: 1.1.0
 - package: github.com/swiftstack/sortedmap
-  version: 1.3.0
+  version: 1.4.0
 - package: bazil.org/fuse
   version: 371fbbdaa8987b715bdd21d6adc4c9b20155f748
   subpackages:

--- a/vendor/github.com/swiftstack/sortedmap/btree_api.go
+++ b/vendor/github.com/swiftstack/sortedmap/btree_api.go
@@ -57,13 +57,19 @@ func NewBPlusTreeCache(evictLowLimit uint64, evictHighLimit uint64) (bPlusTreeCa
 
 // NewBPlusTree is used to construct an in-memory B+Tree supporting the Tree interface
 //
+// The supplied value of maxKeysPerNode, being precisely twice the computed value of
+// (uint64) minKeysPerNode, must be even. In addition, minKeysPerNode must be computed
+// to be greater than one to ensure that during node merge operations, there is always
+// at least one sibling node with which to merge. Hence, maxKeysPerNode must also be
+// at least four.
+//
 // Note that if the B+Tree will reside only in memory, callback argument may be nil.
 // That said, there is no advantage to using a B+Tree for an in-memory collection over
 // the llrb-provided collection implementing the same APIs.
 func NewBPlusTree(maxKeysPerNode uint64, compare Compare, callbacks BPlusTreeCallbacks, bPlusTreeCache BPlusTreeCache) (tree BPlusTree) {
 	minKeysPerNode := maxKeysPerNode >> 1
-	if (0 == maxKeysPerNode) != ((2 * minKeysPerNode) != maxKeysPerNode) {
-		err := fmt.Errorf("maxKeysPerNode (%v) invalid - must be a positive number that is a multiple of 2", maxKeysPerNode)
+	if (4 > maxKeysPerNode) || ((2 * minKeysPerNode) != maxKeysPerNode) {
+		err := fmt.Errorf("maxKeysPerNode (%v) invalid - must be an even positive number greater than 3", maxKeysPerNode)
 		panic(err)
 	}
 

--- a/vendor/github.com/swiftstack/sortedmap/btree_cache_test.go
+++ b/vendor/github.com/swiftstack/sortedmap/btree_cache_test.go
@@ -1,0 +1,310 @@
+package sortedmap
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	testBPlusTreeCacheDelay = 100 * time.Millisecond
+)
+
+type testBPlusTreeStruct struct {
+	sync.Mutex
+	nextObjectNumber uint64
+	objectMap        map[uint64][]byte
+}
+
+func (tree *testBPlusTreeStruct) DumpKey(key Key) (keyAsString string, err error) {
+	var (
+		ok          bool
+		keyAsUint16 uint16
+	)
+
+	keyAsUint16, ok = key.(uint16)
+	if !ok {
+		err = fmt.Errorf("DumpKey() expected key of type uint16... instead it was of type %v", reflect.TypeOf(key))
+		return
+	}
+
+	keyAsString = fmt.Sprintf("0x%04X", keyAsUint16)
+
+	err = nil
+	return
+}
+
+func (tree *testBPlusTreeStruct) DumpValue(value Value) (valueAsString string, err error) {
+	var (
+		ok            bool
+		valueAsUint32 uint32
+	)
+
+	valueAsUint32, ok = value.(uint32)
+	if !ok {
+		err = fmt.Errorf("DumpValue() expected value of type uint32... instead it was of type %v", reflect.TypeOf(value))
+		return
+	}
+
+	valueAsString = fmt.Sprintf("0x%08X", valueAsUint32)
+
+	err = nil
+	return
+}
+
+func (tree *testBPlusTreeStruct) GetNode(objectNumber uint64, objectOffset uint64, objectLength uint64) (nodeByteSlice []byte, err error) {
+	var (
+		ok bool
+	)
+
+	tree.Lock()
+	defer tree.Unlock()
+
+	nodeByteSlice, ok = tree.objectMap[objectNumber]
+	if !ok {
+		err = fmt.Errorf("GetNode() called for non-existent objectNumber 0x%016X", objectNumber)
+		return
+	}
+	if uint64(0) != objectOffset {
+		err = fmt.Errorf("GetNode() called for non-zero objectOffset 0x%016X", objectOffset)
+		return
+	}
+	if uint64(len(nodeByteSlice)) != objectLength {
+		err = fmt.Errorf("GetNode() called for objectLength 0x%016X... for node of length 0x%016X", objectLength, uint64(len(nodeByteSlice)))
+		return
+	}
+
+	err = nil
+	return
+}
+
+func (tree *testBPlusTreeStruct) PutNode(nodeByteSlice []byte) (objectNumber uint64, objectOffset uint64, err error) {
+	tree.Lock()
+	defer tree.Unlock()
+
+	objectNumber = tree.nextObjectNumber
+	tree.nextObjectNumber++
+	tree.objectMap[objectNumber] = nodeByteSlice
+
+	objectOffset = 0
+
+	err = nil
+	return
+}
+
+func (tree *testBPlusTreeStruct) DiscardNode(objectNumber uint64, objectOffset uint64, objectLength uint64) (err error) {
+	var (
+		ok            bool
+		nodeByteSlice []byte
+	)
+
+	tree.Lock()
+	defer tree.Unlock()
+
+	nodeByteSlice, ok = tree.objectMap[objectNumber]
+	if !ok {
+		err = fmt.Errorf("DiscardNode() called for non-existent objectNumber 0x%016X", objectNumber)
+		return
+	}
+	if uint64(0) != objectOffset {
+		err = fmt.Errorf("DiscardNode() called for non-zero objectOffset 0x%016X", objectOffset)
+		return
+	}
+	if uint64(len(nodeByteSlice)) != objectLength {
+		err = fmt.Errorf("DiscardNode() called for objectLength 0x%016X... for node of length 0x%016X", objectLength, uint64(len(nodeByteSlice)))
+		return
+	}
+
+	err = nil
+	return
+}
+
+func (tree *testBPlusTreeStruct) PackKey(key Key) (packedKey []byte, err error) {
+	var (
+		ok          bool
+		keyAsUint16 uint16
+	)
+
+	keyAsUint16, ok = key.(uint16)
+	if !ok {
+		err = fmt.Errorf("PackKey() expected key of type uint16... instead it was of type %v", reflect.TypeOf(key))
+		return
+	}
+
+	packedKey = make([]byte, 2)
+	packedKey[0] = uint8(keyAsUint16 & uint16(0x00FF) >> 0)
+	packedKey[1] = uint8(keyAsUint16 & uint16(0xFF00) >> 8)
+
+	err = nil
+	return
+}
+
+func (tree *testBPlusTreeStruct) UnpackKey(payloadData []byte) (key Key, bytesConsumed uint64, err error) {
+	if len(payloadData) < 2 {
+		err = fmt.Errorf("UnpackKey() called for length %v... expected length of at least 2", len(payloadData))
+		return
+	}
+
+	key = uint16(payloadData[0]) | (uint16(payloadData[1]) << 8)
+
+	bytesConsumed = 2
+
+	err = nil
+	return
+}
+
+func (tree *testBPlusTreeStruct) PackValue(value Value) (packedValue []byte, err error) {
+	var (
+		ok            bool
+		valueAsUint32 uint32
+	)
+
+	valueAsUint32, ok = value.(uint32)
+	if !ok {
+		err = fmt.Errorf("PackValue() expected value of type uint32... instead it was of type %v", reflect.TypeOf(value))
+		return
+	}
+
+	packedValue = make([]byte, 4)
+	packedValue[0] = uint8(valueAsUint32 & uint32(0x000000FF) >> 0)
+	packedValue[1] = uint8(valueAsUint32 & uint32(0x0000FF00) >> 8)
+	packedValue[2] = uint8(valueAsUint32 & uint32(0x00FF0000) >> 16)
+	packedValue[3] = uint8(valueAsUint32 & uint32(0xFF000000) >> 24)
+
+	err = nil
+	return
+}
+
+func (tree *testBPlusTreeStruct) UnpackValue(payloadData []byte) (value Value, bytesConsumed uint64, err error) {
+	if len(payloadData) < 4 {
+		err = fmt.Errorf("UnpackValue() called for length %v... expected length of at least 4", len(payloadData))
+		return
+	}
+
+	value = uint32(payloadData[0]) | (uint32(payloadData[1]) << 8) | (uint32(payloadData[2]) << 16) | (uint32(payloadData[3]) << 24)
+
+	bytesConsumed = 4
+
+	err = nil
+	return
+}
+
+func TestBPlusTreeCache(t *testing.T) {
+	var (
+		treeA           BPlusTree // map[uint16]uint32
+		treeB           BPlusTree // map[uint16]uint32
+		treeCache       BPlusTreeCache
+		treeCacheStruct *btreeNodeCacheStruct
+		treeStruct      *testBPlusTreeStruct
+	)
+
+	treeStruct = &testBPlusTreeStruct{
+		nextObjectNumber: uint64(0),
+		objectMap:        make(map[uint64][]byte),
+	}
+
+	treeCache = NewBPlusTreeCache(1, 4)
+	treeCacheStruct = treeCache.(*btreeNodeCacheStruct)
+
+	// Consume 1 node for treeA
+
+	treeA = NewBPlusTree(4, CompareUint16, treeStruct, treeCache)
+
+	_, _ = treeA.Put(uint16(0x0000), uint32(0x00000000))
+
+	if 0 != treeCacheStruct.cleanLRUItems {
+		t.Fatalf("Expected treeCacheStruct.cleanLRUItems to be 0 (was %v)", treeCacheStruct.cleanLRUItems)
+	}
+	if 1 != treeCacheStruct.dirtyLRUItems {
+		t.Fatalf("Expected treeCacheStruct.dirtyLRUItems to be 1 (was %v)", treeCacheStruct.dirtyLRUItems)
+	}
+
+	treeA.Flush(false)
+
+	if 1 != treeCacheStruct.cleanLRUItems {
+		t.Fatalf("Expected treeCacheStruct.cleanLRUItems to be 1 (was %v)", treeCacheStruct.cleanLRUItems)
+	}
+	if 0 != treeCacheStruct.dirtyLRUItems {
+		t.Fatalf("Expected treeCacheStruct.dirtyLRUItems to be 0 (was %v)", treeCacheStruct.dirtyLRUItems)
+	}
+
+	treeA.Flush(true)
+
+	if 0 != treeCacheStruct.cleanLRUItems {
+		t.Fatalf("Expected treeCacheStruct.cleanLRUItems to be 0 (was %v)", treeCacheStruct.cleanLRUItems)
+	}
+	if 0 != treeCacheStruct.dirtyLRUItems {
+		t.Fatalf("Expected treeCacheStruct.dirtyLRUItems to be 0 (was %v)", treeCacheStruct.dirtyLRUItems)
+	}
+
+	// Consume 4 nodes for treeB
+
+	treeB = NewBPlusTree(4, CompareUint16, treeStruct, treeCache)
+
+	_, _ = treeB.Put(uint16(0x0000), uint32(0x00000000))
+	_, _ = treeB.Put(uint16(0x0001), uint32(0x00000001))
+	_, _ = treeB.Put(uint16(0x0002), uint32(0x00000002))
+	_, _ = treeB.Put(uint16(0x0003), uint32(0x00000003))
+	_, _ = treeB.Put(uint16(0x0004), uint32(0x00000004))
+	_, _ = treeB.Put(uint16(0x0005), uint32(0x00000005))
+	_, _ = treeB.Put(uint16(0x0006), uint32(0x00000006))
+
+	if 0 != treeCacheStruct.cleanLRUItems {
+		t.Fatalf("Expected treeCacheStruct.cleanLRUItems to be 0 (was %v)", treeCacheStruct.cleanLRUItems)
+	}
+	if 4 != treeCacheStruct.dirtyLRUItems {
+		t.Fatalf("Expected treeCacheStruct.dirtyLRUItems to be 4 (was %v)", treeCacheStruct.dirtyLRUItems)
+	}
+
+	treeB.Flush(false)
+
+	if 4 != treeCacheStruct.cleanLRUItems {
+		t.Fatalf("Expected treeCacheStruct.cleanLRUItems to be 4 (was %v)", treeCacheStruct.cleanLRUItems)
+	}
+	if 0 != treeCacheStruct.dirtyLRUItems {
+		t.Fatalf("Expected treeCacheStruct.dirtyLRUItems to be 0 (was %v)", treeCacheStruct.dirtyLRUItems)
+	}
+
+	treeB.Flush(true)
+
+	if 0 != treeCacheStruct.cleanLRUItems {
+		t.Fatalf("Expected treeCacheStruct.cleanLRUItems to be 0 (was %v)", treeCacheStruct.cleanLRUItems)
+	}
+	if 0 != treeCacheStruct.dirtyLRUItems {
+		t.Fatalf("Expected treeCacheStruct.dirtyLRUItems to be 0 (was %v)", treeCacheStruct.dirtyLRUItems)
+	}
+
+	// Read entire treeB filling all 4 treeCacheStruct.cleanLRUItems
+
+	_, _, _ = treeB.GetByKey(uint16(0x0000))
+	_, _, _ = treeB.GetByKey(uint16(0x0001))
+	_, _, _ = treeB.GetByKey(uint16(0x0002))
+	_, _, _ = treeB.GetByKey(uint16(0x0003))
+	_, _, _ = treeB.GetByKey(uint16(0x0004))
+	_, _, _ = treeB.GetByKey(uint16(0x0005))
+	_, _, _ = treeB.GetByKey(uint16(0x0006))
+
+	if 4 != treeCacheStruct.cleanLRUItems {
+		t.Fatalf("Expected treeCacheStruct.cleanLRUItems to be 4 (was %v)", treeCacheStruct.cleanLRUItems)
+	}
+	if 0 != treeCacheStruct.dirtyLRUItems {
+		t.Fatalf("Expected treeCacheStruct.dirtyLRUItems to be 0 (was %v)", treeCacheStruct.dirtyLRUItems)
+	}
+
+	// Read lone key from treeA expecting treeCache to have to purge down to evictLowLimit
+
+	_, _, _ = treeA.GetByKey(uint16(0x0000))
+
+	for treeCacheStruct.drainerActive {
+		time.Sleep(testBPlusTreeCacheDelay)
+	}
+
+	if 1 != treeCacheStruct.cleanLRUItems {
+		t.Fatalf("Expected treeCacheStruct.cleanLRUItems to be 1 (was %v)", treeCacheStruct.cleanLRUItems)
+	}
+	if 0 != treeCacheStruct.dirtyLRUItems {
+		t.Fatalf("Expected treeCacheStruct.dirtyLRUItems to be 0 (was %v)", treeCacheStruct.dirtyLRUItems)
+	}
+}

--- a/vendor/github.com/swiftstack/sortedmap/btree_common_api_test.go
+++ b/vendor/github.com/swiftstack/sortedmap/btree_common_api_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	commonBPlusTreeTestNumKeysMaxSmall   = uint64(2)
+	commonBPlusTreeTestNumKeysMaxSmall   = uint64(4)
 	commonBPlusTreeTestNumKeysMaxModest  = uint64(10)
 	commonBPlusTreeTestNumKeysMaxTypical = uint64(100)
 	commonBPlusTreeTestNumKeysMaxLarge   = uint64(1000)

--- a/vendor/github.com/swiftstack/sortedmap/btree_dump.go
+++ b/vendor/github.com/swiftstack/sortedmap/btree_dump.go
@@ -36,6 +36,8 @@ func (tree *btreeTreeStruct) Dump() (err error) {
 	}
 
 	fmt.Printf("B+Tree @ %p has Root Node @ %p\n", tree, tree.root)
+	fmt.Printf("  .minKeysPerNode      = %v\n", tree.minKeysPerNode)
+	fmt.Printf("  .maxKeysPerNode      = %v\n", tree.maxKeysPerNode)
 
 	err = tree.dumpNode(tree.root, "")
 

--- a/vendor/github.com/swiftstack/sortedmap/btree_specific_api_test.go
+++ b/vendor/github.com/swiftstack/sortedmap/btree_specific_api_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const specificBPlusTreeTestNumKeysMaxSmall = uint64(2)
+const specificBPlusTreeTestNumKeysMaxSmall = uint64(4)
 
 type logSegmentChunkStruct struct {
 	startingOffset uint64
@@ -375,36 +375,90 @@ func TestBPlusTreeSpecific(t *testing.T) {
 
 	err = btreeOld.Purge(false)
 	if nil != err {
-		t.Fatalf("btreeOld.Purge(false) should not have failed")
+		t.Fatalf("btreeOld.Purge(false) [case 1] should not have failed")
 	}
 
 	err = btreeOld.Purge(true)
 	if nil == err {
-		t.Fatalf("btreeOld.Purge(true) should have failed")
+		t.Fatalf("btreeOld.Purge(true) [case 1] should have failed")
+	}
+
+	valueAsValueStructToInsert = valueStruct{u32: 2, s8: uint32To8ReplicaByteArray(2)}
+	ok, err = btreeOld.Put(uint32(2), valueAsValueStructToInsert)
+	if nil != err {
+		t.Fatalf("btreeOld.Put(uint32(2) should not have failed")
+	}
+	if !ok {
+		t.Fatalf("btreeOld.Put(uint32(2), valueAsValueStructToInsert).ok should have been true")
+	}
+
+	valueAsValueStructToInsert = valueStruct{u32: 4, s8: uint32To8ReplicaByteArray(4)}
+	ok, err = btreeOld.Put(uint32(4), valueAsValueStructToInsert)
+	if nil != err {
+		t.Fatalf("btreeOld.Put(uint32(4) should not have failed")
+	}
+	if !ok {
+		t.Fatalf("btreeOld.Put(uint32(4), valueAsValueStructToInsert).ok should have been true")
+	}
+
+	valueAsValueStructToInsert = valueStruct{u32: 6, s8: uint32To8ReplicaByteArray(6)}
+	ok, err = btreeOld.Put(uint32(6), valueAsValueStructToInsert)
+	if nil != err {
+		t.Fatalf("btreeOld.Put(uint32(6) should not have failed")
+	}
+	if !ok {
+		t.Fatalf("btreeOld.Put(uint32(6), valueAsValueStructToInsert).ok should have been true")
+	}
+
+	valueAsValueStructToInsert = valueStruct{u32: 8, s8: uint32To8ReplicaByteArray(8)}
+	ok, err = btreeOld.Put(uint32(8), valueAsValueStructToInsert)
+	if nil != err {
+		t.Fatalf("btreeOld.Put(uint32(8) should not have failed")
+	}
+	if !ok {
+		t.Fatalf("btreeOld.Put(uint32(8), valueAsValueStructToInsert).ok should have been true")
+	}
+
+	err = btreeOld.Purge(false)
+	if nil != err {
+		t.Fatalf("btreeOld.Purge(false) [case 2] should not have failed")
+	}
+
+	err = btreeOld.Purge(true)
+	if nil == err {
+		t.Fatalf("btreeOld.Purge(true) [case 2] should have failed")
 	}
 
 	nextItemIndexToTouch, err := btreeOld.TouchItem(0)
 	if nil != err {
 		t.Fatalf("btreeOld.TouchItem(0) should not have failed")
 	}
-	if 1 != nextItemIndexToTouch {
-		t.Fatalf("btreeOld.TouchItem(0) should have returned 1")
+	if 2 != nextItemIndexToTouch {
+		t.Fatalf("btreeOld.TouchItem(0) should have returned 2")
 	}
 
-	nextItemIndexToTouch, err = btreeOld.TouchItem(1)
+	nextItemIndexToTouch, err = btreeOld.TouchItem(2)
 	if nil != err {
-		t.Fatalf("btreeOld.TouchItem(1) should not have failed")
+		t.Fatalf("btreeOld.TouchItem(2) should not have failed")
 	}
-	if 3 != nextItemIndexToTouch {
-		t.Fatalf("btreeOld.TouchItem(1) should have returned 3")
+	if 4 != nextItemIndexToTouch {
+		t.Fatalf("btreeOld.TouchItem(2) should have returned 4")
 	}
 
-	nextItemIndexToTouch, err = btreeOld.TouchItem(3)
+	nextItemIndexToTouch, err = btreeOld.TouchItem(4)
 	if nil != err {
-		t.Fatalf("btreeOld.TouchItem(3) should not have failed")
+		t.Fatalf("btreeOld.TouchItem(4) should not have failed")
 	}
-	if 1 != nextItemIndexToTouch {
-		t.Fatalf("btreeOld.TouchItem(3) should have returned 1")
+	if 7 != nextItemIndexToTouch {
+		t.Fatalf("btreeOld.TouchItem(4) should have returned 7")
+	}
+
+	nextItemIndexToTouch, err = btreeOld.TouchItem(7)
+	if nil != err {
+		t.Fatalf("btreeOld.TouchItem(7) should not have failed")
+	}
+	if 2 != nextItemIndexToTouch {
+		t.Fatalf("btreeOld.TouchItem(7) should have returned 2")
 	}
 
 	err = btreeOld.Discard()

--- a/vendor/github.com/swiftstack/sortedmap/common_api.go
+++ b/vendor/github.com/swiftstack/sortedmap/common_api.go
@@ -30,6 +30,31 @@ func CompareInt(key1 Key, key2 Key) (result int, err error) {
 	return
 }
 
+func CompareUint16(key1 Key, key2 Key) (result int, err error) {
+	key1Uint16, ok := key1.(uint16)
+	if !ok {
+		err = fmt.Errorf("CompareUint16(non-uint16,) not supported")
+		return
+	}
+	key2Uint16, ok := key2.(uint16)
+	if !ok {
+		err = fmt.Errorf("CompareUint16(uint16, non-uint16) not supported")
+		return
+	}
+
+	if key1Uint16 < key2Uint16 {
+		result = -1
+	} else if key1Uint16 == key2Uint16 {
+		result = 0
+	} else { // key1Uint16 > key2Uint16
+		result = 1
+	}
+
+	err = nil
+
+	return
+}
+
 func CompareUint32(key1 Key, key2 Key) (result int, err error) {
 	key1Uint32, ok := key1.(uint32)
 	if !ok {

--- a/vendor/github.com/swiftstack/sortedmap/compare_test.go
+++ b/vendor/github.com/swiftstack/sortedmap/compare_test.go
@@ -38,6 +38,36 @@ func TestCompareFunctions(t *testing.T) {
 		t.Fatalf("CompareInt(uint32(2),int(2)) should have failed")
 	}
 
+	result, err = CompareUint16(uint16(1), uint16(2))
+	if nil != err {
+		t.Fatalf("CompareUint16(uint16(1),uint16(2)) should not have failed")
+	}
+	if result >= 0 {
+		t.Fatalf("CompareUint16(uint32(1),uint32(2)) should have been < 0")
+	}
+	result, err = CompareUint16(uint16(2), uint16(2))
+	if nil != err {
+		t.Fatalf("CompareUint16(uint16(2),uint16(2)) should not have failed")
+	}
+	if result != 0 {
+		t.Fatalf("CompareUint16(uint16(2),uint16(2)) should have been == 0")
+	}
+	result, err = CompareUint16(uint16(3), uint16(2))
+	if nil != err {
+		t.Fatalf("CompareUint16(uint16(3),uint16(2)) should not have failed")
+	}
+	if result <= 0 {
+		t.Fatalf("CompareUint16(uint16(3),uint16(2)) should have been > 0")
+	}
+	_, err = CompareUint16(uint32(2), uint64(2))
+	if nil == err {
+		t.Fatalf("CompareUint16(uint16(2), uint32(2)) should have failed")
+	}
+	_, err = CompareUint16(uint64(2), uint32(2))
+	if nil == err {
+		t.Fatalf("CompareUint16(uint32(2), uint16(2)) should have failed")
+	}
+
 	result, err = CompareUint32(uint32(1), uint32(2))
 	if nil != err {
 		t.Fatalf("CompareUint32(uint32(1),uint32(2)) should not have failed")


### PR DESCRIPTION
1) B+Tree node splits now performed above leaf nodes
2) B+Tree merges now work after enabling non-leaf node splits
3) B+Tree Cache evict test case added