### PR TITLE
Enhance /.snapshot/ inode.Lookup() calls for "." & ".."

### DIFF
--- a/inode/dir.go
+++ b/inode/dir.go
@@ -653,15 +653,24 @@ func (vS *volumeStruct) lookup(dirInodeNumber InodeNumber, basename string) (tar
 			return
 		}
 
-		// See if basename is the name for an active SnapShot
-
-		snapShot, ok = vS.headhunterVolumeHandle.SnapShotLookupByName(basename)
-
-		if ok {
-			targetInodeNumber = InodeNumber(vS.headhunterVolumeHandle.SnapShotIDAndNonceEncode(snapShot.ID, dirInodeNonce))
+		switch basename {
+		case ".":
+			targetInodeNumber = dirInodeNumber
 			err = nil
-		} else {
-			err = blunder.AddError(fmt.Errorf("/%v/%v SnapShot not found", SnapShotDirName, basename), blunder.NotFoundError)
+		case "..":
+			targetInodeNumber = RootDirInodeNumber
+			err = nil
+		default:
+			// See if basename is the name for an active SnapShot
+
+			snapShot, ok = vS.headhunterVolumeHandle.SnapShotLookupByName(basename)
+
+			if ok {
+				targetInodeNumber = InodeNumber(vS.headhunterVolumeHandle.SnapShotIDAndNonceEncode(snapShot.ID, dirInodeNonce))
+				err = nil
+			} else {
+				err = blunder.AddError(fmt.Errorf("/%v/%v SnapShot not found", SnapShotDirName, basename), blunder.NotFoundError)
+			}
 		}
 
 		return


### PR DESCRIPTION
Although most clients won't actually do a lookup on either "." (kind
of pointless since it will merely return the dirInode argument) nor
".." (since the client likely will just "back up" on the path directly),
correct inode.Lookup() should respond as specified when clients do so.

This pairs with the behavior of inode.ReadDir() that includes "." & ".."
entries in the specified dirInodeNumber-indicated directory.