### PR TITLE
Re-worked inodeCache accesses to maintain an LRU

### DIFF
--- a/inode/gc_test.go
+++ b/inode/gc_test.go
@@ -44,9 +44,12 @@ func TestEmptySegmentDeletion(t *testing.T) {
 	}
 
 	// inspect log segment map
-	ourInode, ok := volume.inodeCache[ino]
+	ourInode, ok, err := volume.fetchInode(ino)
+	if nil != err {
+		t.Fatalf("fetchInode(ino==0x%016X) failed: %v", ino, err)
+	}
 	if !ok {
-		t.Fatalf("expected to find inode #%v in cache", ino)
+		t.Fatalf("fetchInode(ino==0x%016X) returned !ok", ino)
 	}
 	segmentNumbers := make([]uint64, 0, 5)
 	segmentObjectLocations := make([]testObjectLocationStruct, 0, 5)

--- a/inode/symlink.go
+++ b/inode/symlink.go
@@ -1,6 +1,8 @@
 package inode
 
 import (
+	"fmt"
+
 	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/stats"
 )
@@ -22,9 +24,14 @@ func (vS *volumeStruct) CreateSymlink(target string, filePerm InodeMode, userID 
 	symlinkInode.SymlinkTarget = target
 	symlinkInodeNumber = symlinkInode.InodeNumber
 
-	vS.Lock()
-	vS.inodeCache[symlinkInodeNumber] = symlinkInode
-	vS.Unlock()
+	ok, err := vS.inodeCacheInsert(symlinkInode)
+	if nil != err {
+		return
+	}
+	if !ok {
+		err = fmt.Errorf("inodeCacheInsert(symlinkInode) failed")
+		return
+	}
 
 	err = vS.flushInode(symlinkInode)
 	if err != nil {

--- a/inode/validate_test.go
+++ b/inode/validate_test.go
@@ -66,9 +66,19 @@ func TestValidate(t *testing.T) {
 	}
 
 	// Now remove fileInodeNumber from inodeCache
-	testVolume.Lock()
-	delete(testVolume.inodeCache, fileInodeNumber)
-	testVolume.Unlock()
+	fileInode, ok, err := testVolume.inodeCacheFetch(fileInodeNumber)
+	if err != nil {
+		t.Fatalf("inodeCacheFetch(fileInodeNumber) failed: %v", err)
+	}
+	if ok {
+		ok, err = testVolume.inodeCacheDrop(fileInode)
+		if err != nil {
+			t.Fatalf("inodeCacheDrop(fileInode) failed: %v", err)
+		}
+		if !ok {
+			t.Fatalf("inodeCacheDrop(fileInode) returned !ok")
+		}
+	}
 
 	// Try to Validate, observe that it fails
 	validationErr := testVolumeHandle.Validate(fileInodeNumber, false)


### PR DESCRIPTION
As part of this change, the inodeCache is now implemented via a
sortedmap.LLRBTree (rather than a map). This will ultimately
support iterating through the cache in InodeNumber order such
as will be needed by the SnapShot Delete functionality.