### PR TITLE
Ignore SIGPIPE (SIGWINCH, SIGURG, and SIGCHLD as well).

### DIFF
--- a/proxyfsd/daemon.go
+++ b/proxyfsd/daemon.go
@@ -308,8 +308,16 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, e
 		// these signals are normally ignored, but if "signals..." above is empty
 		// they are delivered via the channel.  we should simply ignore them.
 		if signalReceived == unix.SIGCHLD || signalReceived == unix.SIGURG ||
-			signalReceived == unix.SIGWINCH {
+			signalReceived == unix.SIGWINCH || signalReceived == unix.SIGCONT {
+			logger.Infof("Ignored signal: '%v'", signalReceived)
+			continue
+		}
 
+		// we can get SIGPIPE whenever an HTTP or other client closes a
+		// socket on us, so ignore it
+		if signalReceived == unix.SIGPIPE {
+			logger.Infof("Ignored signal: '%v'", signalReceived)
+			continue
 		}
 
 		// SIGHUP means reconfig but any other signal means time to exit


### PR DESCRIPTION
Correctly ignore SIGCHLD, SIGURG, and SIGWINCH (the if statement had no
effect before).

Add SIGPIPE to signals that are ignored because proxyfsd gets hit
with it when it writes to a closed socket, which can happen if an HTTP
client closes its socket before reading a response to its request (and any
other clients as well).

Ignore SIGCONT just in case someone is using SIGSTOP/SIGCONT on proxyfsd.
Without this SIGSTOP stops the process and SIGCONT starts it, but
SIGCONT is also caught and causes proxyfsd to exit.