### PR TITLE
Apply SIGHUP Pause/Resume-enforcing "gate" to package fuse

### DIFF
--- a/fuse/dir.go
+++ b/fuse/dir.go
@@ -21,6 +21,9 @@ type Dir struct {
 }
 
 func (d Dir) Access(ctx context.Context, req *fuselib.AccessRequest) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	if d.mountHandle.Access(inode.InodeUserID(req.Uid), inode.InodeGroupID(req.Gid), nil, d.inodeNumber, inode.InodeMode(req.Mask)) {
 		return nil
 	} else {
@@ -32,6 +35,9 @@ func (d Dir) Attr(ctx context.Context, attr *fuselib.Attr) (err error) {
 	var (
 		stat fs.Stat
 	)
+
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
 
 	stat, err = d.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, d.inodeNumber)
 	if nil != err {
@@ -64,6 +70,9 @@ func (d Dir) Setattr(ctx context.Context, req *fuselib.SetattrRequest, resp *fus
 		stat        fs.Stat
 		statUpdates fs.Stat
 	)
+
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
 
 	stat, err = d.mountHandle.Getstat(inode.InodeUserID(req.Uid), inode.InodeGroupID(req.Gid), nil, d.inodeNumber)
 	if nil != err {
@@ -113,6 +122,9 @@ func (d Dir) Setattr(ctx context.Context, req *fuselib.SetattrRequest, resp *fus
 }
 
 func (d Dir) Lookup(ctx context.Context, name string) (fusefslib.Node, error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	childInodeNumber, err := d.mountHandle.Lookup(inode.InodeRootUserID, inode.InodeGroupID(0), nil, d.inodeNumber, name)
 	if err != nil {
 		return nil, fuselib.ENOENT
@@ -168,6 +180,9 @@ func inodeTypeToDirentType(inodeType inode.InodeType) fuselib.DirentType {
 }
 
 func (d Dir) ReadDirAll(ctx context.Context) ([]fuselib.Dirent, error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	entries := make([]inode.DirEntry, 0)
 	entryCount := uint64(0)
 	lastEntryName := ""
@@ -202,6 +217,9 @@ func (d Dir) ReadDirAll(ctx context.Context) ([]fuselib.Dirent, error) {
 }
 
 func (d Dir) Remove(ctx context.Context, req *fuselib.RemoveRequest) (err error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	if req.Dir {
 		err = d.mountHandle.Rmdir(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, d.inodeNumber, req.Name)
 	} else {
@@ -214,6 +232,9 @@ func (d Dir) Remove(ctx context.Context, req *fuselib.RemoveRequest) (err error)
 }
 
 func (d Dir) Mknod(ctx context.Context, req *fuselib.MknodRequest) (fusefslib.Node, error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	// Note: NFSd apparently prefers to use Mknod() instead of Create() when creating normal files...
 	if 0 != (inode.InodeMode(req.Mode) & ^inode.PosixModePerm) {
 		err := fmt.Errorf("Invalid Mode... only normal file creations supported")
@@ -231,6 +252,9 @@ func (d Dir) Mknod(ctx context.Context, req *fuselib.MknodRequest) (fusefslib.No
 }
 
 func (d Dir) Create(ctx context.Context, req *fuselib.CreateRequest, resp *fuselib.CreateResponse) (fusefslib.Node, fusefslib.Handle, error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	if 0 != (inode.InodeMode(req.Mode) & ^inode.PosixModePerm) {
 		err := fmt.Errorf("Invalid Mode... only normal file creations supported")
 		err = blunder.AddError(err, blunder.InvalidInodeTypeError)
@@ -247,6 +271,9 @@ func (d Dir) Create(ctx context.Context, req *fuselib.CreateRequest, resp *fusel
 }
 
 func (d Dir) Flush(ctx context.Context, req *fuselib.FlushRequest) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	err := d.mountHandle.Flush(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, d.inodeNumber)
 	if err != nil {
 		err = newFuseError(err)
@@ -255,6 +282,9 @@ func (d Dir) Flush(ctx context.Context, req *fuselib.FlushRequest) error {
 }
 
 func (d Dir) Fsync(ctx context.Context, req *fuselib.FsyncRequest) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	err := d.mountHandle.Flush(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil,
 		d.inodeNumber)
 	if err != nil {
@@ -264,6 +294,9 @@ func (d Dir) Fsync(ctx context.Context, req *fuselib.FsyncRequest) error {
 }
 
 func (d Dir) Mkdir(ctx context.Context, req *fuselib.MkdirRequest) (fusefslib.Node, error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	trimmedMode := inode.InodeMode(req.Mode) & inode.PosixModePerm
 	newDirInodeNumber, err := d.mountHandle.Mkdir(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, d.inodeNumber, req.Name, trimmedMode)
 	if err != nil {
@@ -274,6 +307,9 @@ func (d Dir) Mkdir(ctx context.Context, req *fuselib.MkdirRequest) (fusefslib.No
 }
 
 func (d Dir) Rename(ctx context.Context, req *fuselib.RenameRequest, newDir fusefslib.Node) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	dstDir, ok := newDir.(Dir)
 	if !ok {
 		return fuselib.EIO
@@ -286,6 +322,9 @@ func (d Dir) Rename(ctx context.Context, req *fuselib.RenameRequest, newDir fuse
 }
 
 func (d Dir) Symlink(ctx context.Context, req *fuselib.SymlinkRequest) (fusefslib.Node, error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	symlinkInodeNumber, err := d.mountHandle.Symlink(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, d.inodeNumber, req.NewName, req.Target)
 	if err != nil {
 		err = newFuseError(err)
@@ -296,6 +335,9 @@ func (d Dir) Symlink(ctx context.Context, req *fuselib.SymlinkRequest) (fusefsli
 }
 
 func (d Dir) Link(ctx context.Context, req *fuselib.LinkRequest, old fusefslib.Node) (fusefslib.Node, error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	oldFile, ok := old.(File)
 	if !ok {
 		err := fmt.Errorf("old.(File) failed")

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -20,6 +20,9 @@ type File struct {
 }
 
 func (f File) Access(ctx context.Context, req *fuselib.AccessRequest) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	if f.mountHandle.Access(inode.InodeUserID(req.Uid), inode.InodeGroupID(req.Gid), nil, f.inodeNumber, inode.InodeMode(req.Mask)) {
 		return nil
 	} else {
@@ -31,6 +34,9 @@ func (f File) Attr(ctx context.Context, attr *fuselib.Attr) (err error) {
 	var (
 		stat fs.Stat
 	)
+
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
 
 	stat, err = f.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, f.inodeNumber)
 	if nil != err {
@@ -65,6 +71,9 @@ func (f File) Setattr(ctx context.Context, req *fuselib.SetattrRequest, resp *fu
 		stat        fs.Stat
 		statUpdates fs.Stat
 	)
+
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
 
 	stat, err = f.mountHandle.Getstat(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, f.inodeNumber)
 	if nil != err {
@@ -123,6 +132,9 @@ func (f File) Setattr(ctx context.Context, req *fuselib.SetattrRequest, resp *fu
 }
 
 func (f File) Flush(ctx context.Context, req *fuselib.FlushRequest) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	err := f.mountHandle.Flush(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, f.inodeNumber)
 	if nil != err {
 		err = newFuseError(err)
@@ -131,6 +143,9 @@ func (f File) Flush(ctx context.Context, req *fuselib.FlushRequest) error {
 }
 
 func (f File) Fsync(ctx context.Context, req *fuselib.FsyncRequest) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	err := f.mountHandle.Flush(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil,
 		f.inodeNumber)
 	if nil != err {
@@ -140,6 +155,9 @@ func (f File) Fsync(ctx context.Context, req *fuselib.FsyncRequest) error {
 }
 
 func (f File) Read(ctx context.Context, req *fuselib.ReadRequest, resp *fuselib.ReadResponse) (err error) {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	buf, err := f.mountHandle.Read(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, f.inodeNumber, uint64(req.Offset), uint64(req.Size), nil)
 	if err != nil && err != io.EOF {
 		err = newFuseError(err)
@@ -150,6 +168,9 @@ func (f File) Read(ctx context.Context, req *fuselib.ReadRequest, resp *fuselib.
 }
 
 func (f File) Write(ctx context.Context, req *fuselib.WriteRequest, resp *fuselib.WriteResponse) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	size, err := f.mountHandle.Write(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, f.inodeNumber, uint64(req.Offset), req.Data, nil)
 	if nil == err {
 		resp.Size = int(size)

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -29,6 +29,9 @@ func (pfs *ProxyFUSE) Root() (fusefslib.Node, error) {
 }
 
 func (pfs *ProxyFUSE) Statfs(ctx context.Context, req *fuselib.StatfsRequest, resp *fuselib.StatfsResponse) error {
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	statvfs, err := pfs.mountHandle.StatVfs()
 	if err != nil {
 		return newFuseError(err)

--- a/fuse/symlink.go
+++ b/fuse/symlink.go
@@ -23,6 +23,9 @@ func (s Symlink) Attr(ctx context.Context, attr *fuselib.Attr) (err error) {
 		stat fs.Stat
 	)
 
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
+
 	stat, err = s.mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, s.inodeNumber)
 	if nil != err {
 		err = newFuseError(err)
@@ -54,6 +57,9 @@ func (s Symlink) Setattr(ctx context.Context, req *fuselib.SetattrRequest, resp 
 		stat        fs.Stat
 		statUpdates fs.Stat
 	)
+
+	globals.gate.RLock()
+	defer globals.gate.RUnlock()
 
 	stat, err = s.mountHandle.Getstat(inode.InodeUserID(req.Header.Uid), inode.InodeGroupID(req.Header.Gid), nil, s.inodeNumber)
 	if nil != err {


### PR DESCRIPTION
Much like jrpcfs, package fuse is the top-most entrypoint for
proxyfsd and, as such, bears the responsibility to ensure it
follows the convention that, once paused, no traffic to the
layer below it (package fs in this case) will receive any
requests... and that this protection continues until having
completed the resume phase.