### PR TITLE
Reworked pfs-swift-load to support pipelined methods

### DIFF
--- a/pfs-swift-load/pfs-swift-load.conf
+++ b/pfs-swift-load/pfs-swift-load.conf
@@ -1,33 +1,45 @@
 [LoadParameters]
 
-FileWorkerList:              file                   # If non-empty, one of the following FileMethod's is required
-#FileMethod:                 write
-#FileMethod:                 stat
-#FileMethod:                 read
-#FileMethod:                 delete
-MountPoint:                  /CommonMountPoint      # Required if FileWorkerList non-empty
-FileBlockCount:              256                    # Required if FileWorkerList non-empty
-FileBlockSize:               4096                   # Required if FileWorkerList non-empty
-
-SwiftWorkerList:             bimodal                # If non-empty, one of the following SwiftMethod's is required
-#SwiftMethod:                PUT
-#SwiftMethod:                HEAD
-#SwiftMethod:                GET
-#SwiftMethod:                DELETE
-SwiftObjectSize:             1048576                # Required if SwiftWorkerList non-empty
-SwiftProxy:                  http://127.0.0.1:8080/ # Required if SwiftWorkerList non-empty
-
-DisplayInterval:             10s
-OutputFormat:                text                   # Must be either "text" or "csv"
+WorkerList:                  file bimodal pipeline   # Must be non-empty... example file, bimodal, and pipeline workers given below
+DisplayInterval:             1s
+LogPath:                     /dev/null               # Log will be in .csv format
 
 [Worker:file]
+
+MethodList:                  write                   # One of write, stat, read, or delete
+MountPoint:                  /CommonMountPoint
 Directory:                   pfs-swift-load-file
+FileBlockCount:              256
+FileBlockSize:               4096
+Iterations:                  1000
 NumThreads:                  10
 
 [Worker:bimodal]
-SwiftUser:                   test:tester
-SwiftKey:                    testing
+
+MethodList:                  PUT                     # One of PUT, HEAD, GET, or DELETE
+SwiftProxyURL:               http://127.0.0.1:8080/
+SwiftAuthUser:               test:tester
+SwiftAuthKey:                testing
 SwiftAccount:                AUTH_test
-SwiftContainer:              pfs-swift-load-bimodal
 SwiftContainerStoragePolicy: silver
+SwiftContainer:              pfs-swift-load-bimodal
+ObjectSize:                  1048576
+Iterations:                  1000
+NumThreads:                  10
+
+[Worker:pipeline]
+
+MethodList:                  write GET DELETE        # A non-empty list of write, stat, read, delete, PUT, HEAD, GET, and DELETE
+MountPoint:                  /CommonMountPoint       # Typically corresponds to SwiftAccount
+Directory:                   pfs-swift-load-pipeline # Typically matches SwiftContainer
+FileBlockCount:              256                     # Typically,
+FileBlockSize:               4096                    #   (FileBlockCount * FileBlockSize) == ObjectSize
+SwiftProxyURL:               http://127.0.0.1:8080/
+SwiftAuthUser:               test:tester
+SwiftAuthKey:                testing
+SwiftAccount:                AUTH_test               # Typically corresponds to MountPoint
+SwiftContainer:              pfs-swift-load-pipeline # Typically matches Directory
+SwiftContainerStoragePolicy: silver
+ObjectSize:                  1048576                 # Typically matches (FileBlockCount * FileBlockSize)
+Iterations:                  1000
 NumThreads:                  10


### PR DESCRIPTION
This change significantly re-works the layout of the .conf file
to enable per-Worker settings (as opposed to, e.g., making all
File Workers use the same file block size).

Additionally, rather than choosing between "text" and "csv" output,
the "text" form is now always sent to StdOut while the "cvs" output
is sent to a .conf-specified file.