### PR TITLE
Reworked ramswift daemon startup logic

### DIFF
--- a/proxyfsd/daemon.go
+++ b/proxyfsd/daemon.go
@@ -27,9 +27,10 @@ import (
 	"github.com/swiftstack/ProxyFS/swiftclient"
 )
 
-// if signals is empty it means "catch all signals" its possible to catch
-//
-func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, errChan chan error, wg *sync.WaitGroup, execArgs []string, signals ...os.Signal) {
+// Daemon is launched as a GoRoutine that launches ProxyFS. During startup, the parent should read errChan
+// to await Daemon getting to the point where it is ready to handle the specified signal set. Any errors
+// encountered before or after this point will be sent to errChan (and be non-nil of course).
+func Daemon(confFile string, confStrings []string, errChan chan error, wg *sync.WaitGroup, execArgs []string, signals ...os.Signal) {
 	var (
 		confMap        conf.ConfMap
 		err            error
@@ -287,9 +288,8 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, e
 	// if signals is empty it means "catch all signals" its possible to catch
 	signal.Notify(signalChan, signals...)
 
-	if nil != signalHandlerIsArmed {
-		*signalHandlerIsArmed = true
-	}
+	// indicate signal handlers have been armed successfully
+	errChan <- nil
 
 	// Await a signal - reloading confFile each SIGHUP - exiting otherwise
 	for {

--- a/ramswift/daemon.go
+++ b/ramswift/daemon.go
@@ -1433,7 +1433,7 @@ func fetchSwiftInfo(confMap conf.ConfMap) {
 	}
 }
 
-func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, doneChan chan bool, signals ...os.Signal) {
+func Daemon(confFile string, confStrings []string, signalHandlerIsArmedWG *sync.WaitGroup, doneChan chan bool, signals ...os.Signal) {
 	var (
 		confMap        conf.ConfMap
 		err            error
@@ -1502,8 +1502,8 @@ func Daemon(confFile string, confStrings []string, signalHandlerIsArmed *bool, d
 
 	signal.Notify(signalChan, signals...)
 
-	if nil != signalHandlerIsArmed {
-		*signalHandlerIsArmed = true
+	if nil != signalHandlerIsArmedWG {
+		signalHandlerIsArmedWG.Done()
 	}
 
 	// Await a signal - reloading confFile each SIGHUP - exiting otherwise

--- a/ramswift/daemon_test.go
+++ b/ramswift/daemon_test.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
-	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -45,19 +45,17 @@ func TestViaNoAuthClient(t *testing.T) {
 		pipeReader                   *io.PipeReader
 		pipeWriter                   *io.PipeWriter
 		readBuf                      []byte
-		signalHandlerIsArmed         bool
+		signalHandlerIsArmedWG       sync.WaitGroup
 		urlForInfo                   string
 		urlPrefix                    string
 	)
 
-	signalHandlerIsArmed = false
+	signalHandlerIsArmedWG.Add(1)
 	doneChan = make(chan bool, 1) // Must be buffered to avoid race
 
-	go Daemon("/dev/null", confStrings, &signalHandlerIsArmed, doneChan, unix.SIGTERM)
+	go Daemon("/dev/null", confStrings, &signalHandlerIsArmedWG, doneChan, unix.SIGTERM)
 
-	for !signalHandlerIsArmed {
-		time.Sleep(100 * time.Millisecond)
-	}
+	signalHandlerIsArmedWG.Wait()
 
 	// Setup urlPrefix to be "http://127.0.0.1:<SwiftClient.NoAuthTCPPort>/v1/"
 

--- a/saio/etc/samba/smb.conf
+++ b/saio/etc/samba/smb.conf
@@ -1,7 +1,6 @@
 [global]
       security = user
       passdb backend = tdbsam
-      map to guest = nobody
       proxyfs:PrivateIPAddr = 127.0.0.1
       proxyfs:TCPPort = 12345
       proxyfs:FastTCPPort = 32345
@@ -12,7 +11,6 @@
       vfs objects = proxyfs
       proxyfs:volume = CommonVolume
       valid users = swift
-      guest ok = no
       writable = yes
       printable = no
       browseable = yes

--- a/saio/etc/samba/smb.conf
+++ b/saio/etc/samba/smb.conf
@@ -1,6 +1,7 @@
 [global]
       security = user
       passdb backend = tdbsam
+      map to guest = nobody
       proxyfs:PrivateIPAddr = 127.0.0.1
       proxyfs:TCPPort = 12345
       proxyfs:FastTCPPort = 32345
@@ -11,7 +12,7 @@
       vfs objects = proxyfs
       proxyfs:volume = CommonVolume
       valid users = swift
-      public = yes
+      guest ok = no
       writable = yes
       printable = no
       browseable = yes

--- a/saio/vagrant_provision.sh
+++ b/saio/vagrant_provision.sh
@@ -84,6 +84,7 @@ yum -y install fuse
 echo "export GOPATH=/vagrant" >> ~vagrant/.bash_profile
 echo "export PATH=\$PATH:\$GOPATH/bin" >> ~vagrant/.bash_profile
 echo "alias cdpfs=\"cd \$GOPATH/src/github.com/swiftstack/ProxyFS\"" >> ~vagrant/.bash_profile
+echo "alias goclean=\"go clean;go clean --cache;go clean --testcache\"" >> ~vagrant/.bash_profile
 echo "user_allow_other" >> /etc/fuse.conf
 
 # Setup Samba


### PR DESCRIPTION
Previously, ramswift daemon was launched and the "parent" would spin
waiting for a bool passed to each daemon was set to true. The Go
Race Detector would flag this as a race condition... even though it
couldn't actually be since: a) the bool was initialized to false
prior to the daemon's launch, b) only the daemon set it to true, and
c) only the "parent" read the bool awaiting it to be true. Still, this
polling can be cleanly/safely replaced with a sync.WaitGroup.

Note that the proxyfsd.Daemon() launch synchronization works the same
way as did ramswift... but the logic of checking for errors will require
a bit more care in replacing this "racey" pattern.