### PR TITLE
Fix a fsck bug, trap and print all signals, and log PID.

### DIFF
--- a/fs/treewalk.go
+++ b/fs/treewalk.go
@@ -288,7 +288,6 @@ func (jS *jobStruct) jobLogInfoWhileLocked(formatString string, args ...interfac
 func (vVS *validateVolumeStruct) validateVolumeInode(inodeNumber uint64) {
 	var (
 		err error
-		ok  bool
 	)
 
 	defer vVS.childrenWaitGroup.Done()
@@ -297,18 +296,24 @@ func (vVS *validateVolumeStruct) validateVolumeInode(inodeNumber uint64) {
 
 	err = vVS.inodeVolumeHandle.Validate(inode.InodeNumber(inodeNumber), false)
 	if nil != err {
-		vVS.Lock()
-		defer vVS.Unlock()
 		vVS.jobLogInfoWhileLocked("Got inode.Validate(0x%016X) failure: %v", inodeNumber, err)
-		ok, err = vVS.inodeBPTree.Put(inodeNumber, invalidLinkCount)
-		if nil != err {
-			vVS.jobLogErrWhileLocked("Got vVS.inodeBPTree.Put(0x%016X, invalidLinkCount) failure: %v", inodeNumber, err)
-			return
-		}
-		if !ok {
-			vVS.jobLogErrWhileLocked("Got vVS.inodeBPTree.Put(0x%016X, invalidLinkCount) !ok", inodeNumber)
-			return
-		}
+
+		// Ultimately we will to delete or fix corrupt inode, but only after
+		// fixing validation errors.
+		//
+		// vVS.Lock()
+		// defer vVS.Unlock()
+		//
+		// vVS.jobLogInfoWhileLocked("Got inode.Validate(0x%016X) failure: %v", inodeNumber, err)
+		// ok, err = vVS.inodeBPTree.Put(inodeNumber, invalidLinkCount)
+		// if nil != err {
+		// 	vVS.jobLogErrWhileLocked("Got vVS.inodeBPTree.Put(0x%016X, invalidLinkCount) failure: %v", inodeNumber, err)
+		// 	return
+		// }
+		// if !ok {
+		// 	vVS.jobLogErrWhileLocked("Got vVS.inodeBPTree.Put(0x%016X, invalidLinkCount) !ok", inodeNumber)
+		// 	return
+		// }
 	}
 }
 

--- a/logger/api.go
+++ b/logger/api.go
@@ -17,6 +17,7 @@ package logger
 import (
 	"fmt"
 	"io"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -281,6 +282,7 @@ const packageKey string = "package"
 const functionKey string = "function"
 const errorKey string = "error"
 const gidKey string = "goroutine"
+const pidKey string = "pid"
 
 var ssTransIDKey string = "ss_transid" // transaction ID for sock_swift stuff
 
@@ -331,11 +333,16 @@ func newFuncCtx(level int) (ctx *FuncCtx) {
 	// Extract package and function from the call stack
 	fn, pkg, gid := utils.GetFuncPackage(level + 1)
 
+	// Get PID as a string (since our PID only changes in fork(2) and
+	// clone(2) this could be optimized)
+	pid := fmt.Sprint(os.Getpid())
+
 	// Save fields
 	fields := make(log.Fields)
 	fields[functionKey] = fn
 	fields[packageKey] = pkg
 	fields[gidKey] = gid
+	fields[pidKey] = pid
 
 	ctx = &FuncCtx{funcContext: log.WithFields(fields)}
 	return ctx

--- a/logger/config.go
+++ b/logger/config.go
@@ -107,12 +107,18 @@ func up(confMap conf.ConfMap) (err error) {
 func down() (err error) {
 	// We open and close our own logfile
 	if logFile != nil {
+		// Sync() flushes data cached in the kernel to disk, which is
+		// really only useful if the OS were to crash soon
+		logFile.Sync()
 		logFile.Close()
 	}
 	logTargets.Clear()
 	return
 }
 
+// This is used by LogTarget, which is a logging target that is useful for
+// capturing the output logged by other packages for testing in test cases.
+//
 func (log LogTarget) write(p []byte) (n int, err error) {
 	for i := len(log.LogBuf.LogEntries) - 1; i > 0; i-- {
 		log.LogBuf.LogEntries[i] = log.LogBuf.LogEntries[i-1]

--- a/mkproxyfs/api.go
+++ b/mkproxyfs/api.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/swiftstack/ProxyFS/blunder"
 	"github.com/swiftstack/ProxyFS/conf"
@@ -24,7 +25,7 @@ const (
 	ModeReformat
 )
 
-func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings []string) (err error) {
+func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings []string, execArgs []string) (err error) {
 	var (
 		accountName       string
 		confMap           conf.ConfMap
@@ -84,6 +85,8 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 	defer func() {
 		_ = logger.Down()
 	}()
+	logger.Infof("mkproxyfs is starting up (PID %d); invoked as '%s'",
+		os.Getpid(), strings.Join(execArgs, "' '"))
 
 	err = evtlog.Up(confMap)
 	if nil != err {

--- a/mkproxyfs/mkproxyfs/main.go
+++ b/mkproxyfs/mkproxyfs/main.go
@@ -51,7 +51,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = mkproxyfs.Format(mode, os.Args[2], os.Args[3], os.Args[4:])
+	err = mkproxyfs.Format(mode, os.Args[2], os.Args[3], os.Args[4:], os.Args)
 	if nil == err {
 		os.Exit(0)
 	} else {

--- a/proxyfsd/daemon_test.go
+++ b/proxyfsd/daemon_test.go
@@ -240,7 +240,10 @@ func TestDaemon(t *testing.T) {
 	proxyfsdSignalHandlerIsArmed = false
 	errChan = make(chan error, 1) // Must be buffered to avoid race
 
-	go Daemon("/dev/null", confMapStrings, &proxyfsdSignalHandlerIsArmed, errChan, &wg, unix.SIGTERM, unix.SIGHUP)
+	var execArgs []string
+	execArgs = append([]string{"daemon_test", "/dev/null"}, confMapStrings...)
+	go Daemon("/dev/null", confMapStrings, &proxyfsdSignalHandlerIsArmed, errChan, &wg,
+		execArgs, unix.SIGTERM, unix.SIGHUP)
 
 	for !proxyfsdSignalHandlerIsArmed {
 		select {
@@ -336,7 +339,9 @@ func TestDaemon(t *testing.T) {
 	proxyfsdSignalHandlerIsArmed = false
 	errChan = make(chan error, 1) // Must be buffered to avoid race
 
-	go Daemon(testVersionConfFileName, confMapStrings, &proxyfsdSignalHandlerIsArmed, errChan, &wg, unix.SIGTERM, unix.SIGHUP)
+	execArgs = append([]string{"daemon_test", testVersionConfFileName}, confMapStrings...)
+	go Daemon(testVersionConfFileName, confMapStrings, &proxyfsdSignalHandlerIsArmed, errChan, &wg,
+		execArgs, unix.SIGTERM, unix.SIGHUP)
 
 	for !proxyfsdSignalHandlerIsArmed {
 		select {

--- a/proxyfsd/proxyfsd/main.go
+++ b/proxyfsd/proxyfsd/main.go
@@ -4,10 +4,9 @@ package main
 import (
 	"fmt"
 	"log"
+	"log/syslog"
 	"os"
 	"sync"
-
-	"golang.org/x/sys/unix"
 
 	"github.com/swiftstack/ProxyFS/proxyfsd"
 )
@@ -20,14 +19,31 @@ func main() {
 	errChan := make(chan error, 1) // Must be buffered to avoid race
 	var wg sync.WaitGroup
 
-	go proxyfsd.Daemon(os.Args[1], os.Args[2:], nil, errChan, &wg, unix.SIGINT, unix.SIGTERM, unix.SIGHUP)
+	syslogger, err := syslog.Dial("", "", syslog.LOG_DAEMON, "proxyfsd")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "proxyfsd/Daemon(): syslog.Dial() failed: %v\n", err)
+		syslogger = nil
+	} else {
+		syslogger.Info(fmt.Sprintf("starting up: calling Daemon()"))
+	}
 
-	err := <-errChan
+	// empty signal list (final argument) means "catch all signals" its possible to catch
+	go proxyfsd.Daemon(os.Args[1], os.Args[2:], nil, errChan, &wg, os.Args)
+
+	err = <-errChan
+
+	if syslogger != nil {
+		if err == nil {
+			syslogger.Info(fmt.Sprintf("shutting down: Daemon() finished"))
+		} else {
+			syslogger.Err(fmt.Sprintf("shutting down: Daemon() returned error: %v", err))
+		}
+	}
 
 	wg.Wait() // wait for services to go Down()
 
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "proxyfsd/Daemon(): exited with error: %v\n", err) // Can't use logger.*() as it's not currently "up"
-		os.Exit(1)                                                                // Exit with non-success status that can be checked from scripts
+		fmt.Fprintf(os.Stderr, "proxyfsd: Daemon(): returned error: %v\n", err) // Can't use logger.*() as it's not currently "up"
+		os.Exit(1)                                                              // Exit with non-success status that can be checked from scripts
 	}
 }


### PR DESCRIPTION
Fix a bug in fsck that caused sparse files to be fail validation and
their inodes deleted.

Catch all signals that are catchable and print a message when they
are received.  Log a message as to why proxyfsd is exiting in all cases.

Change the logger to print the current PID on each line.  This will
allow us to distinguish log messages generated by proxyfsd from other
processes like mkproxyfs.  Have mkproxyfs log a startup message that
includes its PID.

(We need to get any other processes that use the logger to also print
a message, with their PID, when they start.)

Improve a couple of log messages when inode validation fails during fsck.
Improve some other log messages.