### PR TITLE
jrpc-fixes: Fix typo in checkin cfc4903.

### DIFF
--- a/jrpcfs/filesystem.go
+++ b/jrpcfs/filesystem.go
@@ -71,7 +71,7 @@ func jrpcServerLoop() {
 		globals.connLock.Unlock()
 
 		go func(myConn net.Conn, myElm *list.Element) {
-			srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+			srv.ServeCodec(jsonrpc.NewServerCodec(myConn))
 			globals.connLock.Lock()
 			globals.connections.Remove(myElm)
 


### PR DESCRIPTION
Fix typo in change to jrpcfs/filesystem.go.  it should have included
    conn -> myConn
in the embedded fucntion.  There's a race where that might cause
the wrong connection to be processed.