### PR TITLE
Unhine inode's TestEmptySegementDeletion() test case

### DIFF
--- a/inode/gc_test.go
+++ b/inode/gc_test.go
@@ -14,7 +14,7 @@ type testObjectLocationStruct struct {
 	objectName    string
 }
 
-func UnhideThisTestEmptySegmentDeletion(t *testing.T) {
+func TestEmptySegmentDeletion(t *testing.T) {
 	testVolumeHandle, err := FetchVolumeHandle("TestVolume")
 	if nil != err {
 		t.Fatalf("FetchVolumeHandle(\"TestVolume\") failed: %v", err)


### PR DESCRIPTION
Apparently, this was "hidden" at some point and inadvertantly checked-in
hidden... so this check-in merely unhide's it.