### PR TITLE
Lower #workers in inode stress test to conserve RAM

### DIFF
--- a/inode/file_stress_test.go
+++ b/inode/file_stress_test.go
@@ -20,7 +20,7 @@ type testStressFileWritesGlobalsStruct struct {
 var testStressFileWritesGlobals testStressFileWritesGlobalsStruct
 
 func TestStressFileWritesWhileStarved(t *testing.T) {
-	testStressFileWritesGlobals.testStressNumWorkers = 25
+	testStressFileWritesGlobals.testStressNumWorkers = 10
 	testStressFileWritesGlobals.testStressNumFlushesPerFile = 4 // Currently, each triggers a checkpoint as well
 	testStressFileWritesGlobals.testStressNumBlocksPerFlush = 20
 	testStressFileWritesGlobals.testStressNumBytesPerBlock = 1


### PR DESCRIPTION
In several constrained environments (e.g. runway, SAIO VM), a value
of testStressNumWorkers of 25 causes the amount of trapped RAM in
ramswift (embedded in the inode.test program built for the package)
to exceed available RAM (e.g. 6GB for SAIO VM).

Lowering to 10 will still exercise the exhausted Chunked and NonChunked
connection pools and bound the amount of necessary DRAM to something
around 3GB.