### PR TITLE
Adjust tunables, fix issues with start/stop timers, what entries removed, etc

### DIFF
--- a/inode/inode.go
+++ b/inode/inode.go
@@ -373,8 +373,7 @@ func (vS *volumeStruct) inodeCacheDiscard() {
 		inodesToDrop = (vS.inodeCacheLRUItems * globals.inodeSize) - vS.inodeCacheLRUMaxBytes
 		inodesToDrop = inodesToDrop / globals.inodeSize
 		inodesToDrop += inodesToDrop / 4
-		for ((vS.inodeCacheLRUItems * globals.inodeSize) > vS.inodeCacheLRUMaxBytes) &&
-			(inodesToDrop > 0) {
+		for inodesToDrop > 0 {
 			inodesToDrop--
 
 			ic := vS.inodeCacheLRUHead

--- a/proxyfsd/default.conf
+++ b/proxyfsd/default.conf
@@ -74,8 +74,8 @@ CheckpointInterval:                      10s
 DefaultPhysicalContainerLayout:          CommonVolumePhysicalContainerLayoutReplicated3Way
 FlowControl:                             CommonFlowControl
 SnapShotIDNumBits:                       10
-MaxBytesInodeCache:                      1048576   # 1MB for inode cache
-InodeCacheEvictInterval:                 5s
+MaxBytesInodeCache:                      10485760
+InodeCacheEvictInterval:                 1s
 
 
 # Describes the set of volumes of the file system listed above

--- a/proxyfsd/file_server.conf
+++ b/proxyfsd/file_server.conf
@@ -37,8 +37,8 @@ CheckpointInterval:                       10s
 DefaultPhysicalContainerLayout:           CommonVolumePhysicalContainerLayoutReplicated3Way
 FlowControl:                              CommonFlowControl
 SnapShotIDNumBits:                        10
-MaxBytesInodeCache:                       1048576
-InodeCacheEvictInterval:                  5s
+MaxBytesInodeCache:                       10485760
+InodeCacheEvictInterval:                  1s
 
 [FSGlobals]
 VolumeList:                               CommonVolume


### PR DESCRIPTION
Adjust tunables, start/stop of discard timer and when to discard

    Adjusted the tunables based on more testing.

    Fix issues related to when we start/stop the timers

    Fix bug where we were incorrectly discarding inodes from the inode cache.

    Moved execution of for() loop under if statement since no need to test for() loop
    if if statement did not pass.