### PR TITLE
Finished .conf namespace'ing convertion

### DIFF
--- a/cleanproxyfs/main.go
+++ b/cleanproxyfs/main.go
@@ -49,13 +49,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-	confErr = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-	if nil != confErr {
-		fmt.Fprintf(os.Stderr, "utils.AdjustConfSectionNamespacingAsNecessary() failed: %v\n", confErr)
-		os.Exit(1)
-	}
-
 	// Fetch WhoAmI (qualifies which VolumeList elements are applicable)
 	whoAmI, confErr := confMap.FetchOptionValueString("Cluster", "WhoAmI")
 	if nil != confErr {
@@ -73,7 +66,7 @@ func main() {
 	// Prune VolumeList per PrimaryPeer attribute
 	volumeListPruned := []string{}
 	for _, volumeName := range volumeList {
-		primaryPeerList, confErr := confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, confErr := confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != confErr {
 			fmt.Fprintf(os.Stderr, "confMap did not contain %v.PrimaryPeer\n", volumeName)
 			os.Exit(1)
@@ -103,7 +96,7 @@ func main() {
 	urlPrefix := "http://127.0.0.1:" + noAuthTCPPort + "/v1/"
 
 	for _, volumeName := range volumeListPruned {
-		accountName, confErr := confMap.FetchOptionValueString(utils.VolumeNameConfSection(volumeName), "AccountName")
+		accountName, confErr := confMap.FetchOptionValueString("Volume:"+volumeName, "AccountName")
 		if nil != confErr {
 			fmt.Fprintf(os.Stderr, "confMap did not contain %v.AccountName\n", volumeName)
 			os.Exit(1)
@@ -221,7 +214,7 @@ func main() {
 					os.Exit(1)
 				}
 
-				replayLogFileName, confErr := confMap.FetchOptionValueString(utils.VolumeNameConfSection(volumeName), "ReplayLogFileName")
+				replayLogFileName, confErr := confMap.FetchOptionValueString("Volume:"+volumeName, "ReplayLogFileName")
 				if nil == confErr {
 					if "" != replayLogFileName {
 						removeReplayLogFileErr := os.Remove(replayLogFileName)

--- a/fs/config.go
+++ b/fs/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/swiftstack/ProxyFS/headhunter"
 	"github.com/swiftstack/ProxyFS/inode"
 	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 type inFlightFileInodeDataStruct struct {
@@ -82,7 +81,7 @@ func Up(confMap conf.ConfMap) (err error) {
 	globals.volumeMap = make(map[string]*volumeStruct)
 
 	for _, volumeName = range volumeList {
-		volumeSectionName = utils.VolumeNameConfSection(volumeName)
+		volumeSectionName = "Volume:" + volumeName
 
 		primaryPeerList, err = confMap.FetchOptionValueStringSlice(volumeSectionName, "PrimaryPeer")
 		if nil != err {
@@ -113,7 +112,7 @@ func Up(confMap conf.ConfMap) (err error) {
 				if nil != err {
 					return
 				}
-				flowControlSectionName = utils.FlowControlNameConfSection(flowControlName)
+				flowControlSectionName = "FlowControl:" + flowControlName
 
 				volume.maxFlushTime, err = confMap.FetchOptionValueDuration(flowControlSectionName, "MaxFlushTime")
 				if nil != err {
@@ -176,7 +175,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 	updatedVolumeMap = make(map[string]bool)
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
 			return
@@ -247,7 +246,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, volumeName = range volumeList {
-		volumeSectionName = utils.VolumeNameConfSection(volumeName)
+		volumeSectionName = "Volume:" + volumeName
 
 		primaryPeerList, err = confMap.FetchOptionValueStringSlice(volumeSectionName, "PrimaryPeer")
 		if nil != err {
@@ -280,7 +279,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 					if nil != err {
 						return
 					}
-					flowControlSectionName = utils.FlowControlNameConfSection(flowControlName)
+					flowControlSectionName = "FlowControl:" + flowControlName
 
 					volume.maxFlushTime, err = confMap.FetchOptionValueDuration(flowControlSectionName, "MaxFlushTime")
 					if nil != err {

--- a/fsworkout/main.go
+++ b/fsworkout/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/swiftclient"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 const (
@@ -133,13 +132,6 @@ func main() {
 			fmt.Fprintf(os.Stderr, "confMap.UpdateFromStrings(%#v) failed: %v\n", os.Args[5:], err)
 			os.Exit(1)
 		}
-	}
-
-	// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-	err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "utils.AdjustConfSectionNamespacingAsNecessary() failed: %v\n", err)
-		os.Exit(1)
 	}
 
 	// Start up needed ProxyFS components

--- a/fuse/config.go
+++ b/fuse/config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/fs"
 	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 const (
@@ -66,7 +65,7 @@ func Up(confMap conf.ConfMap) (err error) {
 	// Look thru list of volumes and generate map of volumes to be mounted on
 	// the local node.
 	for _, volumeName = range volumeList {
-		volumeSectionName = utils.VolumeNameConfSection(volumeName)
+		volumeSectionName = "Volume:" + volumeName
 
 		primaryPeerNameList, err = confMap.FetchOptionValueStringSlice(volumeSectionName, "PrimaryPeer")
 		if nil != err {
@@ -149,7 +148,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 	for _, volumeName = range volumeList {
 		_, ok = removedVolumeMap[volumeName]
 		if ok {
-			primaryPeerNameList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+			primaryPeerNameList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 			if nil != err {
 				return
 			}
@@ -208,7 +207,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, volumeName = range volumeList {
-		volumeSectionName = utils.VolumeNameConfSection(volumeName)
+		volumeSectionName = "Volume:" + volumeName
 
 		primaryPeerNameList, err = confMap.FetchOptionValueStringSlice(volumeSectionName, "PrimaryPeer")
 		if nil != err {

--- a/headhunter/config.go
+++ b/headhunter/config.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/swiftclient"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 const (
@@ -196,7 +195,7 @@ func Up(confMap conf.ConfMap) (err error) {
 	globals.volumeMap = make(map[string]*volumeStruct)
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			return
 		}
@@ -246,7 +245,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			return
 		}
@@ -297,7 +296,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			return
 		}
@@ -468,7 +467,7 @@ func upVolume(confMap conf.ConfMap, volumeName string, autoFormat bool) (err err
 		volumeSectionName      string
 	)
 
-	volumeSectionName = utils.VolumeNameConfSection(volumeName)
+	volumeSectionName = "Volume:" + volumeName
 
 	volume = &volumeStruct{
 		volumeName:                           volumeName,
@@ -489,7 +488,7 @@ func upVolume(confMap conf.ConfMap, volumeName string, autoFormat bool) (err err
 	if nil != err {
 		return
 	}
-	flowControlSectionName = utils.FlowControlNameConfSection(flowControlName)
+	flowControlSectionName = "FlowControl:" + flowControlName
 
 	volume.maxFlushSize, err = confMap.FetchOptionValueUint64(flowControlSectionName, "MaxFlushSize")
 	if nil != err {

--- a/httpserver/config.go
+++ b/httpserver/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/swiftstack/ProxyFS/fs"
 	"github.com/swiftstack/ProxyFS/headhunter"
 	"github.com/swiftstack/ProxyFS/inode"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 type ExtentMapElementStruct struct {
@@ -122,7 +121,7 @@ func Up(confMap conf.ConfMap) (err error) {
 	globals.volumeLLRB = sortedmap.NewLLRBTree(sortedmap.CompareString, nil)
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
 			return
@@ -170,7 +169,7 @@ func Up(confMap conf.ConfMap) (err error) {
 		}
 	}
 
-	globals.ipAddr, err = confMap.FetchOptionValueString(utils.PeerNameConfSection(globals.whoAmI), "PrivateIPAddr")
+	globals.ipAddr, err = confMap.FetchOptionValueString("Peer:"+globals.whoAmI, "PrivateIPAddr")
 	if nil != err {
 		err = fmt.Errorf("confMap.FetchOptionValueString(\"<whoAmI>\", \"PrivateIPAddr\") failed: %v", err)
 		return
@@ -223,7 +222,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 		return
 	}
 
-	ipAddr, err = confMap.FetchOptionValueString(utils.PeerNameConfSection(whoAmI), "PrivateIPAddr")
+	ipAddr, err = confMap.FetchOptionValueString("Peer:"+whoAmI, "PrivateIPAddr")
 	if nil != err {
 		err = fmt.Errorf("confMap.FetchOptionValueString(\"<whoAmI>\", \"PrivateIPAddr\") failed: %v", err)
 		return
@@ -263,7 +262,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 	volumeMap = make(map[string]bool)
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
 			return
@@ -357,7 +356,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
 			return

--- a/inode/config.go
+++ b/inode/config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/platform"
 	"github.com/swiftstack/ProxyFS/swiftclient"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 type physicalContainerLayoutStruct struct {
@@ -204,7 +203,7 @@ func Up(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, peerName = range peerNames {
-		peerPrivateIPAddr, err = confMap.FetchOptionValueString(utils.PeerNameConfSection(peerName), "PrivateIPAddr")
+		peerPrivateIPAddr, err = confMap.FetchOptionValueString("Peer:"+peerName, "PrivateIPAddr")
 		if nil != err {
 			return
 		}
@@ -266,7 +265,7 @@ func Up(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, volumeName = range volumeList {
-		volumeSectionName = utils.VolumeNameConfSection(volumeName)
+		volumeSectionName = "Volume:" + volumeName
 
 		volume = &volumeStruct{
 			volumeName:                     volumeName,
@@ -365,7 +364,7 @@ func Up(confMap conf.ConfMap) (err error) {
 
 				physicalContainerLayout.physicalContainerLayoutName = physicalContainerLayoutName
 
-				physicalContainerLayoutSectionName = utils.PhysicalContainerLayoutNameConfSection(physicalContainerLayoutName)
+				physicalContainerLayoutSectionName = "PhysicalContainerLayout:" + physicalContainerLayoutName
 
 				physicalContainerLayout.physicalContainerStoragePolicy, err = confMap.FetchOptionValueString(physicalContainerLayoutSectionName, "ContainerStoragePolicy")
 				if nil != err {
@@ -413,7 +412,7 @@ func Up(confMap conf.ConfMap) (err error) {
 			if nil != err {
 				return
 			}
-			flowControlSectionName = utils.FlowControlNameConfSection(flowControlName)
+			flowControlSectionName = "FlowControl:" + flowControlName
 
 			_, alreadyInFlowControlMap = globals.flowControlMap[flowControlName]
 
@@ -549,7 +548,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, peerName = range peerNames {
-		peerPrivateIPAddr, err = confMap.FetchOptionValueString(utils.PeerNameConfSection(peerName), "PrivateIPAddr")
+		peerPrivateIPAddr, err = confMap.FetchOptionValueString("Peer:"+peerName, "PrivateIPAddr")
 		if nil != err {
 			return
 		}
@@ -596,7 +595,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 
 		_, ok = newVolumeSet[volumeName]
 		if ok {
-			primaryPeerNameList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+			primaryPeerNameList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 			if nil != err {
 				return
 			}
@@ -633,7 +632,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 		volume = globals.volumeMap[volumeName]
 		volume.headhunterVolumeHandle.UnregisterForEvents(volume)
 		volume.active = false
-		primaryPeerNameList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerNameList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			return
 		}
@@ -710,7 +709,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, peerName = range peerNames {
-		peerPrivateIPAddr, err = confMap.FetchOptionValueString(utils.PeerNameConfSection(peerName), "PrivateIPAddr")
+		peerPrivateIPAddr, err = confMap.FetchOptionValueString("Peer:"+peerName, "PrivateIPAddr")
 		if nil != err {
 			return
 		}
@@ -724,7 +723,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	}
 
 	for _, volumeName = range volumeList {
-		volumeSectionName = utils.VolumeNameConfSection(volumeName)
+		volumeSectionName = "Volume:" + volumeName
 
 		fsid, err = confMap.FetchOptionValueUint64(volumeSectionName, "FSID")
 		if nil != err {
@@ -778,7 +777,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 					if nil != err {
 						return
 					}
-					flowControlSectionName = utils.FlowControlNameConfSection(flowControlName)
+					flowControlSectionName = "FlowControl:" + flowControlName
 
 					flowControl = volume.flowControl
 
@@ -874,7 +873,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 			// a set of policies used to determine which one to apply. At such time, the following code will
 			// ensure that the container layouts don't conflict (obviously not a problem when there is only one).
 
-			volumeSectionName = utils.VolumeNameConfSection(volume.volumeName)
+			volumeSectionName = "Volume:" + volume.volumeName
 
 			volume.maxEntriesPerDirNode, err = confMap.FetchOptionValueUint64(volumeSectionName, "MaxEntriesPerDirNode")
 			if nil != err {
@@ -904,7 +903,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 
 				physicalContainerLayout.physicalContainerLayoutName = physicalContainerLayoutName
 
-				physicalContainerLayoutSectionName = utils.PhysicalContainerLayoutNameConfSection(physicalContainerLayoutName)
+				physicalContainerLayoutSectionName = "PhysicalContainerLayout:" + physicalContainerLayoutName
 
 				physicalContainerLayout.physicalContainerStoragePolicy, err = confMap.FetchOptionValueString(physicalContainerLayoutSectionName, "ContainerStoragePolicy")
 				if nil != err {
@@ -952,7 +951,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 			if nil != err {
 				return
 			}
-			flowControlSectionName = utils.FlowControlNameConfSection(flowControlName)
+			flowControlSectionName = "FlowControl:" + flowControlName
 
 			_, alreadyInFlowControlMap = globals.flowControlMap[flowControlName]
 
@@ -1056,7 +1055,7 @@ func adoptFlowControlReadCacheParameters(confMap conf.ConfMap, capExistingReadCa
 		flowControlWeightSum += flowControl.readCacheWeight
 	}
 
-	readCacheQuotaFraction, err = confMap.FetchOptionValueFloat64(utils.PeerNameConfSection(globals.whoAmI), "ReadCacheQuotaFraction")
+	readCacheQuotaFraction, err = confMap.FetchOptionValueFloat64("Peer:"+globals.whoAmI, "ReadCacheQuotaFraction")
 	if nil != err {
 		return
 	}

--- a/inode/cron.go
+++ b/inode/cron.go
@@ -9,7 +9,6 @@ import (
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/headhunter"
 	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 type snapShotScheduleStruct struct {
@@ -60,7 +59,7 @@ func (vS *volumeStruct) loadSnapShotPolicy(confMap conf.ConfMap) (err error) {
 	// Default to no snapShotPolicy found
 	vS.snapShotPolicy = nil
 
-	volumeSectionName = utils.VolumeNameConfSection(vS.volumeName)
+	volumeSectionName = "Volume:" + vS.volumeName
 
 	snapShotPolicyName, err = confMap.FetchOptionValueString(volumeSectionName, "SnapShotPolicy")
 	if nil != err {

--- a/inodeworkout/main.go
+++ b/inodeworkout/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/swiftclient"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 const (
@@ -131,13 +130,6 @@ func main() {
 			fmt.Fprintf(os.Stderr, "confMap.UpdateFromStrings(%#v) failed: %v\n", os.Args[5:], err)
 			os.Exit(1)
 		}
-	}
-
-	// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-	err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "utils.AdjustConfSectionNamespacingAsNecessary() failed: %v\n", err)
-		os.Exit(1)
 	}
 
 	// Start up needed ProxyFS components

--- a/jrpcfs/config.go
+++ b/jrpcfs/config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/fs"
 	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 type globalsStruct struct {
@@ -67,7 +66,7 @@ func Up(confMap conf.ConfMap) (err error) {
 		logger.ErrorfWithError(err, "failed to get Cluster.WhoAmI from config file")
 		return
 	}
-	globals.ipAddr, err = confMap.FetchOptionValueString(utils.PeerNameConfSection(globals.whoAmI), "PrivateIPAddr")
+	globals.ipAddr, err = confMap.FetchOptionValueString("Peer:"+globals.whoAmI, "PrivateIPAddr")
 	if nil != err {
 		logger.ErrorfWithError(err, "failed to get %s.PrivateIPAddr from config file", globals.whoAmI)
 		return
@@ -107,7 +106,7 @@ func Up(confMap conf.ConfMap) (err error) {
 	globals.volumeMap = make(map[string]bool)
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
 			return
@@ -165,7 +164,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 		return
 	}
 
-	ipAddr, err = confMap.FetchOptionValueString(utils.PeerNameConfSection(whoAmI), "PrivateIPAddr")
+	ipAddr, err = confMap.FetchOptionValueString("Peer:"+whoAmI, "PrivateIPAddr")
 	if nil != err {
 		err = fmt.Errorf("confMap.FetchOptionValueString(\"<whoAmI>\", \"PrivateIPAddr\") failed: %v", err)
 		return
@@ -216,7 +215,7 @@ func PauseAndContract(confMap conf.ConfMap) (err error) {
 	updatedVolumeMap = make(map[string]bool)
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
 			return
@@ -282,7 +281,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	updatedVolumeMap = make(map[string]bool)
 
 	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice(utils.VolumeNameConfSection(volumeName), "PrimaryPeer")
+		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
 		if nil != err {
 			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
 			return

--- a/mkproxyfs/api.go
+++ b/mkproxyfs/api.go
@@ -14,7 +14,6 @@ import (
 	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/swiftclient"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 type Mode int
@@ -62,16 +61,9 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 		return
 	}
 
-	// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-	err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-	if nil != err {
-		err = fmt.Errorf("utils.AdjustConfSectionNamespacingAsNecessary() failed: %v", err)
-		return
-	}
-
 	// Fetch confMap particulars needed below
 
-	accountName, err = confMap.FetchOptionValueString(utils.VolumeNameConfSection(volumeNameToFormat), "AccountName")
+	accountName, err = confMap.FetchOptionValueString("Volume:"+volumeNameToFormat, "AccountName")
 	if nil != err {
 		return
 	}
@@ -195,7 +187,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 				isEmpty = (0 == len(containerList))
 			}
 
-			replayLogFileName, err = confMap.FetchOptionValueString(utils.VolumeNameConfSection(volumeNameToFormat), "ReplayLogFileName")
+			replayLogFileName, err = confMap.FetchOptionValueString("Volume:"+volumeNameToFormat, "ReplayLogFileName")
 			if nil == err {
 				if "" != replayLogFileName {
 					removeReplayLogFileErr := os.Remove(replayLogFileName)

--- a/pfs-crash/main.go
+++ b/pfs-crash/main.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/httpserver"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 const (
@@ -181,7 +180,7 @@ func main() {
 		log.Fatalf("volumeName (%s) not found in volumeList (%v)", volumeName, volumeList)
 	}
 
-	volumeSectionName = utils.VolumeNameConfSection(volumeName)
+	volumeSectionName = "Volume:" + volumeName
 
 	primaryPeer, err = confMap.FetchOptionValueString(volumeSectionName, "PrimaryPeer")
 	if nil != err {
@@ -191,7 +190,7 @@ func main() {
 		log.Fatalf("Cluster.WhoAmI (%s) does not match %s.PrimaryPeer (%s)", whoAmI, volumeSectionName, primaryPeer)
 	}
 
-	peerSectionName = utils.PeerNameConfSection(primaryPeer)
+	peerSectionName = "Peer:" + primaryPeer
 
 	privateIPAddr, err = confMap.FetchOptionValueString(peerSectionName, "PrivateIPAddr")
 	if nil != err {

--- a/pfs-stress/main.go
+++ b/pfs-stress/main.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 var (
@@ -77,12 +76,6 @@ func main() {
 	err = confMap.UpdateFromStrings(args[1:])
 	if nil != err {
 		log.Fatalf("failed to load config overrides: %v", err)
-	}
-
-	// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-	err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-	if nil != err {
-		log.Fatalf("utils.AdjustConfSectionNamespacingAsNecessary() failed: %v", err)
 	}
 
 	// Process resultant confMap

--- a/pfsworkout/main.go
+++ b/pfsworkout/main.go
@@ -201,13 +201,6 @@ func main() {
 			}
 		}
 
-		// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-		err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "utils.AdjustConfSectionNamespacingAsNecessary() failed: %v\n", err)
-			os.Exit(1)
-		}
-
 		volumeList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
 		if nil != err {
 			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") failed: %v\n", err)

--- a/proxyfsd/daemon.go
+++ b/proxyfsd/daemon.go
@@ -25,7 +25,6 @@ import (
 	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/statslogger"
 	"github.com/swiftstack/ProxyFS/swiftclient"
-	"github.com/swiftstack/ProxyFS/utils"
 )
 
 // if signals is empty it means "catch all signals" its possible to catch
@@ -48,16 +47,6 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, e
 
 	err = confMap.UpdateFromStrings(confStrings)
 	if nil != err {
-		errChan <- err
-
-		return
-	}
-
-	// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-	err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-	if nil != err {
-		err = fmt.Errorf("utils.AdjustConfSectionNamespacingAsNecessary() failed: %v", err)
-
 		errChan <- err
 
 		return
@@ -356,13 +345,6 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, e
 			err = confMap.UpdateFromStrings(confStrings)
 			if nil != err {
 				err = fmt.Errorf("failed to reapply config overrides: %v", err)
-				break
-			}
-
-			// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-			err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-			if nil != err {
-				err = fmt.Errorf("utils.AdjustConfSectionNamespacingAsNecessary() failed: %v", err)
 				break
 			}
 

--- a/ramswift/daemon.go
+++ b/ramswift/daemon.go
@@ -1175,7 +1175,7 @@ func serveNoAuthSwift(confMap conf.ConfMap) {
 	}
 
 	for _, volumeName = range volumeList {
-		volumeSectionName = utils.VolumeNameConfSection(volumeName)
+		volumeSectionName = "Volume:" + volumeName
 		primaryPeerList, err = confMap.FetchOptionValueStringSlice(volumeSectionName, "PrimaryPeer")
 		if nil != err {
 			log.Fatalf("failed fetch of %v.PrimaryPeer: %v", volumeSectionName, err)
@@ -1267,7 +1267,7 @@ func updateConf(confMap conf.ConfMap) {
 	swiftAccountNameListUpdate = make(map[string]bool)
 
 	for _, volumeName = range volumeListUpdate {
-		volumeSectionName = utils.VolumeNameConfSection(volumeName)
+		volumeSectionName = "Volume:" + volumeName
 		primaryPeerList, err = confMap.FetchOptionValueStringSlice(volumeSectionName, "PrimaryPeer")
 		if nil != err {
 			log.Fatalf("failed fetch of %v.PrimaryPeer: %v", volumeSectionName, err)
@@ -1460,12 +1460,6 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, d
 		log.Fatalf("failed to apply config overrides: %v", err)
 	}
 
-	// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-	err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-	if nil != err {
-		log.Fatalf("utils.AdjustConfSectionNamespacingAsNecessary() failed: %v\n", err)
-	}
-
 	// Find out who "we" are
 
 	globals.whoAmI, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
@@ -1528,12 +1522,6 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, d
 			err = confMap.UpdateFromStrings(confStrings)
 			if nil != err {
 				log.Fatalf("failed to reapply config overrides: %v", err)
-			}
-
-			// TODO: Remove call to utils.AdjustConfSectionNamespacingAsNecessary() when appropriate
-			err = utils.AdjustConfSectionNamespacingAsNecessary(confMap)
-			if nil != err {
-				log.Fatalf("utils.AdjustConfSectionNamespacingAsNecessary() failed: %v\n", err)
 			}
 
 			updateConf(confMap)

--- a/utils/api.go
+++ b/utils/api.go
@@ -11,76 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/swiftstack/ProxyFS/conf"
 )
-
-var (
-	volumeNameConfSectionPrefix                  = "Volume:"
-	physicalContinaerLayoutNameConfSectionPrefix = "PhysicalContainerLayout:"
-	flowControlNameConfSectionPrefix             = "FlowControl:"
-	peerNameConfSectionPrefix                    = "Peer:"
-)
-
-// TODO: Remove AdjustConfSectionNamespacingAsNecessary() when no longer needed
-func AdjustConfSectionNamespacingAsNecessary(confMap conf.ConfMap) (err error) {
-	var (
-		namespacedWhoAmISectionExists   bool
-		namespacedWhoAmISectionName     string
-		unNamespacedWhoAmISectionExists bool
-		unNamespacedWhoAmISectionName   string
-	)
-
-	unNamespacedWhoAmISectionName, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
-	if nil != err {
-		return
-	}
-
-	namespacedWhoAmISectionName = "Peer:" + unNamespacedWhoAmISectionName
-
-	_, unNamespacedWhoAmISectionExists = confMap[unNamespacedWhoAmISectionName]
-	_, namespacedWhoAmISectionExists = confMap[namespacedWhoAmISectionName]
-
-	if (!unNamespacedWhoAmISectionExists && !namespacedWhoAmISectionExists) || (unNamespacedWhoAmISectionExists && namespacedWhoAmISectionExists) {
-		err = fmt.Errorf("Precisely one of [%s] or [%s] must exist in confMap", unNamespacedWhoAmISectionName, namespacedWhoAmISectionName)
-		return
-	}
-
-	if unNamespacedWhoAmISectionExists {
-		volumeNameConfSectionPrefix = ""
-		physicalContinaerLayoutNameConfSectionPrefix = ""
-		flowControlNameConfSectionPrefix = ""
-		peerNameConfSectionPrefix = ""
-	} else { // namespacedWhoAmISectionExists
-		volumeNameConfSectionPrefix = "Volume:"
-		physicalContinaerLayoutNameConfSectionPrefix = "PhysicalContainerLayout:"
-		flowControlNameConfSectionPrefix = "FlowControl:"
-		peerNameConfSectionPrefix = "Peer:"
-	}
-
-	err = nil
-	return
-}
-
-func VolumeNameConfSection(volumeName string) (sectionName string) {
-	sectionName = volumeNameConfSectionPrefix + volumeName
-	return
-}
-
-func PhysicalContainerLayoutNameConfSection(physicalContainerLayoutName string) (sectionName string) {
-	sectionName = physicalContinaerLayoutNameConfSectionPrefix + physicalContainerLayoutName
-	return
-}
-
-func FlowControlNameConfSection(flowControlName string) (sectionName string) {
-	sectionName = flowControlNameConfSectionPrefix + flowControlName
-	return
-}
-
-func PeerNameConfSection(peerName string) (sectionName string) {
-	sectionName = peerNameConfSectionPrefix + peerName
-	return
-}
 
 // TryLockMutex is used to support a timeout a the lock request
 type TryLockMutex struct {


### PR DESCRIPTION
Previously, various sections in the .conf were entirely user specified.
This might potentially collide with fixed section names (e.g. Cluster).
So this was changed to prefix such section names with the qualifier for
what it is (e.g. Volume, PhysicalContainerLayout, FlowControl, and Peer)
followed by a colon (':').

This change removes support for the prior unqualified/namespace'd format.