### PR TITLE
Introduction of new pfsalived Liveness Detector

### DIFF
--- a/GoMakefile
+++ b/GoMakefile
@@ -23,9 +23,6 @@ fmt:
 generate:
 	go generate $(gosubdir)
 
-get:
-	go get $(gosubdir)
-
 install:
 	go install -gcflags "-N -l" $(gosubdir)
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ gopkgsubdirs = \
 	stats \
 	statslogger \
 	swiftclient \
-	utils
+	utils \
+	version
 
 gobinsubdirs = \
 	cleanproxyfs \

--- a/httpserver/.gitignore
+++ b/httpserver/.gitignore
@@ -9,5 +9,4 @@ open_iconic_dot_svg_.go
 open_iconic_dot_ttf_.go
 open_iconic_dot_woff_.go
 popper_dot_min_dot_js_.go
-proxyfs_version.go
 styles_dot_css_.go

--- a/httpserver/Makefile
+++ b/httpserver/Makefile
@@ -12,7 +12,6 @@ generatedfiles := \
 	open_iconic_dot_ttf_.go \
 	open_iconic_dot_woff_.go \
 	popper_dot_min_dot_js_.go \
-	proxyfs_version.go \
 	styles_dot_css_.go
 
 include ../GoMakefile

--- a/httpserver/request_handler.go
+++ b/httpserver/request_handler.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/swiftstack/sortedmap"
+
 	"github.com/swiftstack/ProxyFS/bucketstats"
 	"github.com/swiftstack/ProxyFS/fs"
 	"github.com/swiftstack/ProxyFS/halter"
@@ -21,7 +23,7 @@ import (
 	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/utils"
-	"github.com/swiftstack/sortedmap"
+	"github.com/swiftstack/ProxyFS/version"
 )
 
 type httpRequestHandler struct{}
@@ -192,7 +194,7 @@ func doGet(responseWriter http.ResponseWriter, request *http.Request) {
 	case "/version" == path:
 		responseWriter.Header().Set("Content-Type", "text/plain")
 		responseWriter.WriteHeader(http.StatusOK)
-		_, _ = responseWriter.Write([]byte(proxyfsVersion))
+		_, _ = responseWriter.Write([]byte(version.ProxyFSVersion))
 	case strings.HasPrefix(request.URL.Path, "/trigger"):
 		doGetOfTrigger(responseWriter, request)
 	case strings.HasPrefix(request.URL.Path, "/volume"):
@@ -205,7 +207,7 @@ func doGet(responseWriter http.ResponseWriter, request *http.Request) {
 func doGetOfIndexDotHTML(responseWriter http.ResponseWriter, request *http.Request) {
 	responseWriter.Header().Set("Content-Type", "text/html")
 	responseWriter.WriteHeader(http.StatusOK)
-	_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(indexDotHTMLTemplate, proxyfsVersion, globals.ipAddrTCPPort)))
+	_, _ = responseWriter.Write([]byte(fmt.Sprintf(indexDotHTMLTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort)))
 }
 
 func doGetOfConfig(responseWriter http.ResponseWriter, request *http.Request) {
@@ -245,17 +247,6 @@ func doGetOfConfig(responseWriter http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	paramList, ok = request.URL.Query()["compact"]
-	if ok {
-		if 0 == len(paramList) {
-			sendPackedConfig = false
-		} else {
-			sendPackedConfig = !((paramList[0] == "") || (paramList[0] == "0") || (paramList[0] == "false"))
-		}
-	} else {
-		sendPackedConfig = false
-	}
-
 	confMapJSONPacked, _ = json.Marshal(globals.confMap)
 
 	if formatResponseAsJSON {
@@ -267,13 +258,13 @@ func doGetOfConfig(responseWriter http.ResponseWriter, request *http.Request) {
 		} else {
 			json.Indent(&confMapJSON, confMapJSONPacked, "", "\t")
 			_, _ = responseWriter.Write(confMapJSON.Bytes())
-			_, _ = responseWriter.Write(utils.StringToByteSlice("\n"))
+			_, _ = responseWriter.Write([]byte("\n"))
 		}
 	} else {
 		responseWriter.Header().Set("Content-Type", "text/html")
 		responseWriter.WriteHeader(http.StatusOK)
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(configTemplate, proxyfsVersion, globals.ipAddrTCPPort, utils.ByteSliceToString(confMapJSONPacked))))
+		_, _ = responseWriter.Write([]byte(fmt.Sprintf(configTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, utils.ByteSliceToString(confMapJSONPacked))))
 	}
 }
 
@@ -394,7 +385,7 @@ func doGetOfMetrics(responseWriter http.ResponseWriter, request *http.Request) {
 			responseWriter.Header().Set("Content-Type", "text/html")
 			responseWriter.WriteHeader(http.StatusOK)
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(metricsTemplate, proxyfsVersion, globals.ipAddrTCPPort, utils.ByteSliceToString(metricsJSONPacked))))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(metricsTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, utils.ByteSliceToString(metricsJSONPacked))))
 		} else {
 			responseWriter.Header().Set("Content-Type", "application/json")
 			responseWriter.WriteHeader(http.StatusOK)
@@ -415,7 +406,7 @@ func doGetOfMetrics(responseWriter http.ResponseWriter, request *http.Request) {
 			} else {
 				json.Indent(&metricsJSON, metricsJSONPacked, "", "\t")
 				_, _ = responseWriter.Write(metricsJSON.Bytes())
-				_, _ = responseWriter.Write(utils.StringToByteSlice("\n"))
+				_, _ = responseWriter.Write([]byte("\n"))
 			}
 		}
 	} else {
@@ -443,8 +434,7 @@ func doGetOfStats(responseWriter http.ResponseWriter, request *http.Request) {
 	responseWriter.Header().Set("Content-Type", "text/plain")
 	responseWriter.WriteHeader(http.StatusOK)
 
-	_, _ = responseWriter.Write(utils.StringToByteSlice(
-		bucketstats.SprintStats(bucketstats.StatFormatParsable1, "*", "*")))
+	_, _ = responseWriter.Write([]byte(bucketstats.SprintStats(bucketstats.StatFormatParsable1, "*", "*")))
 }
 
 func doGetOfArmDisarmTrigger(responseWriter http.ResponseWriter, request *http.Request) {
@@ -459,15 +449,15 @@ func doGetOfArmDisarmTrigger(responseWriter http.ResponseWriter, request *http.R
 	responseWriter.Header().Set("Content-Type", "text/html")
 	responseWriter.WriteHeader(http.StatusOK)
 
-	_, _ = responseWriter.Write(utils.StringToByteSlice("<!DOCTYPE html>\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("<html lang=\"en\">\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("  <head>\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf("    <title>Trigger Arm/Disarm Page</title>\n")))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("  </head>\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("  <body>\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("    <form method=\"post\" action=\"/arm-disarm-trigger\">\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("      <select name=\"haltLabelString\">\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("        <option value=\"\">-- select one --</option>\n"))
+	_, _ = responseWriter.Write([]byte("<!DOCTYPE html>\n"))
+	_, _ = responseWriter.Write([]byte("<html lang=\"en\">\n"))
+	_, _ = responseWriter.Write([]byte("  <head>\n"))
+	_, _ = responseWriter.Write([]byte(fmt.Sprintf("    <title>Trigger Arm/Disarm Page</title>\n")))
+	_, _ = responseWriter.Write([]byte("  </head>\n"))
+	_, _ = responseWriter.Write([]byte("  <body>\n"))
+	_, _ = responseWriter.Write([]byte("    <form method=\"post\" action=\"/arm-disarm-trigger\">\n"))
+	_, _ = responseWriter.Write([]byte("      <select name=\"haltLabelString\">\n"))
+	_, _ = responseWriter.Write([]byte("        <option value=\"\">-- select one --</option>\n"))
 
 	availableTriggers = halter.List()
 
@@ -483,15 +473,15 @@ func doGetOfArmDisarmTrigger(responseWriter http.ResponseWriter, request *http.R
 			err = fmt.Errorf("triggersLLRB.Put(%v, true) returned ok == false", haltTriggerString)
 			logger.Fatalf("HTTP Server Logic Error: %v", err)
 		}
-		_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf("        <option value=\"%v\">%v</option>\n", haltTriggerString, haltTriggerString)))
+		_, _ = responseWriter.Write([]byte(fmt.Sprintf("        <option value=\"%v\">%v</option>\n", haltTriggerString, haltTriggerString)))
 	}
 
-	_, _ = responseWriter.Write(utils.StringToByteSlice("      </select>\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("      <input type=\"number\" name=\"haltAfterCount\" min=\"0\" max=\"4294967295\" required>\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("      <input type=\"submit\">\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("    </form>\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("  </body>\n"))
-	_, _ = responseWriter.Write(utils.StringToByteSlice("</html>\n"))
+	_, _ = responseWriter.Write([]byte("      </select>\n"))
+	_, _ = responseWriter.Write([]byte("      <input type=\"number\" name=\"haltAfterCount\" min=\"0\" max=\"4294967295\" required>\n"))
+	_, _ = responseWriter.Write([]byte("      <input type=\"submit\">\n"))
+	_, _ = responseWriter.Write([]byte("    </form>\n"))
+	_, _ = responseWriter.Write([]byte("  </body>\n"))
+	_, _ = responseWriter.Write([]byte("</html>\n"))
 }
 
 func doGetOfTrigger(responseWriter http.ResponseWriter, request *http.Request) {
@@ -597,9 +587,9 @@ func doGetOfTrigger(responseWriter http.ResponseWriter, request *http.Request) {
 		responseWriter.Header().Set("Content-Type", "text/html")
 		responseWriter.WriteHeader(http.StatusOK)
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(triggerTopTemplate, proxyfsVersion, globals.ipAddrTCPPort)))
-		_, _ = responseWriter.Write(utils.StringToByteSlice(triggerAllArmedOrDisarmedActiveString))
-		_, _ = responseWriter.Write(utils.StringToByteSlice(triggerTableTop))
+		_, _ = responseWriter.Write([]byte(fmt.Sprintf(triggerTopTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort)))
+		_, _ = responseWriter.Write([]byte(triggerAllArmedOrDisarmedActiveString))
+		_, _ = responseWriter.Write([]byte(triggerTableTop))
 
 		lenTriggersLLRB, err = triggersLLRB.Len()
 		if nil != err {
@@ -621,10 +611,10 @@ func doGetOfTrigger(responseWriter http.ResponseWriter, request *http.Request) {
 			haltTriggerString = key.(string)
 			haltTriggerCount = value.(uint32)
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(triggerTableRowTemplate, haltTriggerString, haltTriggerCount)))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(triggerTableRowTemplate, haltTriggerString, haltTriggerCount)))
 		}
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(triggerBottom))
+		_, _ = responseWriter.Write([]byte(triggerBottom))
 	case 2:
 		// Form: /trigger/<trigger-name>
 
@@ -635,7 +625,7 @@ func doGetOfTrigger(responseWriter http.ResponseWriter, request *http.Request) {
 			responseWriter.Header().Set("Content-Type", "text/plain")
 			responseWriter.WriteHeader(http.StatusOK)
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf("%v\n", haltTriggerCount)))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf("%v\n", haltTriggerCount)))
 		} else {
 			responseWriter.WriteHeader(http.StatusNotFound)
 		}
@@ -760,19 +750,19 @@ func doGetOfVolume(responseWriter http.ResponseWriter, request *http.Request) {
 			} else {
 				json.Indent(&volumeListJSON, volumeListJSONPacked, "", "\t")
 				_, _ = responseWriter.Write(volumeListJSON.Bytes())
-				_, _ = responseWriter.Write(utils.StringToByteSlice("\n"))
+				_, _ = responseWriter.Write([]byte("\n"))
 			}
 		} else {
 			responseWriter.Header().Set("Content-Type", "text/html")
 			responseWriter.WriteHeader(http.StatusOK)
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(volumeListTopTemplate, proxyfsVersion, globals.ipAddrTCPPort)))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(volumeListTopTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort)))
 
 			for volumeListIndex, volumeName = range volumeList {
-				_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(volumeListPerVolumeTemplate, volumeName)))
+				_, _ = responseWriter.Write([]byte(fmt.Sprintf(volumeListPerVolumeTemplate, volumeName)))
 			}
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(volumeListBottom))
+			_, _ = responseWriter.Write([]byte(volumeListBottom))
 		}
 
 		return
@@ -849,7 +839,7 @@ func doExtentMap(responseWriter http.ResponseWriter, request *http.Request, requ
 		responseWriter.Header().Set("Content-Type", "text/html")
 		responseWriter.WriteHeader(http.StatusOK)
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(extentMapTemplate, proxyfsVersion, globals.ipAddrTCPPort, requestState.volume.name, "null", "null", "false")))
+		_, _ = responseWriter.Write([]byte(fmt.Sprintf(extentMapTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, requestState.volume.name, "null", "null", "false")))
 		return
 	}
 
@@ -870,7 +860,7 @@ func doExtentMap(responseWriter http.ResponseWriter, request *http.Request, requ
 				responseWriter.Header().Set("Content-Type", "text/html")
 				responseWriter.WriteHeader(http.StatusOK)
 
-				_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(extentMapTemplate, proxyfsVersion, globals.ipAddrTCPPort, requestState.volume.name, "null", pathDoubleQuoted, "true")))
+				_, _ = responseWriter.Write([]byte(fmt.Sprintf(extentMapTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, requestState.volume.name, "null", pathDoubleQuoted, "true")))
 				return
 			}
 		}
@@ -885,7 +875,7 @@ func doExtentMap(responseWriter http.ResponseWriter, request *http.Request, requ
 			responseWriter.Header().Set("Content-Type", "text/html")
 			responseWriter.WriteHeader(http.StatusOK)
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(extentMapTemplate, proxyfsVersion, globals.ipAddrTCPPort, requestState.volume.name, "null", pathDoubleQuoted, "true")))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(extentMapTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, requestState.volume.name, "null", pathDoubleQuoted, "true")))
 			return
 		}
 	}
@@ -920,13 +910,13 @@ func doExtentMap(responseWriter http.ResponseWriter, request *http.Request, requ
 		} else {
 			json.Indent(&extentMapJSONBuffer, extentMapJSONPacked, "", "\t")
 			_, _ = responseWriter.Write(extentMapJSONBuffer.Bytes())
-			_, _ = responseWriter.Write(utils.StringToByteSlice("\n"))
+			_, _ = responseWriter.Write([]byte("\n"))
 		}
 	} else {
 		responseWriter.Header().Set("Content-Type", "text/html")
 		responseWriter.WriteHeader(http.StatusOK)
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(extentMapTemplate, proxyfsVersion, globals.ipAddrTCPPort, requestState.volume.name, utils.ByteSliceToString(extentMapJSONPacked), pathDoubleQuoted, "false")))
+		_, _ = responseWriter.Write([]byte(fmt.Sprintf(extentMapTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, requestState.volume.name, utils.ByteSliceToString(extentMapJSONPacked), pathDoubleQuoted, "false")))
 	}
 }
 
@@ -1028,7 +1018,7 @@ func doJob(jobType jobTypeType, responseWriter http.ResponseWriter, request *htt
 			} else {
 				json.Indent(&jobsIDListJSONBuffer, jobsIDListJSONPacked, "", "\t")
 				_, _ = responseWriter.Write(jobsIDListJSONBuffer.Bytes())
-				_, _ = responseWriter.Write(utils.StringToByteSlice("\n"))
+				_, _ = responseWriter.Write([]byte("\n"))
 			}
 		} else {
 			responseWriter.Header().Set("Content-Type", "text/html")
@@ -1036,9 +1026,9 @@ func doJob(jobType jobTypeType, responseWriter http.ResponseWriter, request *htt
 
 			switch jobType {
 			case fsckJobType:
-				_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobsTopTemplate, proxyfsVersion, globals.ipAddrTCPPort, volumeName, "FSCK")))
+				_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobsTopTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, volumeName, "FSCK")))
 			case scrubJobType:
-				_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobsTopTemplate, proxyfsVersion, globals.ipAddrTCPPort, volumeName, "SCRUB")))
+				_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobsTopTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, volumeName, "SCRUB")))
 			}
 
 			for jobsIndex = jobsCount - 1; jobsIndex >= 0; jobsIndex-- {
@@ -1067,9 +1057,9 @@ func doJob(jobType jobTypeType, responseWriter http.ResponseWriter, request *htt
 				if jobRunning == job.state {
 					switch jobType {
 					case fsckJobType:
-						_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobsPerRunningJobTemplate, jobID, job.startTime.Format(time.RFC3339), volumeName, "fsck")))
+						_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobsPerRunningJobTemplate, jobID, job.startTime.Format(time.RFC3339), volumeName, "fsck")))
 					case scrubJobType:
-						_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobsPerRunningJobTemplate, jobID, job.startTime.Format(time.RFC3339), volumeName, "scrub")))
+						_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobsPerRunningJobTemplate, jobID, job.startTime.Format(time.RFC3339), volumeName, "scrub")))
 					}
 				} else {
 					switch job.state {
@@ -1086,25 +1076,25 @@ func doJob(jobType jobTypeType, responseWriter http.ResponseWriter, request *htt
 
 					switch jobType {
 					case fsckJobType:
-						_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobPerJobTemplate, jobID, job.startTime.Format(time.RFC3339), job.endTime.Format(time.RFC3339), volumeName, "fsck")))
+						_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobPerJobTemplate, jobID, job.startTime.Format(time.RFC3339), job.endTime.Format(time.RFC3339), volumeName, "fsck")))
 					case scrubJobType:
-						_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobPerJobTemplate, jobID, job.startTime.Format(time.RFC3339), job.endTime.Format(time.RFC3339), volumeName, "scrub")))
+						_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobPerJobTemplate, jobID, job.startTime.Format(time.RFC3339), job.endTime.Format(time.RFC3339), volumeName, "scrub")))
 					}
 				}
 			}
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(jobsListBottom))
+			_, _ = responseWriter.Write([]byte(jobsListBottom))
 
 			if inactive {
 				switch jobType {
 				case fsckJobType:
-					_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobsStartJobButtonTemplate, volumeName, "fsck")))
+					_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobsStartJobButtonTemplate, volumeName, "fsck")))
 				case scrubJobType:
-					_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobsStartJobButtonTemplate, volumeName, "scrub")))
+					_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobsStartJobButtonTemplate, volumeName, "scrub")))
 				}
 			}
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(jobsBottom))
+			_, _ = responseWriter.Write([]byte(jobsBottom))
 		}
 
 		return
@@ -1164,7 +1154,7 @@ func doJob(jobType jobTypeType, responseWriter http.ResponseWriter, request *htt
 		} else {
 			json.Indent(&jobStatusJSONBuffer, jobStatusJSONPacked, "", "\t")
 			_, _ = responseWriter.Write(jobStatusJSONBuffer.Bytes())
-			_, _ = responseWriter.Write(utils.StringToByteSlice("\n"))
+			_, _ = responseWriter.Write([]byte("\n"))
 		}
 	} else {
 		responseWriter.Header().Set("Content-Type", "text/html")
@@ -1172,9 +1162,9 @@ func doJob(jobType jobTypeType, responseWriter http.ResponseWriter, request *htt
 
 		switch jobType {
 		case fsckJobType:
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobTemplate, proxyfsVersion, globals.ipAddrTCPPort, volumeName, "FSCK", "fsck", job.id, utils.ByteSliceToString(jobStatusJSONPacked))))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, volumeName, "FSCK", "fsck", job.id, utils.ByteSliceToString(jobStatusJSONPacked))))
 		case scrubJobType:
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(jobTemplate, proxyfsVersion, globals.ipAddrTCPPort, volumeName, "SCRUB", "scrub", job.id, utils.ByteSliceToString(jobStatusJSONPacked))))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(jobTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, volumeName, "SCRUB", "scrub", job.id, utils.ByteSliceToString(jobStatusJSONPacked))))
 		}
 	}
 
@@ -1256,25 +1246,25 @@ func doLayoutReport(responseWriter http.ResponseWriter, request *http.Request, r
 		} else {
 			json.Indent(&layoutReportSetJSON, layoutReportSetJSONPacked, "", "\t")
 			_, _ = responseWriter.Write(layoutReportSetJSON.Bytes())
-			_, _ = responseWriter.Write(utils.StringToByteSlice("\n"))
+			_, _ = responseWriter.Write([]byte("\n"))
 		}
 	} else {
 		responseWriter.Header().Set("Content-Type", "text/html")
 		responseWriter.WriteHeader(http.StatusOK)
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(layoutReportTopTemplate, proxyfsVersion, globals.ipAddrTCPPort, requestState.volume.name)))
+		_, _ = responseWriter.Write([]byte(fmt.Sprintf(layoutReportTopTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, requestState.volume.name)))
 
 		for _, layoutReportSetElement = range layoutReportSet {
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(layoutReportTableTopTemplate, layoutReportSetElement.TreeName)))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(layoutReportTableTopTemplate, layoutReportSetElement.TreeName)))
 
 			for layoutReportIndex = 0; layoutReportIndex < len(layoutReportSetElement.LayoutReport); layoutReportIndex++ {
-				_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(layoutReportTableRowTemplate, layoutReportSetElement.LayoutReport[layoutReportIndex].ObjectNumber, layoutReportSetElement.LayoutReport[layoutReportIndex].ObjectBytes)))
+				_, _ = responseWriter.Write([]byte(fmt.Sprintf(layoutReportTableRowTemplate, layoutReportSetElement.LayoutReport[layoutReportIndex].ObjectNumber, layoutReportSetElement.LayoutReport[layoutReportIndex].ObjectBytes)))
 			}
 
-			_, _ = responseWriter.Write(utils.StringToByteSlice(layoutReportTableBottom))
+			_, _ = responseWriter.Write([]byte(layoutReportTableBottom))
 		}
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(layoutReportBottom))
+		_, _ = responseWriter.Write([]byte(layoutReportBottom))
 	}
 }
 
@@ -1339,19 +1329,19 @@ func doGetOfSnapShot(responseWriter http.ResponseWriter, request *http.Request, 
 		} else {
 			json.Indent(&listJSON, listJSONPacked, "", "\t")
 			_, _ = responseWriter.Write(listJSON.Bytes())
-			_, _ = responseWriter.Write(utils.StringToByteSlice("\n"))
+			_, _ = responseWriter.Write([]byte("\n"))
 		}
 	} else {
 		responseWriter.Header().Set("Content-Type", "text/html")
 		responseWriter.WriteHeader(http.StatusOK)
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(snapShotsTopTemplate, proxyfsVersion, globals.ipAddrTCPPort, requestState.volume.name)))
+		_, _ = responseWriter.Write([]byte(fmt.Sprintf(snapShotsTopTemplate, version.ProxyFSVersion, globals.ipAddrTCPPort, requestState.volume.name)))
 
 		for _, snapShot = range list {
-			_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(snapShotsPerSnapShotTemplate, snapShot.ID, snapShot.Time.Format(time.RFC3339), snapShot.Name)))
+			_, _ = responseWriter.Write([]byte(fmt.Sprintf(snapShotsPerSnapShotTemplate, snapShot.ID, snapShot.Time.Format(time.RFC3339), snapShot.Name)))
 		}
 
-		_, _ = responseWriter.Write(utils.StringToByteSlice(fmt.Sprintf(snapShotsBottomTemplate, requestState.volume.name)))
+		_, _ = responseWriter.Write([]byte(fmt.Sprintf(snapShotsBottomTemplate, requestState.volume.name)))
 	}
 }
 
@@ -1730,7 +1720,7 @@ func sortedTwoColumnResponseWriter(llrb sortedmap.LLRBTree, responseWriter http.
 		keyAsString = keyAsKey.(string)
 		valueAsString = valueAsValue.(string)
 		line = fmt.Sprintf(format, keyAsString, valueAsString)
-		_, _ = responseWriter.Write(utils.StringToByteSlice(line))
+		_, _ = responseWriter.Write([]byte(line))
 	}
 }
 

--- a/httpserver/static-content.go
+++ b/httpserver/static-content.go
@@ -1,19 +1,19 @@
 package httpserver
 
-//go:generate go run static-content/make_static_content.go httpserver stylesDotCSS              text/css                      s static-content/styles.css                                         styles_dot_css_.go
+//go:generate make-static-content httpserver stylesDotCSS              text/css                      s static-content/styles.css                                         styles_dot_css_.go
 
-//go:generate go run static-content/make_static_content.go httpserver jsontreeDotJS             application/javascript        s static-content/jsontree.js                                        jsontree_dot_js_.go
+//go:generate make-static-content httpserver jsontreeDotJS             application/javascript        s static-content/jsontree.js                                        jsontree_dot_js_.go
 
-//go:generate go run static-content/make_static_content.go httpserver bootstrapDotCSS           text/css                      s static-content/bootstrap.min.css                                  bootstrap_dot_min_dot_css_.go
+//go:generate make-static-content httpserver bootstrapDotCSS           text/css                      s static-content/bootstrap.min.css                                  bootstrap_dot_min_dot_css_.go
 
-//go:generate go run static-content/make_static_content.go httpserver bootstrapDotJS            application/javascript        s static-content/bootstrap.min.js                                   bootstrap_dot_min_dot_js_.go
-//go:generate go run static-content/make_static_content.go httpserver jqueryDotJS               application/javascript        s static-content/jquery-3.2.1.min.js                                jquery_underline_3_dot_2_dot_1_dot_min_dot_js_.go
-//go:generate go run static-content/make_static_content.go httpserver popperDotJS               application/javascript        b static-content/popper.min.js                                      popper_dot_min_dot_js_.go
+//go:generate make-static-content httpserver bootstrapDotJS            application/javascript        s static-content/bootstrap.min.js                                   bootstrap_dot_min_dot_js_.go
+//go:generate make-static-content httpserver jqueryDotJS               application/javascript        s static-content/jquery-3.2.1.min.js                                jquery_underline_3_dot_2_dot_1_dot_min_dot_js_.go
+//go:generate make-static-content httpserver popperDotJS               application/javascript        b static-content/popper.min.js                                      popper_dot_min_dot_js_.go
 
-//go:generate go run static-content/make_static_content.go httpserver openIconicBootstrapDotCSS text/css                      s static-content/open-iconic/font/css/open-iconic-bootstrap.min.css open_iconic_bootstrap_dot_css_.go
+//go:generate make-static-content httpserver openIconicBootstrapDotCSS text/css                      s static-content/open-iconic/font/css/open-iconic-bootstrap.min.css open_iconic_bootstrap_dot_css_.go
 
-//go:generate go run static-content/make_static_content.go httpserver openIconicDotEOT          application/vnd.ms-fontobject b static-content/open-iconic/font/fonts/open-iconic.eot             open_iconic_dot_eot_.go
-//go:generate go run static-content/make_static_content.go httpserver openIconicDotOTF          application/font-sfnt         b static-content/open-iconic/font/fonts/open-iconic.otf             open_iconic_dot_otf_.go
-//go:generate go run static-content/make_static_content.go httpserver openIconicDotSVG          image/svg+xml                 s static-content/open-iconic/font/fonts/open-iconic.svg             open_iconic_dot_svg_.go
-//go:generate go run static-content/make_static_content.go httpserver openIconicDotTTF          application/font-sfnt         b static-content/open-iconic/font/fonts/open-iconic.ttf             open_iconic_dot_ttf_.go
-//go:generate go run static-content/make_static_content.go httpserver openIconicDotWOFF         application/font-woff         b static-content/open-iconic/font/fonts/open-iconic.woff            open_iconic_dot_woff_.go
+//go:generate make-static-content httpserver openIconicDotEOT          application/vnd.ms-fontobject b static-content/open-iconic/font/fonts/open-iconic.eot             open_iconic_dot_eot_.go
+//go:generate make-static-content httpserver openIconicDotOTF          application/font-sfnt         b static-content/open-iconic/font/fonts/open-iconic.otf             open_iconic_dot_otf_.go
+//go:generate make-static-content httpserver openIconicDotSVG          image/svg+xml                 s static-content/open-iconic/font/fonts/open-iconic.svg             open_iconic_dot_svg_.go
+//go:generate make-static-content httpserver openIconicDotTTF          application/font-sfnt         b static-content/open-iconic/font/fonts/open-iconic.ttf             open_iconic_dot_ttf_.go
+//go:generate make-static-content httpserver openIconicDotWOFF         application/font-woff         b static-content/open-iconic/font/fonts/open-iconic.woff            open_iconic_dot_woff_.go

--- a/httpserver/static-data.go
+++ b/httpserver/static-data.go
@@ -1,3 +1,0 @@
-package httpserver
-
-//go:generate go run static-data/make_static_data.go httpserver proxyfs_version.go

--- a/make-static-content/Makefile
+++ b/make-static-content/Makefile
@@ -1,0 +1,3 @@
+gosubdir := github.com/swiftstack/ProxyFS/make-static-content
+
+include ../GoMakefile

--- a/make-static-content/dummy_test.go
+++ b/make-static-content/dummy_test.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+}

--- a/make-static-content/main.go
+++ b/make-static-content/main.go
@@ -9,16 +9,16 @@ import (
 const bytesPerLine = 16
 
 func usage() {
-	fmt.Println("go run make_static_content.go -?")
+	fmt.Println("make-static-content -?")
 	fmt.Println("   Prints this help text")
-	fmt.Println("go run make_static_content.go <packageName> <contentName> <contentType> <contentFormat> <srcFile> <dstFile.go>")
+	fmt.Println("make-static-content <packageName> <contentName> <contentType> <contentFormat> <srcFile> <dstFile.go>")
 	fmt.Println("   <packageName>   is the name of the ultimate package for <dstFile.go>")
 	fmt.Println("   <contentName>   is the basename of the desired content resource")
 	fmt.Println("   <contentType>   is the string to record as the static content's Content-Type")
 	fmt.Println("   <contentFormat> indicates whether the static content is a string (\"s\") or a []byte (\"b\")")
 	fmt.Println("   <srcFile>       is the path to the static content to be embedded")
 	fmt.Println("   <dstFile.go>    is the name of the generated .go source file containing:")
-	fmt.Println("                     <contentName>ContentType string holding value    of <contentType>")
+	fmt.Println("                     <contentName>ContentType string holding value of <contentType>")
 	fmt.Println("                     <contentName>Content     string or []byte holding contents of <srcFile>")
 }
 

--- a/pfsalived/Makefile
+++ b/pfsalived/Makefile
@@ -1,0 +1,3 @@
+gosubdir := github.com/swiftstack/ProxyFS/pfsalived
+
+include ../GoMakefile

--- a/pfsalived/dummy_test.go
+++ b/pfsalived/dummy_test.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+}

--- a/pfsalived/html_templates.go
+++ b/pfsalived/html_templates.go
@@ -1,0 +1,14 @@
+package main
+
+const indexDotHTML string = `<!doctype html>
+<html lang="en">
+  <head>
+    <title>ProxyFS Liveness Detector</title>
+  </head>
+  <body>
+  <a href="/config">Configuration</a>
+  <a href="/status">Status Report</a>
+  <a href="/version">Version</a>
+  </body>
+</html>
+`

--- a/pfsalived/macpfsalived0.conf
+++ b/pfsalived/macpfsalived0.conf
@@ -1,0 +1,9 @@
+# Peer 0's .conf file
+
+[AliveDaemon]
+WhoAmI:        Peer0
+PeersToWatch:  Peer0
+WatchInterval: 5s
+TCPPort:       15432
+
+.include ../proxyfsd/macproxyfsd0.conf

--- a/pfsalived/main.go
+++ b/pfsalived/main.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/version"
+)
+
+type httpRequestHandler struct{}
+
+const (
+	volumeStateAlive   = "alive"
+	volumeStateDead    = "dead"
+	volumeStateUnknown = "unknown"
+)
+
+type volumeStruct struct {
+	peer          *peerStruct
+	next          *volumeStruct // circular linked list currently pointed to by globalsStruct.volumesToWatch
+	Name          string
+	State         string
+	LastCheckTime time.Time
+}
+
+type peerStruct struct {
+	Name           string
+	PublicIPAddr   string
+	PrivateIPAddr  string
+	VolumesToWatch map[string]*volumeStruct // key == volumeStruct.name
+}
+
+type globalsStruct struct {
+	confMap           conf.ConfMap
+	whoAmI            string
+	peersToWatch      map[string]*peerStruct // key == peerStruct.name
+	volumesToWatch    *volumeStruct          // links to next volumeStruct to examine
+	volumesToWatchLen time.Duration          // using this type makes pollingInterval computation avoid casting
+	pollingInterval   time.Duration          // volumesToWatchLen / AliveDaemon.WatchInterval
+	tcpPort           uint16
+	ipAddr            string
+	ipAddrTCPPort     string
+	netListener       net.Listener
+	childrenWG        sync.WaitGroup
+}
+
+var globals globalsStruct
+
+func main() {
+	var (
+		args          []string
+		err           error
+		ok            bool
+		peer          *peerStruct
+		peerName      string
+		peersToWatch  []string
+		volume        *volumeStruct
+		volumeList    []string
+		volumeName    string
+		watchInterval time.Duration
+	)
+
+	// Parse arguments
+
+	args = os.Args[1:]
+
+	// Check that os.Args[1] was supplied... it might be a .conf or an option list (followed by a .conf)
+	if 0 == len(args) {
+		log.Fatalf("No .conf file specified")
+	}
+
+	globals.confMap, err = conf.MakeConfMapFromFile(args[0])
+	if nil != err {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Update confMap with any extra os.Args supplied
+	err = globals.confMap.UpdateFromStrings(args[1:])
+	if nil != err {
+		log.Fatalf("Failed to load config overrides: %v", err)
+	}
+
+	// Process resultant confMap
+
+	globals.whoAmI, err = globals.confMap.FetchOptionValueString("AliveDaemon", "WhoAmI")
+	if nil != err {
+		log.Fatal(err)
+	}
+
+	peersToWatch, err = globals.confMap.FetchOptionValueStringSlice("AliveDaemon", "PeersToWatch")
+	if nil != err {
+		log.Fatal(err)
+	}
+
+	globals.peersToWatch = make(map[string]*peerStruct)
+
+	for _, peerName = range peersToWatch {
+		peer = &peerStruct{
+			Name:           peerName,
+			VolumesToWatch: make(map[string]*volumeStruct),
+		}
+		peer.PublicIPAddr, err = globals.confMap.FetchOptionValueString("Peer:"+peerName, "PublicIPAddr")
+		if nil != err {
+			log.Fatal(err)
+		}
+		peer.PrivateIPAddr, err = globals.confMap.FetchOptionValueString("Peer:"+peerName, "PrivateIPAddr")
+		if nil != err {
+			log.Fatal(err)
+		}
+		globals.peersToWatch[peer.Name] = peer
+	}
+
+	volumeList, err = globals.confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
+	if nil != err {
+		log.Fatal(err)
+	}
+
+	globals.volumesToWatch = nil
+	globals.volumesToWatchLen = time.Duration(0)
+
+	for _, volumeName = range volumeList {
+		peerName, err = globals.confMap.FetchOptionValueString("Volume:"+volumeName, "PrimaryPeer")
+		if nil != err {
+			log.Fatal(err)
+		}
+		peer, ok = globals.peersToWatch[peerName]
+		if ok {
+			volume = &volumeStruct{
+				peer:          peer,
+				next:          globals.volumesToWatch,
+				Name:          volumeName,
+				State:         volumeStateUnknown,
+				LastCheckTime: time.Now(),
+			}
+			if 0 == globals.volumesToWatchLen {
+				volume.next = volume
+			} else {
+				globals.volumesToWatch.next = volume
+			}
+			globals.volumesToWatch = volume
+			globals.volumesToWatchLen++
+			peer.VolumesToWatch[volume.Name] = volume
+		}
+	}
+
+	if 0 == globals.volumesToWatchLen {
+		log.Fatalf("No volumes to watch")
+	}
+
+	watchInterval, err = globals.confMap.FetchOptionValueDuration("AliveDaemon", "WatchInterval")
+	if nil != err {
+		log.Fatal(err)
+	}
+
+	globals.pollingInterval = watchInterval / globals.volumesToWatchLen
+
+	globals.tcpPort, err = globals.confMap.FetchOptionValueUint16("AliveDaemon", "TCPPort")
+	if nil != err {
+		log.Fatal(err)
+	}
+
+	globals.ipAddr, err = globals.confMap.FetchOptionValueString("Peer:"+globals.whoAmI, "PrivateIPAddr")
+	if nil != err {
+		log.Fatal(err)
+	}
+
+	globals.ipAddrTCPPort = net.JoinHostPort(globals.ipAddr, strconv.Itoa(int(globals.tcpPort)))
+
+	globals.netListener, err = net.Listen("tcp", globals.ipAddrTCPPort)
+	if nil != err {
+		log.Fatal(err)
+	}
+
+	globals.childrenWG.Add(1)
+
+	go doPolling()
+	go serveHTTP()
+
+	globals.childrenWG.Wait()
+}
+
+func doPolling() {
+	var (
+		volume *volumeStruct
+	)
+
+	for {
+		time.Sleep(globals.pollingInterval)
+		volume = globals.volumesToWatch
+		// TODO
+		volume.LastCheckTime = time.Now()
+		globals.volumesToWatch = volume.next
+	}
+
+	// globals.childrenWG.Done()
+}
+
+func serveHTTP() {
+	var (
+		err error
+	)
+
+	err = http.Serve(globals.netListener, httpRequestHandler{})
+	if nil != err {
+		log.Fatal(err)
+	}
+
+	globals.childrenWG.Done()
+}
+
+func (h httpRequestHandler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+	switch request.Method {
+	case http.MethodGet:
+		doGet(responseWriter, request)
+	default:
+		responseWriter.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func doGet(responseWriter http.ResponseWriter, request *http.Request) {
+	var (
+		path string
+	)
+
+	path = strings.TrimRight(request.URL.Path, "/")
+
+	switch {
+	case "" == path:
+		doGetOfIndexDotHTML(responseWriter, request)
+	case "/config" == path:
+		doGetOfConfig(responseWriter, request)
+	case "/index.html" == path:
+		doGetOfIndexDotHTML(responseWriter, request)
+	case "/status" == path:
+		doGetOfStatus(responseWriter, request)
+	case "/version" == path:
+		doGetOfVersion(responseWriter, request)
+	default:
+		responseWriter.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func doGetOfIndexDotHTML(responseWriter http.ResponseWriter, request *http.Request) {
+	responseWriter.Header().Set("Content-Type", "text/html")
+	responseWriter.WriteHeader(http.StatusOK)
+	_, _ = responseWriter.Write([]byte(indexDotHTML))
+}
+
+func doGetOfConfig(responseWriter http.ResponseWriter, request *http.Request) {
+	var (
+		confMapJSON       bytes.Buffer
+		confMapJSONPacked []byte
+		ok                bool
+		paramList         []string
+		sendPackedConfig  bool
+	)
+
+	paramList, ok = request.URL.Query()["compact"]
+	if ok {
+		if 0 == len(paramList) {
+			sendPackedConfig = false
+		} else {
+			sendPackedConfig = !((paramList[0] == "") || (paramList[0] == "0") || (paramList[0] == "false"))
+		}
+	} else {
+		sendPackedConfig = false
+	}
+
+	confMapJSONPacked, _ = json.Marshal(globals.confMap)
+
+	responseWriter.Header().Set("Content-Type", "application/json")
+	responseWriter.WriteHeader(http.StatusOK)
+
+	if sendPackedConfig {
+		_, _ = responseWriter.Write(confMapJSONPacked)
+	} else {
+		json.Indent(&confMapJSON, confMapJSONPacked, "", "\t")
+		_, _ = responseWriter.Write(confMapJSON.Bytes())
+		_, _ = responseWriter.Write([]byte("\n"))
+	}
+}
+
+func doGetOfStatus(responseWriter http.ResponseWriter, request *http.Request) {
+	var (
+		ok               bool
+		paramList        []string
+		sendPackedStatus bool
+		statusJSON       bytes.Buffer
+		statusJSONPacked []byte
+	)
+
+	paramList, ok = request.URL.Query()["compact"]
+	if ok {
+		if 0 == len(paramList) {
+			sendPackedStatus = false
+		} else {
+			sendPackedStatus = !((paramList[0] == "") || (paramList[0] == "0") || (paramList[0] == "false"))
+		}
+	} else {
+		sendPackedStatus = false
+	}
+
+	statusJSONPacked, _ = json.Marshal(globals.peersToWatch)
+
+	responseWriter.Header().Set("Content-Type", "application/json")
+	responseWriter.WriteHeader(http.StatusOK)
+
+	if sendPackedStatus {
+		_, _ = responseWriter.Write(statusJSONPacked)
+	} else {
+		json.Indent(&statusJSON, statusJSONPacked, "", "\t")
+		_, _ = responseWriter.Write(statusJSON.Bytes())
+		_, _ = responseWriter.Write([]byte("\n"))
+	}
+}
+
+func doGetOfVersion(responseWriter http.ResponseWriter, request *http.Request) {
+	responseWriter.Header().Set("Content-Type", "text/plain")
+	responseWriter.WriteHeader(http.StatusOK)
+	_, _ = responseWriter.Write([]byte(version.ProxyFSVersion))
+}

--- a/pfsalived/pfsalived0.conf
+++ b/pfsalived/pfsalived0.conf
@@ -1,0 +1,9 @@
+# Peer 0's .conf file
+
+[AliveDaemon]
+WhoAmI:        Peer0
+PeersToWatch:  Peer0
+WatchInterval: 5s
+TCPPort:       15432
+
+.include ../proxyfsd/proxyfsd0.conf

--- a/pfsalived/saiopfsalived0.conf
+++ b/pfsalived/saiopfsalived0.conf
@@ -1,0 +1,9 @@
+# Peer 0's .conf file
+
+[AliveDaemon]
+WhoAmI:        Peer0
+PeersToWatch:  Peer0
+WatchInterval: 5s
+TCPPort:       15432
+
+.include ../proxyfsd/saioproxyfsd0.conf

--- a/proxyfsd/saio_cluster_1_peer.conf
+++ b/proxyfsd/saio_cluster_1_peer.conf
@@ -4,7 +4,7 @@
 
 [Peer:Peer0]
 PublicIPAddr:           127.0.0.1
-PrivateIPAddr:          127.0.0.1
+PrivateIPAddr:          0.0.0.0
 ReadCacheQuotaFraction: 0.20
 
 [Cluster]

--- a/saio/Vagrantfile
+++ b/saio/Vagrantfile
@@ -24,5 +24,6 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "../../../../../", "/vagrant", type: "virtualbox"
   config.vm.network "private_network", ip: "172.28.128.2", :name => 'vboxnet0', :adapter => 2
   config.vm.network "forwarded_port", guest: 15346, host: 25346
+  config.vm.network "forwarded_port", guest: 15432, host: 25432
   config.vm.provision "shell", path: "vagrant_provision.sh"
 end

--- a/version/.gitignore
+++ b/version/.gitignore
@@ -1,0 +1,1 @@
+proxyfs_version.go

--- a/version/Makefile
+++ b/version/Makefile
@@ -1,0 +1,6 @@
+gosubdir := github.com/swiftstack/ProxyFS/version
+
+generatedfiles := \
+	proxyfs_version.go
+
+include ../GoMakefile

--- a/version/dummy_test.go
+++ b/version/dummy_test.go
@@ -1,0 +1,8 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+}

--- a/version/static-data.go
+++ b/version/static-data.go
@@ -1,0 +1,3 @@
+package version
+
+//go:generate go run static-data/make_static_data.go version proxyfs_version.go

--- a/version/static-data/make_static_data.go
+++ b/version/static-data/make_static_data.go
@@ -69,7 +69,7 @@ func main() {
 		proxyfsVersionString = string(gitDescribeOutput[:len(gitDescribeOutput)-1])
 	}
 
-	_, err = dstFile.Write([]byte(fmt.Sprintf("const proxyfsVersion = `%v`\n", proxyfsVersionString)))
+	_, err = dstFile.Write([]byte(fmt.Sprintf("const ProxyFSVersion = `%v`\n", proxyfsVersionString)))
 	if nil != err {
 		panic(err.Error())
 	}


### PR DESCRIPTION
This commit includes the framework by which pfsalived is configured
and conducts its polling of selected volumes. It does not, however,
actually perform the liveness detection.

To get an idea of how liveness is reported, checkout the JSON response
from the embedded HTTP server inside pfsalived. While on "Peer0" at
localhost (127.0.0.1) a curl of http://127.0.0.1:15432/status will
return something like this:

{
	"Peer0": {
		"Name": "Peer0",
		"PublicIPAddr": "127.0.0.1",
		"PrivateIPAddr": "127.0.0.1",
		"VolumesToWatch": {
			"CommonVolume": {
				"Name": "CommonVolume",
				"State": "unknown",
				"LastCheckTime": "2018-09-14T11:33:00.867629-07:00"
			}
		}
	}
}