### PR TITLE
Fixed race condition in ramswift daemon startup

### DIFF
--- a/ramswift/daemon.go
+++ b/ramswift/daemon.go
@@ -1487,11 +1487,13 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, d
 	for {
 		resp, err = http.Get("http://" + globals.noAuthAddr + "/info")
 		if nil != err {
-			log.Fatalf("failed GET of \"/info\": %v", err)
+			log.Printf("failed GET of \"/info\": %v", err)
+			continue
 		}
 		if http.StatusOK == resp.StatusCode {
 			break
 		}
+		log.Printf("GET of \"/info\" returned Status %v", resp.Status)
 		time.Sleep(100 * time.Millisecond)
 	}
 


### PR DESCRIPTION
While dependent launchers (e.g. inode/api_test.go) waited until
the launched ramswift.Daemon() indicated it's signal handler
was armed, this actually came before the http.ListenAndServe()
call was executed...introducing a race.

The fix internally polls the NoAuth ramswift server instance
until it responds successfully.