### PR TITLE
Fixed bug in inode.provisionPhysicalContainer()

### DIFF
--- a/fs/setup_teardown_test.go
+++ b/fs/setup_teardown_test.go
@@ -73,7 +73,7 @@ func testSetup(t *testing.T, starvationMode bool) {
 		"FlowControl:TestFlowControl.ReadCacheWeight=100",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainerStoragePolicy=silver",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainerNamePrefix=Replicated3Way_",
-		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainersPerPeer=1000",
+		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainersPerPeer=10",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.MaxObjectsPerContainer=1000000",
 		"Peer:Peer0.PrivateIPAddr=localhost",
 		"Peer:Peer0.ReadCacheQuotaFraction=0.20",

--- a/inode/inode.go
+++ b/inode/inode.go
@@ -887,9 +887,7 @@ func fetchVolumeHandle(volumeName string) (volumeHandle VolumeHandle, err error)
 }
 
 func (vS *volumeStruct) provisionPhysicalContainer(physicalContainerLayout *physicalContainerLayoutStruct) (err error) {
-	existingObjectCount := physicalContainerLayout.physicalContainerNameSliceLoopCount % (physicalContainerLayout.physicalContainerCountMax + 1)
-
-	if 0 == existingObjectCount {
+	if 0 == (physicalContainerLayout.physicalContainerNameSliceLoopCount % physicalContainerLayout.physicalObjectCountMax) {
 		// We need to provision a new PhysicalContainer in this PhysicalContainerLayout
 
 		physicalContainerNameSuffix, nonShadowingErr := vS.headhunterVolumeHandle.FetchNonce()

--- a/inode/setup_teardown_test.go
+++ b/inode/setup_teardown_test.go
@@ -68,7 +68,7 @@ func testSetup(t *testing.T, starvationMode bool) {
 		"FlowControl:TestFlowControl.ReadCacheWeight=100",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainerStoragePolicy=silver",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainerNamePrefix=Replicated3Way_",
-		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainersPerPeer=1000",
+		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainersPerPeer=10",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.MaxObjectsPerContainer=1000000",
 		"Peer:Peer0.PrivateIPAddr=localhost",
 		"Peer:Peer0.ReadCacheQuotaFraction=0.20",

--- a/jrpcfs/middleware_test.go
+++ b/jrpcfs/middleware_test.go
@@ -122,12 +122,12 @@ func testSetup() []func() {
 		"FlowControl:JrpcfsTestFlowControl.ReadCacheWeight=100",
 		"PhysicalContainerLayout:SomeContainerLayout.ContainerStoragePolicy=silver",
 		"PhysicalContainerLayout:SomeContainerLayout.ContainerNamePrefix=kittens",
-		"PhysicalContainerLayout:SomeContainerLayout.ContainersPerPeer=1000",
+		"PhysicalContainerLayout:SomeContainerLayout.ContainersPerPeer=10",
 		"PhysicalContainerLayout:SomeContainerLayout.MaxObjectsPerContainer=1000000",
 		"PhysicalContainerLayout:SomeContainerLayout2.ContainerStoragePolicy=silver",
 		"PhysicalContainerLayout:SomeContainerLayout2.ContainerNamePrefix=puppies",
-		"PhysicalContainerLayout:SomeContainerLayout2.ContainersPerPeer=1234",
-		"PhysicalContainerLayout:SomeContainerLayout2.MaxObjectsPerContainer=1234567",
+		"PhysicalContainerLayout:SomeContainerLayout2.ContainersPerPeer=10",
+		"PhysicalContainerLayout:SomeContainerLayout2.MaxObjectsPerContainer=1000000",
 		"JSONRPCServer.TCPPort=12346",     // 12346 instead of 12345 so that test can run if proxyfsd is already running
 		"JSONRPCServer.FastTCPPort=32346", // ...and similarly here...
 		"JSONRPCServer.DataPathLogging=false",

--- a/proxyfsd/daemon_test.go
+++ b/proxyfsd/daemon_test.go
@@ -98,7 +98,7 @@ func TestDaemon(t *testing.T) {
 
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainerStoragePolicy=silver",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainerNamePrefix=Replicated3Way_",
-		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainersPerPeer=1000",
+		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainersPerPeer=10",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.MaxObjectsPerContainer=1000000",
 
 		"Volume:CommonVolume.FSID=1",


### PR DESCRIPTION
The calculation for when to spill over to a new set of containers was
wrong. What is supposed to happen is that each of ContainersPerPeer
containers is supposed to be populated with MaxObjectsPerContainer
objects before a new set of ContainersPerPeer are allocated. The
prior code modded by the ContainersPerPeer instead of MaxObjectsPerContainer.