### PR TITLE
Typo caused fileDelete's to not be counted in pfs-swift-load

### DIFF
--- a/pfs-swift-load/main.go
+++ b/pfs-swift-load/main.go
@@ -781,7 +781,7 @@ func (worker *workerStruct) workerThreadLauncher() {
 				case fileDelete:
 					doSwiftMethod = false
 					err = os.Remove(path)
-					if nil == err {
+					if nil != err {
 						abandonedIteration = true
 					}
 				case http.MethodPut:


### PR DESCRIPTION
Also want to add that this set of changes also provides a means
to set the number of "Iterations" each Worker will attempt before
exiting the program.