### PR TITLE
Fix shadowing problem with obstacleInodeNumber causing fetchInode 0

### DIFF
--- a/fs/api_internal.go
+++ b/fs/api_internal.go
@@ -1934,7 +1934,8 @@ func putObjectHelper(mS *mountStruct, vContainerName string, vObjectPath string,
 	haveObstacle := false
 	var obstacleInodeNumber inode.InodeNumber
 	if 0 == len(dirs) {
-		obstacleInodeNumber, err1 := mS.volStruct.inodeVolumeHandle.Lookup(dirInodeNumber, vObjectBaseName)
+		var err1 error
+		obstacleInodeNumber, err1 = mS.volStruct.inodeVolumeHandle.Lookup(dirInodeNumber, vObjectBaseName)
 		if err1 != nil && blunder.Errno(err1) == int(blunder.NotFoundError) {
 			// File not found? Good!
 		} else if err1 != nil {


### PR DESCRIPTION
obstacleInodeNumber had a shadow variable which meant the original
obstacleInodeNumber was still 0.   This resulted in Destory() being
called for inode 0