### PR TITLE
Update ramswift to actually release memory on "exit"

### DIFF
--- a/ramswift/daemon.go
+++ b/ramswift/daemon.go
@@ -83,7 +83,7 @@ type globalsStruct struct {
 	containerListingLimit           uint64
 }
 
-var globals globalsStruct
+var globals *globalsStruct
 
 type httpRequestHandler struct{}
 
@@ -1444,6 +1444,8 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, d
 
 	// Initialization
 
+	globals = &globalsStruct{}
+
 	globals.swiftAccountMap = make(map[string]*swiftAccountStruct)
 
 	// Compute confMap
@@ -1537,6 +1539,8 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, d
 			updateConf(confMap)
 		} else {
 			// signalReceived either SIGINT or SIGTERM... so just exit
+
+			globals = nil
 
 			doneChan <- true
 


### PR DESCRIPTION
globals is now a pointer to a globalsStruct and will
be set to nil upon exit... this should give the GC an
opportunity to release the now unreferenced data that
was PUT to ramswift... useful if ramswift is restarted
any number of times with the caller expecting to have
free memory to spare for each iteration.