### PR TITLE
Disable ReplayLog by default

### DIFF
--- a/proxyfsd/default.conf
+++ b/proxyfsd/default.conf
@@ -71,7 +71,7 @@ CheckpointContainerName:                 .__checkpoint__
 CheckpointContainerStoragePolicy:        gold
 CheckpointInterval:                      10s
 CheckpointIntervalsPerCompaction:        100
-ReplayLogFileName:                       CommonVolume.rlog
+#ReplayLogFileName:                       CommonVolume.rlog
 DefaultPhysicalContainerLayout:          CommonVolumePhysicalContainerLayoutReplicated3Way
 FlowControl:                             CommonFlowControl
 SnapShotIDNumBits:                       10

--- a/proxyfsd/file_server.conf
+++ b/proxyfsd/file_server.conf
@@ -34,7 +34,7 @@ CheckpointContainerName:                  .__checkpoint__
 CheckpointContainerStoragePolicy:         gold
 CheckpointInterval:                       10s
 CheckpointIntervalsPerCompaction:         100
-ReplayLogFileName:                        CommonVolume.rlog
+#ReplayLogFileName:                        CommonVolume.rlog
 DefaultPhysicalContainerLayout:           CommonVolumePhysicalContainerLayoutReplicated3Way
 FlowControl:                              CommonFlowControl
 SnapShotIDNumBits:                        10


### PR DESCRIPTION
As it appears we will not be enabling ReplayLog anytime soon,
the impetus for defaulting our test environment to enable it
(i.e. to get developer exposure to it) is not imminent.