### PR TITLE
Added new transitions package (unintegrated)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ gopkgsubdirs = \
 	stats \
 	statslogger \
 	swiftclient \
+	transitions \
 	utils \
 	version
 
@@ -41,7 +42,7 @@ gobinsubdirs = \
 	proxyfsd/proxyfsd \
 	ramswift/ramswift
 
-uname := $(shell uname)
+uname = $(shell uname)
 
 ifeq ($(uname),Linux)
     distro := $(shell python -c "import platform; print platform.linux_distribution()[0]")

--- a/blunder/api_test.go
+++ b/blunder/api_test.go
@@ -7,48 +7,47 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/evtlog"
 	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/stats"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
+var testConfMap conf.ConfMap
+
 func testSetup(t *testing.T) {
-	confStrings := []string{
+	var (
+		err             error
+		testConfStrings []string
+	)
+
+	testConfStrings = []string{
 		"Stats.IPAddr=localhost",
 		"Stats.UDPPort=52184",
 		"Stats.BufferLength=100",
 		"Stats.MaxLatency=1s",
+		"Logging.LogFilePath=/dev/null",
+		"Cluster.WhoAmI=nobody",
+		"FSGlobals.VolumeGroupList=",
 	}
 
-	confMap, err := conf.MakeConfMapFromStrings(confStrings)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	err = evtlog.Up(confMap)
+	testConfMap, err = conf.MakeConfMapFromStrings(testConfStrings)
 	if nil != err {
-		tErr := fmt.Sprintf("evtlog.Up(confMap) failed: %v", err)
-		t.Fatalf(tErr)
+		t.Fatalf("conf.MakeConfMapFromStrings() failed: %v", err)
 	}
 
-	err = stats.Up(confMap)
+	err = transitions.Up(testConfMap)
 	if nil != err {
-		tErr := fmt.Sprintf("stats.Up(confMap) failed: %v", err)
-		t.Fatalf(tErr)
+		t.Fatalf("transitions.Up() failed: %v", err)
 	}
 }
 
 func testTeardown(t *testing.T) {
-	err := stats.Down()
-	if nil != err {
-		tErr := fmt.Sprintf("stats.Down() failed: %v", err)
-		t.Fatalf(tErr)
-	}
+	var (
+		err error
+	)
 
-	err = evtlog.Down()
+	err = transitions.Down(testConfMap)
 	if nil != err {
-		tErr := fmt.Sprintf("evtlog.Down() failed: %v", err)
-		t.Fatalf(tErr)
+		t.Fatalf("transitions.Down() failed: %v", err)
 	}
 }
 

--- a/cleanproxyfs/main.go
+++ b/cleanproxyfs/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/transitions"
 	"github.com/swiftstack/ProxyFS/utils"
 )
 
@@ -49,6 +50,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Upgrade confMap if necessary (remove when appropriate)
+	//   Note that this follows UpdateFromStrings()
+	//        hence overrides should be relative to the pre-upgraded .conf format
+	confErr = transitions.UpgradeConfMapIfNeeded(confMap)
+	if nil != confErr {
+		fmt.Fprintf(os.Stderr, "failed to perform transitions.UpgradeConfMapIfNeeded(): %v\n", confErr)
+		os.Exit(1)
+	}
+
 	// Fetch WhoAmI (qualifies which VolumeList elements are applicable)
 	whoAmI, confErr := confMap.FetchOptionValueString("Cluster", "WhoAmI")
 	if nil != confErr {
@@ -56,31 +66,34 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Fetch VolumeList
-	volumeList, confErr := confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
+	// Compute activeVolumeNameList from each "active" VolumeGroup's VolumeList
+	activeVolumeNameList := []string{}
+	volumeGroupNameList, confErr := confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeGroupList")
 	if nil != confErr {
-		fmt.Fprintf(os.Stderr, "confMap did not contain FSGlobals.VolumeList\n")
+		fmt.Fprintf(os.Stderr, "confMap did not contain FSGlobals.VolumeGroupList\n")
 		os.Exit(1)
 	}
-
-	// Prune VolumeList per PrimaryPeer attribute
-	volumeListPruned := []string{}
-	for _, volumeName := range volumeList {
-		primaryPeerList, confErr := confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
+	for _, volumeGroupName := range volumeGroupNameList {
+		volumeGroupSectionName := "VolumeGroup:" + volumeGroupName
+		primaryPeerList, confErr := confMap.FetchOptionValueStringSlice(volumeGroupSectionName, "PrimaryPeer")
 		if nil != confErr {
-			fmt.Fprintf(os.Stderr, "confMap did not contain %v.PrimaryPeer\n", volumeName)
+			fmt.Fprintf(os.Stderr, "confMap did not contain %v.PrimaryPeer\n", volumeGroupSectionName)
 			os.Exit(1)
 		}
-
 		if 0 == len(primaryPeerList) {
 			continue
 		} else if 1 == len(primaryPeerList) {
 			if whoAmI == primaryPeerList[0] {
-				volumeListPruned = append(volumeListPruned, volumeName)
+				volumeNameList, confErr := confMap.FetchOptionValueStringSlice(volumeGroupSectionName, "VolumeList")
+				if nil != confErr {
+					fmt.Fprintf(os.Stderr, "confMap did not contain %v.VolumeGroupList\n", volumeGroupSectionName)
+					os.Exit(1)
+				}
+				activeVolumeNameList = append(activeVolumeNameList, volumeNameList...)
+			} else {
+				fmt.Fprintf(os.Stderr, "confMap contained multiple values for %v.PrimaryPeer: %v\n", volumeGroupSectionName, primaryPeerList)
+				os.Exit(1)
 			}
-		} else {
-			fmt.Fprintf(os.Stderr, "confMap contained multiple values for %v.PrimaryPeer: %v\n", volumeName, primaryPeerList)
-			os.Exit(1)
 		}
 	}
 
@@ -95,10 +108,11 @@ func main() {
 
 	urlPrefix := "http://127.0.0.1:" + noAuthTCPPort + "/v1/"
 
-	for _, volumeName := range volumeListPruned {
-		accountName, confErr := confMap.FetchOptionValueString("Volume:"+volumeName, "AccountName")
+	for _, volumeName := range activeVolumeNameList {
+		volumeSectionName := "Volume:" + volumeName
+		accountName, confErr := confMap.FetchOptionValueString(volumeSectionName, "AccountName")
 		if nil != confErr {
-			fmt.Fprintf(os.Stderr, "confMap did not contain %v.AccountName\n", volumeName)
+			fmt.Fprintf(os.Stderr, "confMap did not contain %v.AccountName\n", volumeSectionName)
 			os.Exit(1)
 		}
 
@@ -214,7 +228,7 @@ func main() {
 					os.Exit(1)
 				}
 
-				replayLogFileName, confErr := confMap.FetchOptionValueString("Volume:"+volumeName, "ReplayLogFileName")
+				replayLogFileName, confErr := confMap.FetchOptionValueString(volumeSectionName, "ReplayLogFileName")
 				if nil == confErr {
 					if "" != replayLogFileName {
 						removeReplayLogFileErr := os.Remove(replayLogFileName)

--- a/dlm/config.go
+++ b/dlm/config.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 type globalsStruct struct {
@@ -24,24 +25,43 @@ type globalsStruct struct {
 
 var globals globalsStruct
 
-func Up(confMap conf.ConfMap) (err error) {
+func init() {
+	transitions.Register("dlm", &globals)
+}
+
+func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	// Create map used to store locks
 	globals.localLockMap = make(map[string]*localLockTrack)
 	return
 }
 
-func PauseAndContract(confMap conf.ConfMap) (err error) {
-	// Nothing to do here
-	err = nil
-	return
+func (dummy *globalsStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
 }
-
-func ExpandAndResume(confMap conf.ConfMap) (err error) {
-	// Nothing to do here
-	err = nil
-	return
+func (dummy *globalsStruct) VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
 }
-
-func Down() (err error) {
-	return
+func (dummy *globalsStruct) VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) Signaled(confMap conf.ConfMap) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) Down(confMap conf.ConfMap) (err error) {
+	return nil
 }

--- a/evtlog/api_test.go
+++ b/evtlog/api_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/logger"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 func TestAPI(t *testing.T) {
@@ -37,6 +37,8 @@ func TestAPI(t *testing.T) {
 		"Logging.TraceLevelLogging=none",
 		"Logging.DebugLevelLogging=none",
 		"Logging.LogToConsole=false",
+		"Cluster.WhoAmI=nobody",
+		"FSGlobals.VolumeGroupList=",
 		"EventLog.Enabled=true",
 		"EventLog.BufferKey=9876",     // Don't conflict with a running instance
 		"EventLog.BufferLength=65536", // 64KiB
@@ -49,12 +51,7 @@ func TestAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = logger.Up(testConfMap)
-	if nil != err {
-		t.Fatal(err)
-	}
-
-	err = Up(testConfMap)
+	err = transitions.Up(testConfMap)
 	if nil != err {
 		t.Fatal(err)
 	}
@@ -151,12 +148,7 @@ func TestAPI(t *testing.T) {
 
 	// TODO: Eventually, it would be nice to test the overrun & wrap cases...
 
-	err = Down()
-	if nil != err {
-		t.Fatal(err)
-	}
-
-	err = logger.Down()
+	err = transitions.Down(testConfMap)
 	if nil != err {
 		t.Fatal(err)
 	}

--- a/evtlog/benchmark_test.go
+++ b/evtlog/benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/logger"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 var (
@@ -13,7 +13,6 @@ var (
 
 func benchmarkSetup(b *testing.B, enable bool) {
 	var (
-		benchmarkConfMap        conf.ConfMap
 		benchmarkConfMapStrings []string
 		err                     error
 	)
@@ -24,6 +23,8 @@ func benchmarkSetup(b *testing.B, enable bool) {
 			"Logging.TraceLevelLogging=none",
 			"Logging.DebugLevelLogging=none",
 			"Logging.LogToConsole=false",
+			"Cluster.WhoAmI=nobody",
+			"FSGlobals.VolumeGroupList=",
 			"EventLog.Enabled=true",
 			"EventLog.BufferKey=1234",
 			"EventLog.BufferLength=65536", //64KiB
@@ -36,6 +37,8 @@ func benchmarkSetup(b *testing.B, enable bool) {
 			"Logging.TraceLevelLogging=none",
 			"Logging.DebugLevelLogging=none",
 			"Logging.LogToConsole=false",
+			"Cluster.WhoAmI=nobody",
+			"FSGlobals.VolumeGroupList=",
 			"EventLog.Enabled=false",
 		}
 	}
@@ -45,12 +48,7 @@ func benchmarkSetup(b *testing.B, enable bool) {
 		b.Fatal(err)
 	}
 
-	err = logger.Up(benchmarkConfMap)
-	if nil != err {
-		b.Fatal(err)
-	}
-
-	err = Up(benchmarkConfMap)
+	err = transitions.Up(benchmarkConfMap)
 	if nil != err {
 		b.Fatal(err)
 	}
@@ -63,12 +61,7 @@ func benchmarkTeardown(b *testing.B) {
 		err error
 	)
 
-	err = Down()
-	if nil != err {
-		b.Fatal(err)
-	}
-
-	err = logger.Down()
+	err = transitions.Down(benchmarkConfMap)
 	if nil != err {
 		b.Fatal(err)
 	}

--- a/evtlog/config.go
+++ b/evtlog/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/logger"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 // #include <errno.h>
@@ -57,6 +58,10 @@ type eventLogConfigSettings struct {
 	eventLogLockMaxBackoff time.Duration
 }
 
+func init() {
+	transitions.Register("evtlog", &globals)
+}
+
 // Extract the settings from the confMap and perform minimal sanity checking
 //
 func parseConfMap(confMap conf.ConfMap) (settings eventLogConfigSettings, err error) {
@@ -99,8 +104,7 @@ func parseConfMap(confMap conf.ConfMap) (settings eventLogConfigSettings, err er
 	return
 }
 
-// Up initializes the package and must successfully return before any API functions are invoked
-func Up(confMap conf.ConfMap) (err error) {
+func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	var settings eventLogConfigSettings
 
 	settings, err = parseConfMap(confMap)
@@ -124,15 +128,32 @@ func Up(confMap conf.ConfMap) (err error) {
 	return
 }
 
-// PauseAndContract pauses the evtlog package and applies any removals from the supplied confMap
-func PauseAndContract(confMap conf.ConfMap) (err error) {
-
-	// Nothing to do here
-	return
+func (dummy *globalsStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
 }
 
-// ExpandAndResume applies any additions from the supplied confMap and resumes the evtlog package
-func ExpandAndResume(confMap conf.ConfMap) (err error) {
+func (dummy *globalsStruct) Signaled(confMap conf.ConfMap) (err error) {
 	var settings eventLogConfigSettings
 
 	settings, err = parseConfMap(confMap)
@@ -177,8 +198,7 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	return
 }
 
-// Down terminates event logging and should only be called once no API functions are active or subsequently invoked
-func Down() (err error) {
+func (dummy *globalsStruct) Down(confMap conf.ConfMap) (err error) {
 	if globals.eventLogEnabled {
 		err = disableLogging()
 	}

--- a/evtlog/pfsevtlogd/main.go
+++ b/evtlog/pfsevtlogd/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/evtlog"
-	"github.com/swiftstack/ProxyFS/logger"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 func usage() {
@@ -65,25 +65,16 @@ func main() {
 		log.Fatalf("failed to apply config overrides: %v", err)
 	}
 
-	err = logger.Up(confMap)
+	err = transitions.Up(confMap)
 	if nil != err {
-		log.Fatalf("logger.Up() failed: %v", err)
-	}
-
-	err = evtlog.Up(confMap)
-	if nil != err {
-		log.Fatalf("evtlog.Up() failed: %v", err)
+		log.Fatalf("transitions.Up() failed: %v", err)
 	}
 
 	if justDeleteSharedMemoryObject {
 		evtlog.MarkForDeletion()
-		err = evtlog.Down()
+		err = transitions.Down(confMap)
 		if nil != err {
-			log.Fatalf("evtlog.Down() failed: %v", err)
-		}
-		err = logger.Down()
-		if nil != err {
-			log.Fatalf("logger.Down() failed: %v", err)
+			log.Fatalf("transitions.Down() failed: %v", err)
 		}
 		os.Exit(0)
 	}
@@ -119,14 +110,9 @@ func main() {
 					log.Fatalf("outputFile.Close() failed: %v", err)
 				}
 
-				err = evtlog.Down()
+				err = transitions.Down(confMap)
 				if nil != err {
-					log.Fatalf("evtlog.Down() failed: %v", err)
-				}
-
-				err = logger.Down()
-				if nil != err {
-					log.Fatalf("logger.Down() failed: %v", err)
+					log.Fatalf("transitions.Down() failed: %v", err)
 				}
 
 				os.Exit(0)

--- a/fsworkout/main.go
+++ b/fsworkout/main.go
@@ -9,14 +9,9 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/dlm"
-	"github.com/swiftstack/ProxyFS/evtlog"
 	"github.com/swiftstack/ProxyFS/fs"
-	"github.com/swiftstack/ProxyFS/headhunter"
 	"github.com/swiftstack/ProxyFS/inode"
-	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/stats"
-	"github.com/swiftstack/ProxyFS/swiftclient"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 const (
@@ -35,7 +30,6 @@ var (
 	rootDirMutex    sync.Mutex
 	stepErrChan     chan error
 	threads         uint64
-	volumeHandle    inode.VolumeHandle
 	volumeName      string
 )
 
@@ -67,9 +61,15 @@ func main() {
 		err                          error
 		latencyPerOpInMilliSeconds   float64
 		opsPerSecond                 float64
+		primaryPeer                  string
+		threadIndex                  uint64
 		timeAfterMeasuredOperations  time.Time
 		timeBeforeMeasuredOperations time.Time
+		volumeGroupToCheck           string
+		volumeGroupToUse             string
+		volumeGroupList              []string
 		volumeList                   []string
+		whoAmI                       string
 	)
 
 	// Parse arguments
@@ -136,83 +136,60 @@ func main() {
 
 	// Start up needed ProxyFS components
 
-	err = logger.Up(confMap)
+	err = transitions.Up(confMap)
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "logger.Up() failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "transitions.Up() failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	err = evtlog.Up(confMap)
+	// Select first Volume of the first "active" VolumeGroup in [FSGlobals]VolumeGroupList
+
+	whoAmI, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "evtlog.Up() failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueString(\"Cluster\", \"WhoAmI\") failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	err = stats.Up(confMap)
+	volumeGroupList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeGroupList")
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "stats.Up() failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeGroupList\") failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	err = dlm.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "dlm.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
+	volumeGroupToUse = ""
 
-	err = swiftclient.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "swiftclient.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = headhunter.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "headhunter.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = inode.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "inode.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = fs.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "fs.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Select first "active" volumeName in volumeList by attempting to mount each
-
-	volumeList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") failed: %v\n", err)
-		os.Exit(1)
-	}
-	if 1 > len(volumeList) {
-		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") returned empty volumeList")
-		os.Exit(1)
-	}
-
-	for _, volumeName = range volumeList {
-		volumeHandle, err = inode.FetchVolumeHandle(volumeName)
-		if nil == err {
+	for _, volumeGroupToCheck = range volumeGroupList {
+		primaryPeer, err = confMap.FetchOptionValueString("VolumeGroup:"+volumeGroupToCheck, "PrimaryPeer")
+		if nil != err {
+			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueString(\"VolumeGroup:%s\", \"PrimaryPeer\") failed: %v\n", volumeGroupToCheck, err)
+			os.Exit(1)
+		}
+		if whoAmI == primaryPeer {
+			volumeGroupToUse = volumeGroupToCheck
 			break
-		} else {
-			volumeHandle = nil
 		}
 	}
 
-	if nil == volumeHandle {
-		fmt.Fprintf(os.Stderr, "inode.FetchVolumeHandle() failed on every volumeName in volumeList: %v\n", volumeList)
+	if "" == volumeGroupToUse {
+		fmt.Fprintf(os.Stderr, "confMap didn't contain an \"active\" VolumeGroup")
 		os.Exit(1)
 	}
 
+	volumeList, err = confMap.FetchOptionValueStringSlice("VolumeGroup:"+volumeGroupToUse, "VolumeList")
+	if nil != err {
+		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"VolumeGroup:%s\", \"PrimaryPeer\") failed: %v\n", volumeGroupToUse, err)
+		os.Exit(1)
+	}
+	if 1 > len(volumeList) {
+		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"VolumeGroup:%s\", \"VolumeList\") returned empty volumeList", volumeGroupToUse)
+		os.Exit(1)
+	}
+
+	volumeName = volumeList[0]
+
 	mountHandle, err = fs.Mount(volumeName, fs.MountOptions(0))
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "fs.Mount(\"%value\",,) failed: %v\n", volumeName, err)
+		fmt.Fprintf(os.Stderr, "fs.Mount(\"%value\",) failed: %v\n", volumeName, err)
 		os.Exit(1)
 	}
 
@@ -222,10 +199,10 @@ func main() {
 	doNextStepChan = make(chan bool, 0) //threads)
 
 	// Do initialization step
-	for threadIndex := uint64(0); threadIndex < threads; threadIndex++ {
+	for threadIndex = uint64(0); threadIndex < threads; threadIndex++ {
 		go fsWorkout(threadIndex)
 	}
-	for threadIndex := uint64(0); threadIndex < threads; threadIndex++ {
+	for threadIndex = uint64(0); threadIndex < threads; threadIndex++ {
 		err = <-stepErrChan
 		if nil != err {
 			fmt.Fprintf(os.Stderr, "fsWorkout() initialization step returned: %v\n", err)
@@ -235,10 +212,10 @@ func main() {
 
 	// Do measured operations step
 	timeBeforeMeasuredOperations = time.Now()
-	for threadIndex := uint64(0); threadIndex < threads; threadIndex++ {
+	for threadIndex = uint64(0); threadIndex < threads; threadIndex++ {
 		doNextStepChan <- true
 	}
-	for threadIndex := uint64(0); threadIndex < threads; threadIndex++ {
+	for threadIndex = uint64(0); threadIndex < threads; threadIndex++ {
 		err = <-stepErrChan
 		if nil != err {
 			fmt.Fprintf(os.Stderr, "fsWorkout() measured operations step returned: %v\n", err)
@@ -248,10 +225,10 @@ func main() {
 	timeAfterMeasuredOperations = time.Now()
 
 	// Do shutdown step
-	for threadIndex := uint64(0); threadIndex < threads; threadIndex++ {
+	for threadIndex = uint64(0); threadIndex < threads; threadIndex++ {
 		doNextStepChan <- true
 	}
-	for threadIndex := uint64(0); threadIndex < threads; threadIndex++ {
+	for threadIndex = uint64(0); threadIndex < threads; threadIndex++ {
 		err = <-stepErrChan
 		if nil != err {
 			fmt.Fprintf(os.Stderr, "fsWorkout() shutdown step returned: %v\n", err)
@@ -261,51 +238,9 @@ func main() {
 
 	// Stop ProxyFS components launched above
 
-	err = fs.Down()
+	err = transitions.Down(confMap)
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "fs.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = inode.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "inode.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = swiftclient.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "swiftclient.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = headhunter.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "headhunter.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = dlm.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "dlm.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = stats.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "stats.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = evtlog.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "evtlog.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = logger.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "logger.Down() failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "transitions.Down() failed: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/halter/api_test.go
+++ b/halter/api_test.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/swiftstack/ProxyFS/evtlog"
+	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 var (
@@ -12,13 +13,20 @@ var (
 )
 
 func TestAPI(t *testing.T) {
-	err := evtlog.Up(nil)
-	if nil != err {
-		t.Fatalf("evtlog.Up() unexpeectedly failed: %v", err)
+	testConfMapStrings := []string{
+		"Logging.LogFilePath=/dev/null",
+		"Cluster.WhoAmI=nobody",
+		"FSGlobals.VolumeGroupList=",
 	}
-	err = Up(nil)
+
+	testConfMap, err := conf.MakeConfMapFromStrings(testConfMapStrings)
 	if nil != err {
-		t.Fatalf("halter.Up() unexpeectedly failed: %v", err)
+		t.Fatal(err)
+	}
+
+	err = transitions.Up(testConfMap)
+	if nil != err {
+		t.Fatal(err)
 	}
 
 	configureTestModeHaltCB(testHalt)
@@ -161,6 +169,11 @@ func TestAPI(t *testing.T) {
 	}
 	if "halter.TriggerArm(haltLabelString==halter.testHaltLabel2) triggered HALT" != testHaltErr.Error() {
 		t.Fatalf("Trigger(apiTestHaltLabel2) [case 2] unexpectedly set testHaltErr to %v", testHaltErr)
+	}
+
+	err = transitions.Down(testConfMap)
+	if nil != err {
+		t.Fatal(err)
 	}
 }
 

--- a/halter/config.go
+++ b/halter/config.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 type globalsStruct struct {
@@ -16,8 +17,11 @@ type globalsStruct struct {
 
 var globals globalsStruct
 
-// Up initializes the package and must successfully return before any API functions are invoked
-func Up(confMap conf.ConfMap) (err error) {
+func init() {
+	transitions.Register("halter", &globals)
+}
+
+func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	globals.armedTriggers = make(map[uint32]uint32)
 	globals.triggerNamesToNumbers = make(map[string]uint32)
 	globals.triggerNumbersToNames = make(map[uint32]string)
@@ -30,23 +34,35 @@ func Up(confMap conf.ConfMap) (err error) {
 	return
 }
 
-// PauseAndContract pauses the evtlog package and applies any removals from the supplied confMap
-func PauseAndContract(confMap conf.ConfMap) (err error) {
-	// Nothing to do here
-	err = nil
-	return
+func (dummy *globalsStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) Signaled(confMap conf.ConfMap) (err error) {
+	return nil
 }
 
-// ExpandAndResume applies any additions from the supplied confMap and resumes the evtlog package
-func ExpandAndResume(confMap conf.ConfMap) (err error) {
-	// Nothing to do here
-	err = nil
-	return
-}
-
-// Down terminates the halter package
-func Down() (err error) {
-	// Nothing to do here
+func (dummy *globalsStruct) Down(confMap conf.ConfMap) (err error) {
 	err = nil
 	return
 }

--- a/httpserver/request_handler_test.go
+++ b/httpserver/request_handler_test.go
@@ -2,55 +2,14 @@ package httpserver
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
-	"os"
 	"testing"
-
-	"github.com/swiftstack/ProxyFS/conf"
 )
 
-func testSetup() (err error) {
-	testConfMapStrings := []string{
-		"Stats.IPAddr=localhost",
-		"Stats.UDPPort=52184",
-		"Stats.BufferLength=100",
-	}
-
-	testConfMap, err := conf.MakeConfMapFromStrings(testConfMapStrings)
-	if nil != err {
-		return
-	}
-
-	globals.confMap = testConfMap
-
-	return nil
-}
-
-func testTeardown() (err error) {
-	return
-}
-
-func TestMain(m *testing.M) {
-	err := testSetup()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "test setup failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	testResults := m.Run()
-
-	err = testTeardown()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "test teardown failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	os.Exit(testResults)
-}
-
 func TestConfigExpansion(t *testing.T) {
+	testSetup(t)
+	defer testTeardown(t)
 
 	testConfigExpansion := func(url string, shouldBeExpanded bool) {
 		req := httptest.NewRequest("GET", "http://pfs.com"+url, nil)

--- a/httpserver/setup_teardown_test.go
+++ b/httpserver/setup_teardown_test.go
@@ -1,0 +1,103 @@
+package httpserver
+
+import (
+	"sync"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/ramswift"
+	"github.com/swiftstack/ProxyFS/transitions"
+)
+
+var (
+	ramswiftDoneChan chan bool // our global ramswiftDoneChan used during testTeardown() to know ramswift is, indeed, down
+	testConfMap      conf.ConfMap
+)
+
+func testSetup(t *testing.T) {
+	var (
+		err                    error
+		signalHandlerIsArmedWG sync.WaitGroup
+		testConfMapStrings     []string
+		testConfUpdateStrings  []string
+	)
+
+	testConfMapStrings = []string{
+		"Stats.IPAddr=localhost",
+		"Stats.UDPPort=52184",
+		"Stats.BufferLength=100",
+		"Stats.MaxLatency=1s",
+		"Logging.LogFilePath=/dev/null",
+		"Logging.LogToConsole=false",
+		"SwiftClient.NoAuthIPAddr=127.0.0.1",
+		"SwiftClient.NoAuthTCPPort=45262",
+		"SwiftClient.Timeout=10s",
+		"SwiftClient.RetryLimit=3",
+		"SwiftClient.RetryLimitObject=3",
+		"SwiftClient.RetryDelay=10ms",
+		"SwiftClient.RetryDelayObject=10ms",
+		"SwiftClient.RetryExpBackoff=1.2",
+		"SwiftClient.RetryExpBackoffObject=2.0",
+		"SwiftClient.ChunkedConnectionPoolSize=256",
+		"SwiftClient.NonChunkedConnectionPoolSize=64",
+		"Peer:Peer0.PrivateIPAddr=localhost",
+		"Peer:Peer0.ReadCacheQuotaFraction=0.20",
+		"Cluster.Peers=Peer0",
+		"Cluster.WhoAmI=Peer0",
+		"FSGlobals.VolumeGroupList=",
+		"FSGlobals.InodeRecCacheEvictLowLimit=10000",
+		"FSGlobals.InodeRecCacheEvictHighLimit=10010",
+		"FSGlobals.LogSegmentRecCacheEvictLowLimit=10000",
+		"FSGlobals.LogSegmentRecCacheEvictHighLimit=10010",
+		"FSGlobals.BPlusTreeObjectCacheEvictLowLimit=10000",
+		"FSGlobals.BPlusTreeObjectCacheEvictHighLimit=10010",
+		"FSGlobals.DirEntryCacheEvictLowLimit=10000",
+		"FSGlobals.DirEntryCacheEvictHighLimit=10010",
+		"FSGlobals.FileExtentMapEvictLowLimit=10000",
+		"FSGlobals.FileExtentMapEvictHighLimit=10010",
+		"RamSwiftInfo.MaxAccountNameLength=256",
+		"RamSwiftInfo.MaxContainerNameLength=256",
+		"RamSwiftInfo.MaxObjectNameLength=1024",
+		"RamSwiftInfo.AccountListingLimit=10000",
+		"RamSwiftInfo.ContainerListingLimit=10000",
+		"HTTPServer.TCPPort=53461",
+	}
+
+	testConfMap, err = conf.MakeConfMapFromStrings(testConfMapStrings)
+	if nil != err {
+		t.Fatalf("conf.MakeConfMapFromStrings() failed: %v", err)
+	}
+
+	err = testConfMap.UpdateFromStrings(testConfUpdateStrings)
+	if nil != err {
+		t.Fatalf("testConfMap.UpdateFromStrings(testConfUpdateStrings) failed: %v", err)
+	}
+
+	signalHandlerIsArmedWG.Add(1)
+	ramswiftDoneChan = make(chan bool, 1)
+	go ramswift.Daemon("/dev/null", testConfMapStrings, &signalHandlerIsArmedWG, ramswiftDoneChan, unix.SIGTERM)
+
+	signalHandlerIsArmedWG.Wait()
+
+	err = transitions.Up(testConfMap)
+	if nil != err {
+		t.Fatalf("transitions.Up() failed: %v", err)
+	}
+}
+
+func testTeardown(t *testing.T) {
+	var (
+		err error
+	)
+
+	err = transitions.Down(testConfMap)
+	if nil != err {
+		t.Fatalf("transitions.Down() failed: %v", err)
+	}
+
+	_ = syscall.Kill(syscall.Getpid(), unix.SIGTERM)
+	_ = <-ramswiftDoneChan
+}

--- a/inode/benchmark_test.go
+++ b/inode/benchmark_test.go
@@ -122,11 +122,11 @@ func readCacheBenchmarkHelper(b *testing.B, byteSize uint64) {
 	for i := 0; i < b.N; i++ {
 		buf := []byte{}
 		readCacheKey := readCacheKeyStruct{volumeName: "TestVolume", logSegmentNumber: logSegmentNumber, cacheLineTag: 0}
-		volume.flowControl.Lock()
-		readCacheElement, _ := volume.flowControl.readCache[readCacheKey]
+		volume.volumeGroup.Lock()
+		readCacheElement, _ := volume.volumeGroup.readCache[readCacheKey]
 		cacheLine := readCacheElement.cacheLine
 		buf = append(buf, cacheLine[:byteSize]...)
-		volume.flowControl.Unlock()
+		volume.volumeGroup.Unlock()
 	}
 }
 

--- a/inode/cache.go
+++ b/inode/cache.go
@@ -1,0 +1,124 @@
+package inode
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/logger"
+	"github.com/swiftstack/ProxyFS/platform"
+)
+
+func adoptVolumeGroupReadCacheParameters(confMap conf.ConfMap) (err error) {
+	var (
+		readCacheLineCount     uint64
+		readCacheMemSize       uint64
+		readCacheQuotaFraction float64
+		readCacheTotalSize     uint64
+		readCacheWeightSum     uint64
+		totalMemSize           uint64
+		volumeGroup            *volumeGroupStruct
+	)
+
+	readCacheWeightSum = 0
+
+	for _, volumeGroup = range globals.volumeGroupMap {
+		if 0 < volumeGroup.numServed {
+			readCacheWeightSum += volumeGroup.readCacheWeight
+		}
+	}
+
+	readCacheQuotaFraction, err = confMap.FetchOptionValueFloat64("Peer:"+globals.whoAmI, "ReadCacheQuotaFraction")
+	if nil != err {
+		return
+	}
+	if (0 > readCacheQuotaFraction) || (1 < readCacheQuotaFraction) {
+		err = fmt.Errorf("%s.ReadCacheQuotaFraction (%v) must be between 0 and 1", globals.whoAmI, readCacheQuotaFraction)
+		return
+	}
+
+	totalMemSize = platform.MemSize()
+
+	readCacheMemSize = uint64(float64(totalMemSize) * readCacheQuotaFraction / platform.GoHeapAllocationMultiplier)
+
+	logger.Infof("Adopting ReadCache Parameters...")
+	logger.Infof("...ReadCacheQuotaFraction(%v) of memSize(0x%016X) totals 0x%016X",
+		readCacheQuotaFraction,
+		totalMemSize,
+		readCacheMemSize)
+
+	for _, volumeGroup = range globals.volumeGroupMap {
+		if 0 < volumeGroup.numServed {
+			readCacheTotalSize = readCacheMemSize * volumeGroup.readCacheWeight / readCacheWeightSum
+
+			readCacheLineCount = readCacheTotalSize / volumeGroup.readCacheLineSize
+			if 0 == readCacheLineCount {
+				err = fmt.Errorf("[VolumeGroup:%s]ReadCacheWeight must result in at least one ReadCacheLineSize (%v) of memory", volumeGroup.name, volumeGroup.readCacheLineSize)
+				return
+			}
+
+			volumeGroup.Lock()
+			volumeGroup.readCacheLineCount = readCacheLineCount
+			volumeGroup.capReadCacheWhileLocked()
+			volumeGroup.Unlock()
+
+			logger.Infof("...0x%08X cache lines (each of size 0x%08X) totalling 0x%016X for Volume Group %v",
+				volumeGroup.readCacheLineCount,
+				volumeGroup.readCacheLineSize,
+				volumeGroup.readCacheLineCount*volumeGroup.readCacheLineSize,
+				volumeGroup.name)
+		}
+	}
+
+	err = nil
+	return
+}
+
+func startInodeCacheDiscard(confMap conf.ConfMap, volume *volumeStruct, volumeSectionName string) (err error) {
+	var (
+		LRUCacheMaxBytes       uint64
+		LRUDiscardTimeInterval time.Duration
+	)
+
+	LRUCacheMaxBytes, err = confMap.FetchOptionValueUint64(volumeSectionName, "MaxBytesInodeCache")
+	if nil != err {
+		LRUCacheMaxBytes = 10485760 // TODO - Remove setting a default value
+		err = nil
+	}
+	volume.inodeCacheLRUMaxBytes = LRUCacheMaxBytes
+
+	LRUDiscardTimeInterval, err = confMap.FetchOptionValueDuration(volumeSectionName, "InodeCacheEvictInterval")
+	if nil != err {
+		LRUDiscardTimeInterval = 1 * time.Second // TODO - Remove setting a default value
+		err = nil
+	}
+
+	if LRUDiscardTimeInterval != 0 {
+		volume.inodeCacheLRUTickerInterval = LRUDiscardTimeInterval
+		volume.inodeCacheLRUTicker = time.NewTicker(volume.inodeCacheLRUTickerInterval)
+
+		logger.Infof("Inode cache discard ticker for 'volume: %v' is: %v MaxBytesInodeCache: %v",
+			volume.volumeName, volume.inodeCacheLRUTickerInterval, volume.inodeCacheLRUMaxBytes)
+
+		// Start ticker for inode cache discard thread
+		go func() {
+			for range volume.inodeCacheLRUTicker.C {
+				_, _, _, _ = volume.inodeCacheDiscard()
+			}
+		}()
+	} else {
+		logger.Infof("Inode cache discard ticker for 'volume: %v' is disabled.",
+			volume.volumeName)
+		return
+	}
+
+	return
+}
+
+func stopInodeCacheDiscard(volume *volumeStruct) {
+	if volume.inodeCacheLRUTicker != nil {
+		volume.inodeCacheLRUTicker.Stop()
+		logger.Infof("Inode cache discard ticker for 'volume: %v' stopped.",
+			volume.volumeName)
+	}
+}

--- a/inode/file_stress_test.go
+++ b/inode/file_stress_test.go
@@ -20,7 +20,7 @@ type testStressFileWritesGlobalsStruct struct {
 var testStressFileWritesGlobals testStressFileWritesGlobalsStruct
 
 func TestStressFileWritesWhileStarved(t *testing.T) {
-	testStressFileWritesGlobals.testStressNumWorkers = 10
+	testStressFileWritesGlobals.testStressNumWorkers = 100
 	testStressFileWritesGlobals.testStressNumFlushesPerFile = 4 // Currently, each triggers a checkpoint as well
 	testStressFileWritesGlobals.testStressNumBlocksPerFlush = 20
 	testStressFileWritesGlobals.testStressNumBytesPerBlock = 1
@@ -29,7 +29,7 @@ func TestStressFileWritesWhileStarved(t *testing.T) {
 }
 
 func TestStressFileWritesWhileNotStarved(t *testing.T) {
-	testStressFileWritesGlobals.testStressNumWorkers = 1000
+	testStressFileWritesGlobals.testStressNumWorkers = 100
 	testStressFileWritesGlobals.testStressNumFlushesPerFile = 10 // Currently, each triggers a checkpoint as well
 	testStressFileWritesGlobals.testStressNumBlocksPerFlush = 20
 	testStressFileWritesGlobals.testStressNumBytesPerBlock = 1

--- a/inode/setup_teardown_test.go
+++ b/inode/setup_teardown_test.go
@@ -11,17 +11,14 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/dlm"
-	"github.com/swiftstack/ProxyFS/evtlog"
-	"github.com/swiftstack/ProxyFS/headhunter"
-	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/ramswift"
-	"github.com/swiftstack/ProxyFS/stats"
-	"github.com/swiftstack/ProxyFS/swiftclient"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
-// our global ramswiftDoneChan used during testTeardown() to know ramswift is, indeed, down
-var ramswiftDoneChan chan bool
+var (
+	ramswiftDoneChan chan bool
+	testConfMap      conf.ConfMap
+)
 
 func testSetup(t *testing.T, starvationMode bool) {
 	var (
@@ -30,7 +27,6 @@ func testSetup(t *testing.T, starvationMode bool) {
 		rLimitMinimum                 uint64
 		signalHandlerIsArmedWG        sync.WaitGroup
 		testChunkedConnectionPoolSize uint64
-		testConfMap                   conf.ConfMap
 		testConfStrings               []string
 		testConfUpdateStrings         []string
 		testDir                       string
@@ -62,10 +58,6 @@ func testSetup(t *testing.T, starvationMode bool) {
 		"SwiftClient.RetryDelayObject=10ms",
 		"SwiftClient.RetryExpBackoff=1.2",
 		"SwiftClient.RetryExpBackoffObject=1.0",
-		"FlowControl:TestFlowControl.MaxFlushSize=10000000",
-		"FlowControl:TestFlowControl.MaxFlushTime=10s",
-		"FlowControl:TestFlowControl.ReadCacheLineSize=1000000",
-		"FlowControl:TestFlowControl.ReadCacheWeight=100",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainerStoragePolicy=silver",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainerNamePrefix=Replicated3Way_",
 		"PhysicalContainerLayout:PhysicalContainerLayoutReplicated3Way.ContainersPerPeer=10",
@@ -75,13 +67,14 @@ func testSetup(t *testing.T, starvationMode bool) {
 		"Cluster.Peers=Peer0",
 		"Cluster.WhoAmI=Peer0",
 		"Volume:TestVolume.FSID=1",
-		"Volume:TestVolume.PrimaryPeer=Peer0",
 		"Volume:TestVolume.AccountName=AUTH_test",
+		"Volume:TestVolume.AutoFormat=true",
 		"Volume:TestVolume.CheckpointContainerName=.__checkpoint__",
 		"Volume:TestVolume.CheckpointContainerStoragePolicy=gold",
 		"Volume:TestVolume.CheckpointInterval=10s",
 		"Volume:TestVolume.DefaultPhysicalContainerLayout=PhysicalContainerLayoutReplicated3Way",
-		"Volume:TestVolume.FlowControl=TestFlowControl",
+		"Volume:TestVolume.MaxFlushSize=10000000",
+		"Volume:TestVolume.MaxFlushTime=10s",
 		"Volume:TestVolume.NonceValuesToReserve=100",
 		"Volume:TestVolume.MaxEntriesPerDirNode=32",
 		"Volume:TestVolume.MaxExtentsPerFileNode=32",
@@ -90,7 +83,12 @@ func testSetup(t *testing.T, starvationMode bool) {
 		"Volume:TestVolume.MaxDirFileNodesPerMetadataNode=16",
 		"Volume:TestVolume.MaxBytesInodeCache=100000",
 		"Volume:TestVolume.InodeCacheEvictInterval=1s",
-		"FSGlobals.VolumeList=TestVolume",
+		"VolumeGroup:TestVolumeGroup.VolumeList=TestVolume",
+		"VolumeGroup:TestVolumeGroup.VirtualIPAddr=",
+		"VolumeGroup:TestVolumeGroup.PrimaryPeer=Peer0",
+		"VolumeGroup:TestVolumeGroup.ReadCacheLineSize=1000000",
+		"VolumeGroup:TestVolumeGroup.ReadCacheWeight=100",
+		"FSGlobals.VolumeGroupList=TestVolumeGroup",
 		"FSGlobals.InodeRecCacheEvictLowLimit=10000",
 		"FSGlobals.InodeRecCacheEvictHighLimit=10010",
 		"FSGlobals.LogSegmentRecCacheEvictLowLimit=10000",
@@ -163,44 +161,9 @@ func testSetup(t *testing.T, starvationMode bool) {
 
 	signalHandlerIsArmedWG.Wait()
 
-	err = logger.Up(testConfMap)
+	err = transitions.Up(testConfMap)
 	if nil != err {
-		t.Fatalf("logger.Up() failed: %v", err)
-	}
-
-	err = evtlog.Up(testConfMap)
-	if nil != err {
-		t.Fatalf("evtlog.Up() failed: %v", err)
-	}
-
-	err = stats.Up(testConfMap)
-	if nil != err {
-		t.Fatalf("stats.Up() failed: %v", err)
-	}
-
-	err = dlm.Up(testConfMap)
-	if nil != err {
-		t.Fatalf("dlm.Up() failed: %v", err)
-	}
-
-	err = swiftclient.Up(testConfMap)
-	if nil != err {
-		t.Fatalf("swiftclient.Up() failed: %v", err)
-	}
-
-	err = headhunter.Format(testConfMap, "TestVolume")
-	if nil != err {
-		t.Fatalf("headhunter.Format() failed: %v", err)
-	}
-
-	err = headhunter.Up(testConfMap)
-	if nil != err {
-		t.Fatalf("headhunter.Up() failed: %v", err)
-	}
-
-	err = Up(testConfMap)
-	if nil != err {
-		t.Fatalf("inode.Up() failed: %v", err)
+		t.Fatalf("transitions.Up() failed: %v", err)
 	}
 }
 
@@ -210,39 +173,9 @@ func testTeardown(t *testing.T) {
 		testDir string
 	)
 
-	err = Down()
+	err = transitions.Down(testConfMap)
 	if nil != err {
-		t.Fatalf("inode.Down() failed: %v", err)
-	}
-
-	err = headhunter.Down()
-	if nil != err {
-		t.Fatalf("headhunter.Down() failed: %v", err)
-	}
-
-	err = swiftclient.Down()
-	if nil != err {
-		t.Fatalf("swiftclient.Down() failed: %v", err)
-	}
-
-	err = dlm.Down()
-	if nil != err {
-		t.Fatalf("dlm.Down() failed: %v", err)
-	}
-
-	err = stats.Down()
-	if nil != err {
-		t.Fatalf("stats.Down() failed: %v", err)
-	}
-
-	err = evtlog.Down()
-	if nil != err {
-		t.Fatalf("evtlog.Down() failed: %v", err)
-	}
-
-	err = logger.Down()
-	if nil != err {
-		t.Fatalf("logger.Down() failed: %v", err)
+		t.Fatalf("transitions.Down() failed: %v", err)
 	}
 
 	_ = syscall.Kill(syscall.Getpid(), unix.SIGTERM)

--- a/inodeworkout/main.go
+++ b/inodeworkout/main.go
@@ -9,13 +9,8 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/dlm"
-	"github.com/swiftstack/ProxyFS/evtlog"
-	"github.com/swiftstack/ProxyFS/headhunter"
 	"github.com/swiftstack/ProxyFS/inode"
-	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/stats"
-	"github.com/swiftstack/ProxyFS/swiftclient"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 const (
@@ -65,9 +60,14 @@ func main() {
 		err                          error
 		latencyPerOpInMilliSeconds   float64
 		opsPerSecond                 float64
+		primaryPeer                  string
 		timeAfterMeasuredOperations  time.Time
 		timeBeforeMeasuredOperations time.Time
+		volumeGroupToCheck           string
+		volumeGroupToUse             string
+		volumeGroupList              []string
 		volumeList                   []string
+		whoAmI                       string
 	)
 
 	// Parse arguments
@@ -134,71 +134,60 @@ func main() {
 
 	// Start up needed ProxyFS components
 
-	err = logger.Up(confMap)
+	err = transitions.Up(confMap)
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "logger.Up() failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "transitions.Up() failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	err = evtlog.Up(confMap)
+	// Select first Volume of the first "active" VolumeGroup in [FSGlobals]VolumeGroupList
+
+	whoAmI, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "evtlog.Up() failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueString(\"Cluster\", \"WhoAmI\") failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	err = stats.Up(confMap)
+	volumeGroupList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeGroupList")
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "stats.Up() failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeGroupList\") failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	err = dlm.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "dlm.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
+	volumeGroupToUse = ""
 
-	err = swiftclient.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "swiftclient.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = headhunter.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "headhunter.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = inode.Up(confMap)
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "inode.Up() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Select first "active" volumeName in volumeList by attempting to mount each
-
-	volumeList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") failed: %v\n", err)
-		os.Exit(1)
-	}
-	if 1 > len(volumeList) {
-		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") returned empty volumeList")
-		os.Exit(1)
-	}
-
-	for _, volumeName = range volumeList {
-		volumeHandle, err = inode.FetchVolumeHandle(volumeName)
-		if nil == err {
+	for _, volumeGroupToCheck = range volumeGroupList {
+		primaryPeer, err = confMap.FetchOptionValueString("VolumeGroup:"+volumeGroupToCheck, "PrimaryPeer")
+		if nil != err {
+			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueString(\"VolumeGroup:%s\", \"PrimaryPeer\") failed: %v\n", volumeGroupToCheck, err)
+			os.Exit(1)
+		}
+		if whoAmI == primaryPeer {
+			volumeGroupToUse = volumeGroupToCheck
 			break
-		} else {
-			volumeHandle = nil
 		}
 	}
 
-	if nil == volumeHandle {
-		fmt.Fprintf(os.Stderr, "inode.FetchVolumeHandle() failed on every volumeName in volumeList: %v\n", volumeList)
+	if "" == volumeGroupToUse {
+		fmt.Fprintf(os.Stderr, "confMap didn't contain an \"active\" VolumeGroup")
+		os.Exit(1)
+	}
+
+	volumeList, err = confMap.FetchOptionValueStringSlice("VolumeGroup:"+volumeGroupToUse, "VolumeList")
+	if nil != err {
+		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"VolumeGroup:%s\", \"PrimaryPeer\") failed: %v\n", volumeGroupToUse, err)
+		os.Exit(1)
+	}
+	if 1 > len(volumeList) {
+		fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"VolumeGroup:%s\", \"VolumeList\") returned empty volumeList", volumeGroupToUse)
+		os.Exit(1)
+	}
+
+	volumeName = volumeList[0]
+
+	volumeHandle, err = inode.FetchVolumeHandle(volumeName)
+	if nil != err {
+		fmt.Fprintf(os.Stderr, "inode.FetchVolumeHandle(\"%value\") failed: %v\n", volumeName, err)
 		os.Exit(1)
 	}
 
@@ -247,45 +236,9 @@ func main() {
 
 	// Stop ProxyFS components launched above
 
-	err = inode.Down()
+	err = transitions.Down(confMap)
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "inode.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = swiftclient.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "swiftclient.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = headhunter.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "headhunter.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = dlm.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "dlm.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = stats.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "stats.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = evtlog.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "evtlog.Down() failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	err = logger.Down()
-	if nil != err {
-		fmt.Fprintf(os.Stderr, "logger.Down() failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "transitions.Down() failed: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/jrpcfs/config.go
+++ b/jrpcfs/config.go
@@ -9,14 +9,13 @@ import (
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/fs"
 	"github.com/swiftstack/ProxyFS/logger"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 type globalsStruct struct {
-	sync.Mutex
-
-	gate sync.RWMutex // SIGHUP triggered confMap change control
-	//                   API Requests RLock()/RUnlock
-	//                   SIGHUP confMap changes Lock()/Unlock()
+	mapsLock sync.Mutex   // protects volumeMap/mountIDMap/lastMountID/bimodalMountMap
+	gate     sync.RWMutex // API Requests RLock()/RUnlock()
+	//                       confMap changes Lock()/Unlock()
 
 	whoAmI          string
 	ipAddr          string
@@ -27,13 +26,13 @@ type globalsStruct struct {
 	// Map used to enumerate volumes served by this peer
 	volumeMap map[string]bool // key == volumeName; value is ignored
 
-	// Map used to store volumes already mounted for bimodal support
+	// Map used to store volumes by ID already mounted for bimodal support
 	// TODO: These never get purged !!!
-	mountIDMap  map[uint64]fs.MountHandle
+	mountIDMap  map[uint64]fs.MountHandle // key == mountID
 	lastMountID uint64
 
-	// Map used to store volumes already mounted for bimodal support
-	bimodalMountMap map[string]fs.MountHandle
+	// Map used to store volumes by name already mounted for bimodal support
+	bimodalMountMap map[string]fs.MountHandle // key == volumeName
 
 	// Connection list and listener list to close during shutdown:
 	halting     bool
@@ -46,18 +45,14 @@ type globalsStruct struct {
 
 var globals globalsStruct
 
-// NOTE: Don't use logger.Fatal* to error out from this function; it prevents us
-//       from handling returned errors and gracefully unwinding.
-func Up(confMap conf.ConfMap) (err error) {
-	var (
-		primaryPeerList []string
-		volumeList      []string
-		volumeName      string
-	)
+func init() {
+	transitions.Register("jrpcfs", &globals)
+}
 
+func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
+	globals.volumeMap = make(map[string]bool)
 	globals.mountIDMap = make(map[uint64]fs.MountHandle)
 	globals.lastMountID = uint64(0) // The only invalid MountID
-
 	globals.bimodalMountMap = make(map[string]fs.MountHandle)
 
 	// Fetch IPAddr from config file
@@ -96,34 +91,7 @@ func Up(confMap conf.ConfMap) (err error) {
 		return
 	}
 
-	// Compute volumeMap
-	volumeList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
-	if nil != err {
-		err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") failed: %v", err)
-		return
-	}
-
-	globals.volumeMap = make(map[string]bool)
-
-	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
-		if nil != err {
-			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
-			return
-		}
-
-		if 0 == len(primaryPeerList) {
-			continue
-		} else if 1 == len(primaryPeerList) {
-			if globals.whoAmI == primaryPeerList[0] {
-				globals.volumeMap[volumeName] = true
-			}
-		} else {
-			err = fmt.Errorf("%v.PrimaryPeer cannot be multi-valued", volumeName)
-			return
-		}
-	}
-
+	// Init listeners
 	globals.listeners = make([]net.Listener, 0, 2)
 	globals.connections = list.New()
 
@@ -136,170 +104,58 @@ func Up(confMap conf.ConfMap) (err error) {
 	return
 }
 
-func PauseAndContract(confMap conf.ConfMap) (err error) {
-	var (
-		dataPathLogging    bool
-		fastPortString     string
-		ipAddr             string
-		mountHandle        fs.MountHandle
-		mountID            uint64
-		ok                 bool
-		portString         string
-		primaryPeerList    []string
-		removedMountIDList []uint64
-		removedVolumeList  []string
-		updatedVolumeMap   map[string]bool
-		volumeList         []string
-		volumeName         string
-		whoAmI             string
-	)
+func (dummy *globalsStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
 
-	whoAmI, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
-	if nil != err {
-		err = fmt.Errorf("confMap.FetchOptionValueString(\"Cluster\", \"WhoAmI\") failed: %v", err)
-		return
-	}
-	if whoAmI != globals.whoAmI {
-		err = fmt.Errorf("confMap change not allowed to alter [Cluster]WhoAmI")
-		return
-	}
-
-	ipAddr, err = confMap.FetchOptionValueString("Peer:"+whoAmI, "PrivateIPAddr")
-	if nil != err {
-		err = fmt.Errorf("confMap.FetchOptionValueString(\"<whoAmI>\", \"PrivateIPAddr\") failed: %v", err)
-		return
-	}
-	if ipAddr != globals.ipAddr {
-		err = fmt.Errorf("confMap change not allowed to alter [<whoAmI>]PrivateIPAddr")
-		return
-	}
-
-	portString, err = confMap.FetchOptionValueString("JSONRPCServer", "TCPPort")
-	if nil != err {
-		err = fmt.Errorf("confMap.FetchOptionValueString(\"JSONRPCServer\", \"TCPPort\") failed: %v", err)
-		return
-	}
-	if portString != globals.portString {
-		err = fmt.Errorf("confMap change not allowed to alter [JSONRPCServer]TCPPort")
-		return
-	}
-
-	fastPortString, err = confMap.FetchOptionValueString("JSONRPCServer", "FastTCPPort")
-	if nil != err {
-		err = fmt.Errorf("confMap.FetchOptionValueString(\"JSONRPCServer\", \"FastTCPPort\") failed: %v", err)
-		return
-	}
-	if fastPortString != globals.fastPortString {
-		err = fmt.Errorf("confMap change not allowed to alter [JSONRPCServer]FastTCPPort")
-		return
-	}
-
-	dataPathLogging, err = confMap.FetchOptionValueBool("JSONRPCServer", "DataPathLogging")
-	if nil != err {
-		err = fmt.Errorf("confMap.FetchOptionValueString(\"JSONRPCServer\", \"DataPathLogging\") failed: %v", err)
-		return
-	}
-	if dataPathLogging != globals.dataPathLogging {
-		err = fmt.Errorf("confMap change not allowed to alter [JSONRPCServer]DataPathLogging")
-		return
-	}
-
+func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string) (err error) {
 	globals.gate.Lock()
-
-	volumeList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
-	if nil != err {
-		err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") failed: %v", err)
-		return
-	}
-
-	updatedVolumeMap = make(map[string]bool)
-
-	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
-		if nil != err {
-			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
-			return
-		}
-
-		if 0 == len(primaryPeerList) {
-			continue
-		} else if 1 == len(primaryPeerList) {
-			if globals.whoAmI == primaryPeerList[0] {
-				updatedVolumeMap[volumeName] = true
-			}
-		} else {
-			err = fmt.Errorf("%v.PrimaryPeer cannot be multi-valued", volumeName)
-			return
-		}
-	}
-
-	removedVolumeList = make([]string, 0, len(globals.volumeMap))
-	removedMountIDList = make([]uint64, 0, len(globals.mountIDMap))
-
-	for volumeName = range globals.volumeMap {
-		_, ok = updatedVolumeMap[volumeName]
-		if !ok {
-			removedVolumeList = append(removedVolumeList, volumeName)
-			for mountID, mountHandle = range globals.mountIDMap {
-				if mountHandle.VolumeName() == volumeName {
-					removedMountIDList = append(removedMountIDList, mountID)
-				}
-			}
-		}
-	}
-
-	for _, volumeName = range removedVolumeList {
-		delete(globals.volumeMap, volumeName)
-		_, ok = globals.bimodalMountMap[volumeName]
-		if ok {
-			delete(globals.bimodalMountMap, volumeName)
-		}
-	}
-
-	for _, mountID = range removedMountIDList {
-		delete(globals.mountIDMap, mountID)
-	}
+	globals.volumeMap[volumeName] = true
+	globals.gate.Unlock()
 
 	err = nil
 	return
 }
 
-func ExpandAndResume(confMap conf.ConfMap) (err error) {
+func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
 	var (
-		primaryPeerList  []string
-		updatedVolumeMap map[string]bool
-		volumeList       []string
-		volumeName       string
+		mountHandle        fs.MountHandle
+		mountID            uint64
+		removedMountID     uint64
+		removedMountIDList []uint64
 	)
 
-	volumeList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
-	if nil != err {
-		err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") failed: %v", err)
-		return
-	}
+	globals.gate.Lock()
 
-	updatedVolumeMap = make(map[string]bool)
+	removedMountIDList = make([]uint64, 0, len(globals.mountIDMap))
 
-	for _, volumeName = range volumeList {
-		primaryPeerList, err = confMap.FetchOptionValueStringSlice("Volume:"+volumeName, "PrimaryPeer")
-		if nil != err {
-			err = fmt.Errorf("confMap.FetchOptionValueStringSlice(\"%s\", \"PrimaryPeer\") failed: %v", volumeName, err)
-			return
-		}
-
-		if 0 == len(primaryPeerList) {
-			continue
-		} else if 1 == len(primaryPeerList) {
-			if globals.whoAmI == primaryPeerList[0] {
-				updatedVolumeMap[volumeName] = true
-			}
-		} else {
-			err = fmt.Errorf("%v.PrimaryPeer cannot be multi-valued", volumeName)
-			return
+	for mountID, mountHandle = range globals.mountIDMap {
+		if mountHandle.VolumeName() == volumeName {
+			removedMountIDList = append(removedMountIDList, mountID)
 		}
 	}
 
-	globals.volumeMap = updatedVolumeMap
+	for _, removedMountID = range removedMountIDList {
+		delete(globals.mountIDMap, removedMountID)
+	}
+
+	delete(globals.volumeMap, volumeName)
+	delete(globals.bimodalMountMap, volumeName)
 
 	globals.gate.Unlock()
 
@@ -307,33 +163,24 @@ func ExpandAndResume(confMap conf.ConfMap) (err error) {
 	return
 }
 
-func Down() (err error) {
+func (dummy *globalsStruct) Signaled(confMap conf.ConfMap) (err error) {
+	return nil
+}
+
+func (dummy *globalsStruct) Down(confMap conf.ConfMap) (err error) {
+	if 0 != len(globals.volumeMap) {
+		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.volumeMap")
+		return
+	}
+	if 0 != len(globals.mountIDMap) {
+		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.mountIDMap")
+		return
+	}
+	if 0 != len(globals.bimodalMountMap) {
+		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.bimodalMountMap")
+		return
+	}
+
 	err = nil
-	globals.halting = true
-
-	jsonRpcServerDown()
-	ioServerDown()
-
-	// Close the listeners first, so that there are no new connections.
-	globals.connLock.Lock()
-	for _, listener := range globals.listeners {
-		if listener != nil {
-			listener.Close()
-		}
-	}
-
-	globals.connLock.Unlock()
-
-	globals.listenersWG.Wait()
-
-	globals.connLock.Lock()
-	for elm := globals.connections.Front(); elm != nil; elm = elm.Next() {
-		conn := elm.Value.(net.Conn)
-		conn.Close()
-	}
-	globals.connLock.Unlock()
-
-	globals.connWG.Wait()
-
 	return
 }

--- a/jrpcfs/filesystem.go
+++ b/jrpcfs/filesystem.go
@@ -199,18 +199,18 @@ var saveChannelSize int = 1000
 var loggedOutOfStatsRoom map[OpType]bool = make(map[OpType]bool)
 
 func allocateMountID(mountHandle fs.MountHandle) (mountID uint64) {
-	globals.Lock()
+	globals.mapsLock.Lock()
 	globals.lastMountID++
 	mountID = globals.lastMountID
 	globals.mountIDMap[mountID] = mountHandle
-	globals.Unlock()
+	globals.mapsLock.Unlock()
 	return
 }
 
 func lookupMountHandle(mountID uint64) (mountHandle fs.MountHandle, err error) {
-	globals.Lock()
+	globals.mapsLock.Lock()
 	mountHandle, ok := globals.mountIDMap[mountID]
-	globals.Unlock()
+	globals.mapsLock.Unlock()
 	if ok {
 		err = nil
 	} else {

--- a/jrpcfs/middleware.go
+++ b/jrpcfs/middleware.go
@@ -39,8 +39,8 @@ func mountIfNotMounted(virtPath string) (accountName string, containerName strin
 	// However, this results in two different mountHandle's for the different jrpcfs threads supporting middleware.
 	//
 	// Therefore, jrpcfs has to do its own serialization and store the result in globals.bimodalMountMap.
-	globals.Lock()
-	defer globals.Unlock()
+	globals.mapsLock.Lock()
+	defer globals.mapsLock.Unlock()
 
 	// Is volume mounted for this user?  If is, return the results.
 	mountHandle, ok = globals.bimodalMountMap[volumeName]

--- a/logger/api.go
+++ b/logger/api.go
@@ -21,33 +21,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/utils"
 )
 
 type Level int
-
-// Call to configure the logger.  This really should be done before using it,
-// but you can log things before calling.  However, they will not appear in
-// the logfile and will not be in the new text format.
-//
-// Config variables that affect logging include:
-//     Logging.LogFilePath        string       if present, pathname to log file
-//     Logging.LogToConsole       bool         if present and true, log to console as well as file
-//     Logging.TraceLevelLogging  stringslice  list of packages where tracing is enabled (name must
-//                                             also appear in packageTraceSettings)
-//     Logging.DebugLevelLogging  stringslice
-//
-func Up(confMap conf.ConfMap) (err error) {
-	return up(confMap)
-}
-
-// Call to shutdown logging (closes the logfile)
-//
-func Down() (err error) {
-	return down()
-}
 
 // Our logging levels - These are the different logging levels supported by this package.
 //
@@ -810,9 +787,6 @@ func (ctx FuncCtx) log(level Level, args ...interface{}) {
 	}
 	// NOTE: Debug level checking is done in logWithID; all debug logging should
 	//       come through that API and not directly to this one.
-
-	// Peg the stat for the appropriate log level
-	stats.IncrementOperations(level.statString())
 
 	switch level {
 	case PanicLevel:

--- a/logger/api_test.go
+++ b/logger/api_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/utils"
 )
 
@@ -44,12 +43,6 @@ func TestAPI(t *testing.T) {
 		t.Fatalf(tErr)
 	}
 
-	err = stats.Up(confMap)
-	if nil != err {
-		tErr := fmt.Sprintf("stats.Up(confMap) failed: %v", err)
-		t.Fatalf(tErr)
-	}
-
 	Tracef("hello there!")
 	Tracef("hello again, %s!", "you")
 	Tracef("%v: %v", utils.GetFnName(), err)
@@ -61,15 +54,9 @@ func TestAPI(t *testing.T) {
 
 	testLogTargets(t)
 
-	err = stats.Down()
+	err = Down(confMap)
 	if nil != err {
-		tErr := fmt.Sprintf("stats.Down() failed: %v", err)
-		t.Fatalf(tErr)
-	}
-
-	err = Down()
-	if nil != err {
-		tErr := fmt.Sprintf("logger.Down() failed: %v", err)
+		tErr := fmt.Sprintf("logger.Down(confMap) failed: %v", err)
 		t.Fatalf(tErr)
 	}
 }

--- a/mkproxyfs/api.go
+++ b/mkproxyfs/api.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/swiftstack/ProxyFS/blunder"
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/dlm"
-	"github.com/swiftstack/ProxyFS/evtlog"
 	"github.com/swiftstack/ProxyFS/headhunter"
 	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/swiftclient"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 type Mode int
@@ -34,6 +32,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 		objectList        []string
 		objectName        string
 		replayLogFileName string
+		whoAmI            string
 	)
 
 	// Valid mode?
@@ -61,6 +60,23 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 		return
 	}
 
+	// Upgrade confMap if necessary
+	// [should be removed once backwards compatibility is no longer required...]
+
+	err = transitions.UpgradeConfMapIfNeeded(confMap)
+	if nil != err {
+		err = fmt.Errorf("failed to upgrade config: %v", err)
+		return
+	}
+
+	// Update confMap to specify an empty FSGlobals.VolumeGroupList
+
+	err = confMap.UpdateFromString("FSGlobals.VolumeGroupList=")
+	if nil != err {
+		err = fmt.Errorf("failed to empty config VolumeGroupList: %v", err)
+		return
+	}
+
 	// Fetch confMap particulars needed below
 
 	accountName, err = confMap.FetchOptionValueString("Volume:"+volumeNameToFormat, "AccountName")
@@ -68,49 +84,15 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 		return
 	}
 
-	// Call Up() for required packages (deferring their Down() calls until function return)
+	// Call transitions.Up() with empty FSGlobals.VolumeGroupList
 
-	err = logger.Up(confMap)
+	err = transitions.Up(confMap)
 	if nil != err {
 		return
 	}
-	defer func() {
-		_ = logger.Down()
-	}()
+
 	logger.Infof("mkproxyfs is starting up (PID %d); invoked as '%s'",
 		os.Getpid(), strings.Join(execArgs, "' '"))
-
-	err = evtlog.Up(confMap)
-	if nil != err {
-		return
-	}
-	defer func() {
-		_ = evtlog.Down()
-	}()
-
-	err = stats.Up(confMap)
-	if nil != err {
-		return
-	}
-	defer func() {
-		_ = stats.Down()
-	}()
-
-	err = dlm.Up(confMap)
-	if nil != err {
-		return
-	}
-	defer func() {
-		_ = dlm.Down()
-	}()
-
-	err = swiftclient.Up(confMap)
-	if nil != err {
-		return
-	}
-	defer func() {
-		_ = swiftclient.Down()
-	}()
 
 	// Determine if underlying accountName is empty
 
@@ -123,6 +105,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 			// accountName does not exist, so accountName is empty
 			isEmpty = true
 		} else {
+			_ = transitions.Down(confMap)
 			err = fmt.Errorf("failed to GET %v: %v", accountName, err)
 			return
 		}
@@ -133,11 +116,13 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 		case ModeNew:
 			// If Swift Account is not empty && ModeNew, exit with failure
 
+			_ = transitions.Down(confMap)
 			err = fmt.Errorf("%v found to be non-empty with mode == ModeNew (%v)", accountName, ModeNew)
 			return
 		case ModeOnlyIfNeeded:
 			// If Swift Account is not empty && ModeOnlyIfNeeded, exit successfully
 
+			_ = transitions.Down(confMap)
 			err = nil
 			return
 		case ModeReformat:
@@ -147,6 +132,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 				for _, containerName = range containerList {
 					_, objectList, err = swiftclient.ContainerGet(accountName, containerName)
 					if nil != err {
+						_ = transitions.Down(confMap)
 						err = fmt.Errorf("failed to GET %v/%v: %v", accountName, containerName, err)
 						return
 					}
@@ -157,6 +143,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 						for _, objectName = range objectList {
 							err = swiftclient.ObjectDelete(accountName, containerName, objectName, 0)
 							if nil != err {
+								_ = transitions.Down(confMap)
 								err = fmt.Errorf("failed to DELETE %v/%v/%v: %v", accountName, containerName, objectName, err)
 								return
 							}
@@ -164,6 +151,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 
 						_, objectList, err = swiftclient.ContainerGet(accountName, containerName)
 						if nil != err {
+							_ = transitions.Down(confMap)
 							err = fmt.Errorf("failed to GET %v/%v: %v", accountName, containerName, err)
 							return
 						}
@@ -173,6 +161,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 
 					err = swiftclient.ContainerDelete(accountName, containerName)
 					if nil != err {
+						_ = transitions.Down(confMap)
 						err = fmt.Errorf("failed to DELETE %v/%v: %v", accountName, containerName, err)
 						return
 					}
@@ -180,6 +169,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 
 				_, containerList, err = swiftclient.AccountGet(accountName)
 				if nil != err {
+					_ = transitions.Down(confMap)
 					err = fmt.Errorf("failed to GET %v: %v", accountName, err)
 					return
 				}
@@ -193,6 +183,7 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 					removeReplayLogFileErr := os.Remove(replayLogFileName)
 					if nil != removeReplayLogFileErr {
 						if !os.IsNotExist(removeReplayLogFileErr) {
+							_ = transitions.Down(confMap)
 							err = fmt.Errorf("os.Remove(replayLogFileName == \"%v\") returned unexpected error: %v", replayLogFileName, removeReplayLogFileErr)
 							return
 						}
@@ -202,9 +193,48 @@ func Format(mode Mode, volumeNameToFormat string, confFile string, confStrings [
 		}
 	}
 
-	// Format Swift Account (who's error return will suffice for this function's error return)
+	// Call transitions.Down() before restarting to do format
 
-	err = headhunter.Format(confMap, volumeNameToFormat)
+	err = transitions.Down(confMap)
+	if nil != err {
+		return
+	}
+
+	// Update confMap to specify only volumeNameToFormat with AuthFormat set to true
+
+	whoAmI, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
+	if nil != err {
+		return
+	}
+
+	err = confMap.UpdateFromStrings([]string{
+		"FSGlobals.VolumeGroupList=MKPROXYFS",
+		"VolumeGroup:MKPROXYFS.VolumeList=" + volumeNameToFormat,
+		"VolumeGroup:MKPROXYFS.VirtualIPAddr=",
+		"VolumeGroup:MKPROXYFS.PrimaryPeer=" + whoAmI,
+		"Volume:" + volumeNameToFormat + ".AutoFormat=true"})
+	if nil != err {
+		err = fmt.Errorf("failed to retarget config at only %s: %v", volumeNameToFormat, err)
+		return
+	}
+
+	// Restart... this time AutoFormat of volumeNameToFormat will be applied
+
+	err = transitions.Up(confMap)
+	if nil != err {
+		return
+	}
+
+	// Make reference to package headhunter to ensure it gets registered with package transitions
+
+	_, err = headhunter.FetchVolumeHandle(volumeNameToFormat)
+	if nil != err {
+		return
+	}
+
+	// With format complete, we can shutdown for good... return code set appropriately by Down()
+
+	err = transitions.Down(confMap)
 
 	return
 }

--- a/pfs-crash/main.go
+++ b/pfs-crash/main.go
@@ -94,17 +94,12 @@ func main() {
 		mkproxyfsCmd                *exec.Cmd
 		nextHalterTriggerIndex      int
 		peerSectionName             string
-		primaryPeer                 string
 		privateIPAddr               string
 		randomHaltAfterCount        uint64
 		randomKillDelay             time.Duration
 		signalChan                  chan os.Signal
 		signalToSend                os.Signal
 		triggerBoolAndTrafficScript string
-		volumeList                  []string
-		volumeListElement           string
-		volumeNameInVolumeList      bool
-		volumeSectionName           string
 		whoAmI                      string
 	)
 
@@ -165,32 +160,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	volumeList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
-	if nil != err {
-		return
-	}
-	volumeNameInVolumeList = false
-	for _, volumeListElement = range volumeList {
-		if volumeName == volumeListElement {
-			volumeNameInVolumeList = true
-			break
-		}
-	}
-	if !volumeNameInVolumeList {
-		log.Fatalf("volumeName (%s) not found in volumeList (%v)", volumeName, volumeList)
-	}
-
-	volumeSectionName = "Volume:" + volumeName
-
-	primaryPeer, err = confMap.FetchOptionValueString(volumeSectionName, "PrimaryPeer")
-	if nil != err {
-		log.Fatal(err)
-	}
-	if whoAmI != primaryPeer {
-		log.Fatalf("Cluster.WhoAmI (%s) does not match %s.PrimaryPeer (%s)", whoAmI, volumeSectionName, primaryPeer)
-	}
-
-	peerSectionName = "Peer:" + primaryPeer
+	peerSectionName = "Peer:" + whoAmI
 
 	privateIPAddr, err = confMap.FetchOptionValueString(peerSectionName, "PrivateIPAddr")
 	if nil != err {
@@ -204,7 +174,7 @@ func main() {
 
 	ipAddrTCPPort = net.JoinHostPort(privateIPAddr, strconv.Itoa(int(httpServerTCPPort)))
 
-	fuseMountPointName, err = confMap.FetchOptionValueString(volumeSectionName, "FUSEMountPointName")
+	fuseMountPointName, err = confMap.FetchOptionValueString("Volume:"+volumeName, "FUSEMountPointName")
 	if nil != err {
 		log.Fatal(err)
 	}

--- a/pfsalived/macpfsalived0.conf
+++ b/pfsalived/macpfsalived0.conf
@@ -1,9 +1,9 @@
 # Peer 0's .conf file
 
 [AliveDaemon]
-WhoAmI:        Peer0
-PeersToWatch:  Peer0
-WatchInterval: 5s
-TCPPort:       15432
+WhoAmI:               Peer0
+VolumeGroupsToWatch:  CommonVolumeGroup
+WatchInterval:        5s
+TCPPort:              15432
 
 .include ../proxyfsd/macproxyfsd0.conf

--- a/pfsalived/main.go
+++ b/pfsalived/main.go
@@ -35,55 +35,70 @@ const maxRPCReplySize = 4096
 type httpRequestHandler struct{}
 
 const (
-	volumeStateAlive   = "alive"
-	volumeStateDead    = "dead"
-	volumeStateUnknown = "unknown"
+	stateAlive      = "alive"
+	stateFragmented = "fragmented"
+	stateDead       = "dead"
+	stateUnknown    = "unknown"
 )
 
 type volumeStruct struct {
-	peer          *peerStruct
-	next          *volumeStruct // circular linked list currently pointed to by globalsStruct.volumesToWatch
+	next          *volumeStruct
+	volumeGroup   *volumeGroupStruct
 	Name          string
 	State         string
 	LastCheckTime time.Time
 }
 
+type volumeGroupStruct struct {
+	next          *volumeGroupStruct
+	peer          *peerStruct
+	Name          string
+	headVolume    *volumeStruct // links to first volumeStruct; nil-terminated
+	virtualIPAddr string
+}
+
 type peerStruct struct {
-	Name           string
-	PublicIPAddr   string
-	PrivateIPAddr  string
-	ipAddrTCPPort  string
-	VolumesToWatch map[string]*volumeStruct // key == volumeStruct.name
+	Name          string
+	publicIPAddr  string
+	privateIPAddr string
+	ipAddrTCPPort string
 }
 
 type globalsStruct struct {
-	confMap           conf.ConfMap
-	whoAmI            string
-	peersToWatch      map[string]*peerStruct // key == peerStruct.name
-	volumesToWatch    *volumeStruct          // links to next volumeStruct to examine
-	volumesToWatchLen time.Duration          // using this type makes pollingInterval computation avoid casting
-	pollingInterval   time.Duration          // volumesToWatchLen / AliveDaemon.WatchInterval
-	netListener       net.Listener
-	childrenWG        sync.WaitGroup
+	confMap             conf.ConfMap
+	whoAmI              string
+	volumeGroupsToWatch []string
+	watchInterval       time.Duration
+	daemonTCPPort       uint16
+	jrpcTCPPort         uint16
+	headVolumeGroup     *volumeGroupStruct     // links to first volumeGroupStruct; nil-terminated
+	peerMap             map[string]*peerStruct // key == peerStruct.Name
+	nextVolumeToWatch   *volumeStruct
+	numVolumesToWatch   uint64
+	volumesToWatch      []*volumeStruct
+	pollingInterval     time.Duration // watchInterval / numVolumesToWatch
+	netListener         net.Listener
+	childrenWG          sync.WaitGroup
 }
 
 var globals globalsStruct
 
 func main() {
 	var (
-		args          []string
-		err           error
-		ipAddr        string
-		ipAddrTCPPort string
-		ok            bool
-		peer          *peerStruct
-		peerName      string
-		peersToWatch  []string
-		tcpPort       uint16
-		volume        *volumeStruct
-		volumeList    []string
-		volumeName    string
-		watchInterval time.Duration
+		args                   []string
+		err                    error
+		ipAddr                 string
+		ipAddrTCPPort          string
+		ok                     bool
+		peer                   *peerStruct
+		peerSectionName        string
+		primaryPeer            string
+		volume                 *volumeStruct
+		volumeGroup            *volumeGroupStruct
+		volumeGroupName        string
+		volumeGroupSectionName string
+		volumeList             []string
+		volumeName             string
 	)
 
 	// Parse arguments
@@ -113,90 +128,131 @@ func main() {
 		log.Fatal(err)
 	}
 
-	peersToWatch, err = globals.confMap.FetchOptionValueStringSlice("AliveDaemon", "PeersToWatch")
+	globals.volumeGroupsToWatch, err = globals.confMap.FetchOptionValueStringSlice("AliveDaemon", "VolumeGroupsToWatch")
+	if nil != err {
+		log.Fatal(err)
+	}
+	if 0 == len(globals.volumeGroupsToWatch) {
+		log.Fatalf("No VolumeGroups to watch")
+	}
+
+	globals.watchInterval, err = globals.confMap.FetchOptionValueDuration("AliveDaemon", "WatchInterval")
 	if nil != err {
 		log.Fatal(err)
 	}
 
-	tcpPort, err = globals.confMap.FetchOptionValueUint16("JSONRPCServer", "TCPPort")
+	globals.daemonTCPPort, err = globals.confMap.FetchOptionValueUint16("AliveDaemon", "TCPPort")
 	if nil != err {
 		log.Fatal(err)
 	}
 
-	globals.peersToWatch = make(map[string]*peerStruct)
-
-	for _, peerName = range peersToWatch {
-		peer = &peerStruct{
-			Name:           peerName,
-			VolumesToWatch: make(map[string]*volumeStruct),
-		}
-		peer.PublicIPAddr, err = globals.confMap.FetchOptionValueString("Peer:"+peerName, "PublicIPAddr")
-		if nil != err {
-			log.Fatal(err)
-		}
-		peer.PrivateIPAddr, err = globals.confMap.FetchOptionValueString("Peer:"+peerName, "PrivateIPAddr")
-		if nil != err {
-			log.Fatal(err)
-		}
-		peer.ipAddrTCPPort = net.JoinHostPort(peer.PrivateIPAddr, strconv.Itoa(int(tcpPort)))
-		globals.peersToWatch[peer.Name] = peer
-	}
-
-	volumeList, err = globals.confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
+	globals.jrpcTCPPort, err = globals.confMap.FetchOptionValueUint16("JSONRPCServer", "TCPPort")
 	if nil != err {
 		log.Fatal(err)
 	}
 
-	globals.volumesToWatch = nil
-	globals.volumesToWatchLen = time.Duration(0)
+	globals.headVolumeGroup = nil
+	globals.peerMap = make(map[string]*peerStruct)
+	globals.nextVolumeToWatch = nil
+	globals.numVolumesToWatch = uint64(0)
 
-	for _, volumeName = range volumeList {
-		peerName, err = globals.confMap.FetchOptionValueString("Volume:"+volumeName, "PrimaryPeer")
+	for _, volumeGroupName = range globals.volumeGroupsToWatch {
+		volumeGroup = &volumeGroupStruct{
+			next:       globals.headVolumeGroup,
+			Name:       volumeGroupName,
+			headVolume: nil,
+		}
+
+		volumeGroupSectionName = "VolumeGroup:" + volumeGroup.Name
+
+		volumeList, err = globals.confMap.FetchOptionValueStringSlice(volumeGroupSectionName, "VolumeList")
 		if nil != err {
 			log.Fatal(err)
 		}
-		peer, ok = globals.peersToWatch[peerName]
-		if ok {
+		if 0 == len(volumeList) {
+			log.Fatalf("No Volumes in VolumeGroup \"%s\" to watch", volumeGroup.Name)
+		}
+
+		for _, volumeName = range volumeList {
 			volume = &volumeStruct{
-				peer:          peer,
-				next:          globals.volumesToWatch,
+				next:          volumeGroup.headVolume,
+				volumeGroup:   volumeGroup,
 				Name:          volumeName,
-				State:         volumeStateUnknown,
+				State:         stateUnknown,
 				LastCheckTime: time.Now(),
 			}
-			if 0 == globals.volumesToWatchLen {
-				volume.next = volume
-			} else {
-				globals.volumesToWatch.next = volume
-			}
-			globals.volumesToWatch = volume
-			globals.volumesToWatchLen++
-			peer.VolumesToWatch[volume.Name] = volume
+
+			volumeGroup.headVolume = volume
+			globals.nextVolumeToWatch = volume
+			globals.numVolumesToWatch++
 		}
+
+		volumeGroup.virtualIPAddr, err = globals.confMap.FetchOptionValueString(volumeGroupSectionName, "VirtualIPAddr")
+		if nil != err {
+			if nil == globals.confMap.VerifyOptionValueIsEmpty(volumeGroupSectionName, "VirtualIPAddr") {
+				volumeGroup.virtualIPAddr = ""
+			} else {
+				log.Fatal(err)
+			}
+		}
+
+		primaryPeer, err = globals.confMap.FetchOptionValueString(volumeGroupSectionName, "PrimaryPeer")
+		if nil != err {
+			log.Fatal(err)
+		}
+
+		volumeGroup.peer, ok = globals.peerMap[primaryPeer]
+
+		if !ok {
+			peer = &peerStruct{
+				Name: primaryPeer,
+			}
+
+			peerSectionName = "Peer:" + peer.Name
+
+			peer.publicIPAddr, err = globals.confMap.FetchOptionValueString(peerSectionName, "PublicIPAddr")
+			if nil != err {
+				log.Fatal(err)
+			}
+			peer.privateIPAddr, err = globals.confMap.FetchOptionValueString(peerSectionName, "PrivateIPAddr")
+			if nil != err {
+				log.Fatal(err)
+			}
+
+			peer.ipAddrTCPPort = net.JoinHostPort(peer.privateIPAddr, strconv.Itoa(int(globals.jrpcTCPPort)))
+
+			globals.peerMap[peer.Name] = peer
+
+			volumeGroup.peer = peer
+		}
+
+		globals.headVolumeGroup = volumeGroup
 	}
 
-	if 0 == globals.volumesToWatchLen {
-		log.Fatalf("No volumes to watch")
+	globals.volumesToWatch = make([]*volumeStruct, 0, globals.numVolumesToWatch)
+
+	volumeGroup = globals.headVolumeGroup
+
+	for nil != volumeGroup {
+		volume = volumeGroup.headVolume
+
+		for nil != volume {
+			globals.volumesToWatch = append(globals.volumesToWatch, volume)
+
+			volume = volume.next
+		}
+
+		volumeGroup = volumeGroup.next
 	}
 
-	watchInterval, err = globals.confMap.FetchOptionValueDuration("AliveDaemon", "WatchInterval")
-	if nil != err {
-		log.Fatal(err)
-	}
-
-	globals.pollingInterval = watchInterval / globals.volumesToWatchLen
-
-	tcpPort, err = globals.confMap.FetchOptionValueUint16("AliveDaemon", "TCPPort")
-	if nil != err {
-		log.Fatal(err)
-	}
+	globals.pollingInterval = globals.watchInterval / time.Duration(globals.numVolumesToWatch)
 
 	ipAddr, err = globals.confMap.FetchOptionValueString("Peer:"+globals.whoAmI, "PrivateIPAddr")
 	if nil != err {
 		log.Fatal(err)
 	}
 
-	ipAddrTCPPort = net.JoinHostPort(ipAddr, strconv.Itoa(int(tcpPort)))
+	ipAddrTCPPort = net.JoinHostPort(ipAddr, strconv.Itoa(int(globals.daemonTCPPort)))
 
 	globals.netListener, err = net.Listen("tcp", ipAddrTCPPort)
 	if nil != err {
@@ -232,7 +288,7 @@ func doPolling() {
 
 	for {
 		time.Sleep(globals.pollingInterval)
-		volume = globals.volumesToWatch
+		volume = globals.nextVolumeToWatch
 		timeNow = time.Now()
 		pingReq.JSONrpc = "2.0"
 		pingReq.Method = "Server.RpcPing"
@@ -240,7 +296,7 @@ func doPolling() {
 		pingReq.ID = nextID
 		pingReqBuf, err = json.Marshal(pingReq)
 		if nil == err {
-			tcpAddr, err = net.ResolveTCPAddr("tcp", volume.peer.ipAddrTCPPort)
+			tcpAddr, err = net.ResolveTCPAddr("tcp", volume.volumeGroup.peer.ipAddrTCPPort)
 			if nil == err {
 				tcpConn, err = net.DialTCP("tcp", nil, tcpAddr)
 				if nil == err {
@@ -254,32 +310,40 @@ func doPolling() {
 								pingReplyBuf = pingReplyBuf[:pingReplyLen]
 								err = json.Unmarshal(pingReplyBuf, &pingReply)
 								if nil == err {
-									volume.State = volumeStateAlive
+									volume.State = stateAlive
 								} else {
-									volume.State = volumeStateDead
+									volume.State = stateDead
 								}
 							} else {
-								volume.State = volumeStateDead
+								volume.State = stateDead
 							}
 						} else {
 							_ = tcpConn.Close()
-							volume.State = volumeStateDead
+							volume.State = stateDead
 						}
 					} else {
 						_ = tcpConn.Close()
-						volume.State = volumeStateDead
+						volume.State = stateDead
 					}
 				} else {
-					volume.State = volumeStateDead
+					volume.State = stateDead
 				}
 			} else {
-				volume.State = volumeStateDead
+				volume.State = stateDead
 			}
 		} else {
-			volume.State = volumeStateDead
+			volume.State = stateDead
 		}
 		volume.LastCheckTime = timeNow
-		globals.volumesToWatch = volume.next
+		if nil == volume.next {
+			if nil == volume.volumeGroup.next {
+				globals.nextVolumeToWatch = globals.headVolumeGroup.headVolume
+			} else {
+				globals.nextVolumeToWatch = volume.volumeGroup.next.headVolume
+			}
+		} else {
+			globals.nextVolumeToWatch = volume.next
+		}
 		nextID++
 	}
 }
@@ -389,7 +453,7 @@ func doGetOfStatus(responseWriter http.ResponseWriter, request *http.Request) {
 		sendPackedStatus = false
 	}
 
-	statusJSONPacked, _ = json.Marshal(globals.peersToWatch)
+	statusJSONPacked, _ = json.Marshal(globals.volumesToWatch)
 
 	responseWriter.Header().Set("Content-Type", "application/json")
 	responseWriter.WriteHeader(http.StatusOK)

--- a/pfsalived/pfsalived0.conf
+++ b/pfsalived/pfsalived0.conf
@@ -1,9 +1,9 @@
 # Peer 0's .conf file
 
 [AliveDaemon]
-WhoAmI:        Peer0
-PeersToWatch:  Peer0
-WatchInterval: 5s
-TCPPort:       15432
+WhoAmI:               Peer0
+VolumeGroupsToWatch:  CommonVolumeGroup
+WatchInterval:        5s
+TCPPort:              15432
 
 .include ../proxyfsd/proxyfsd0.conf

--- a/pfsalived/saiopfsalived0.conf
+++ b/pfsalived/saiopfsalived0.conf
@@ -1,9 +1,9 @@
 # Peer 0's .conf file
 
 [AliveDaemon]
-WhoAmI:        Peer0
-PeersToWatch:  Peer0
-WatchInterval: 5s
-TCPPort:       15432
+WhoAmI:               Peer0
+VolumeGroupsToWatch:  CommonVolumeGroup
+WatchInterval:        5s
+TCPPort:              15432
 
 .include ../proxyfsd/saioproxyfsd0.conf

--- a/pfsworkout/main.go
+++ b/pfsworkout/main.go
@@ -9,15 +9,11 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/dlm"
-	"github.com/swiftstack/ProxyFS/evtlog"
 	"github.com/swiftstack/ProxyFS/fs"
-	"github.com/swiftstack/ProxyFS/fuse"
 	"github.com/swiftstack/ProxyFS/headhunter"
 	"github.com/swiftstack/ProxyFS/inode"
-	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/stats"
 	"github.com/swiftstack/ProxyFS/swiftclient"
+	"github.com/swiftstack/ProxyFS/transitions"
 	"github.com/swiftstack/ProxyFS/utils"
 )
 
@@ -85,8 +81,6 @@ func main() {
 		confMap conf.ConfMap
 
 		proxyfsRequired = false
-		fsRequired      = false
-		fuseRequired    = false
 
 		doDirWorkout         = false
 		doFuseWorkout        = false
@@ -95,6 +89,13 @@ func main() {
 		doSwiftclientWorkout = false
 		doSameFile           = false
 		doRandomIO           = false
+
+		primaryPeer        string
+		volumeGroupToCheck string
+		volumeGroupToUse   string
+		volumeGroupList    []string
+		volumeList         []string
+		whoAmI             string
 
 		timeBeforeWrites time.Time
 		timeAfterWrites  time.Time
@@ -125,14 +126,9 @@ func main() {
 			doDirWorkout = true
 		case 'm':
 			proxyfsRequired = true
-			fsRequired = true
-			fuseRequired = true
-
 			doFuseWorkout = true
 		case 'f':
 			proxyfsRequired = true
-			fsRequired = true
-
 			doFsWorkout = true
 		case 'i':
 			proxyfsRequired = true
@@ -142,11 +138,9 @@ func main() {
 			doSwiftclientWorkout = true
 		case 'r':
 			proxyfsRequired = true
-			fsRequired = true
 			doRandomIO = true
 		case 'u':
 			proxyfsRequired = true
-			fsRequired = true
 			doSameFile = true
 		default:
 			fmt.Fprintf(os.Stderr, "workoutSelector ('%v') must be one of 'd', 'm', 'f', 'i', or 's'\n", string(workoutSelector))
@@ -201,13 +195,54 @@ func main() {
 			}
 		}
 
-		volumeList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeList")
+		// Select first Volume of the first "active" VolumeGroup in [FSGlobals]VolumeGroupList
+
+		whoAmI, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
 		if nil != err {
-			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") failed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueString(\"Cluster\", \"WhoAmI\") failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		volumeGroupList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeGroupList")
+		if nil != err {
+			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeGroupList\") failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		volumeGroupToUse = ""
+
+		for _, volumeGroupToCheck = range volumeGroupList {
+			primaryPeer, err = confMap.FetchOptionValueString("VolumeGroup:"+volumeGroupToCheck, "PrimaryPeer")
+			if nil != err {
+				fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueString(\"VolumeGroup:%s\", \"PrimaryPeer\") failed: %v\n", volumeGroupToCheck, err)
+				os.Exit(1)
+			}
+			if whoAmI == primaryPeer {
+				volumeGroupToUse = volumeGroupToCheck
+				break
+			}
+		}
+
+		if "" == volumeGroupToUse {
+			fmt.Fprintf(os.Stderr, "confMap didn't contain an \"active\" VolumeGroup")
+			os.Exit(1)
+		}
+
+		volumeList, err = confMap.FetchOptionValueStringSlice("VolumeGroup:"+volumeGroupToUse, "VolumeList")
+		if nil != err {
+			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"VolumeGroup:%s\", \"PrimaryPeer\") failed: %v\n", volumeGroupToUse, err)
 			os.Exit(1)
 		}
 		if 1 > len(volumeList) {
-			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"FSGlobals\", \"VolumeList\") returned empty volumeList")
+			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueStringSlice(\"VolumeGroup:%s\", \"VolumeList\") returned empty volumeList", volumeGroupToUse)
+			os.Exit(1)
+		}
+
+		volumeName = volumeList[0]
+
+		mountPointName, err = confMap.FetchOptionValueString("Volume:"+volumeName, "FUSEMountPointName")
+		if nil != err {
+			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueString(\"Volume:%s\", \"FUSEMountPointName\") failed: %v\n", volumeName, err)
 			os.Exit(1)
 		}
 	}
@@ -215,85 +250,15 @@ func main() {
 	if proxyfsRequired {
 		// Start up needed ProxyFS components
 
-		err = logger.Up(confMap)
+		err = transitions.Up(confMap)
 		if nil != err {
-			fmt.Fprintf(os.Stderr, "logger.Up() failed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "transitions.Up() failed: %v\n", err)
 			os.Exit(1)
 		}
 
-		err = evtlog.Up(confMap)
+		headhunterVolumeHandle, err = headhunter.FetchVolumeHandle(volumeName)
 		if nil != err {
-			fmt.Fprintf(os.Stderr, "evtlog.Up() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = stats.Up(confMap)
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "stats.Up() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = dlm.Up(confMap)
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "dlm.Up() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = swiftclient.Up(confMap)
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "swiftclient.Up() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = headhunter.Up(confMap)
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "headhunter.Up() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = inode.Up(confMap)
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "inode.Up() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		if fsRequired {
-			err = fs.Up(confMap)
-			if nil != err {
-				fmt.Fprintf(os.Stderr, "fs.Up() failed: %v\n", err)
-				os.Exit(1)
-			}
-
-			if fuseRequired {
-				err = fuse.Up(confMap)
-				if nil != err {
-					fmt.Fprintf(os.Stderr, "fuse.Up() failed: %v\n", err)
-					os.Exit(1)
-				}
-			}
-		}
-	}
-
-	// Select first "active" volumeName in volumeList by attempting to mount each (if required)
-
-	if doFuseWorkout || doFsWorkout || doInodeWorkout || doSwiftclientWorkout {
-		for _, volumeName = range volumeList {
-			headhunterVolumeHandle, err = headhunter.FetchVolumeHandle(volumeName)
-			if nil == err {
-				break
-			} else {
-				headhunterVolumeHandle = nil
-			}
-		}
-
-		if nil == headhunterVolumeHandle {
-			fmt.Fprintf(os.Stderr, "headhunter.FetchVolumeHandle() failed on every volumeName in volumeList: %v\n", volumeList)
-			os.Exit(1)
-		}
-
-		mountPointName, err = confMap.FetchOptionValueString(volumeName, "FUSEMountPointName")
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "confMap.FetchOptionValueString(\"%v\", \"FUSEMountPointName\") failed: %v\n", volumeName, err)
+			fmt.Fprintf(os.Stderr, "headhunter.FetchVolumeHandle(\"%s\") failed: %v\n", volumeName, err)
 			os.Exit(1)
 		}
 	}
@@ -632,61 +597,9 @@ func main() {
 	if proxyfsRequired {
 		// Stop ProxyFS components launched above
 
-		if fuseRequired {
-			err = fuse.Down()
-			if nil != err {
-				fmt.Fprintf(os.Stderr, "fuse.Down() failed: %v\n", err)
-				os.Exit(1)
-			}
-		}
-
-		if fsRequired {
-			err = fs.Down()
-			if nil != err {
-				fmt.Fprintf(os.Stderr, "fs.Down() failed: %v\n", err)
-				os.Exit(1)
-			}
-		}
-
-		err = inode.Down()
+		err = transitions.Down(confMap)
 		if nil != err {
-			fmt.Fprintf(os.Stderr, "inode.Down() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = swiftclient.Down()
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "swiftclient.Down() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = headhunter.Down()
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "headhunter.Down() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = dlm.Down()
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "dlm.Down() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = stats.Down()
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "stats.Down() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = evtlog.Down()
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "evtlog.Down() failed: %v\n", err)
-			os.Exit(1)
-		}
-
-		err = logger.Down()
-		if nil != err {
-			fmt.Fprintf(os.Stderr, "logger.Down() failed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "transitions.Down() failed: %v\n", err)
 			os.Exit(1)
 		}
 	}

--- a/proxyfsd/daemon.go
+++ b/proxyfsd/daemon.go
@@ -12,19 +12,13 @@ import (
 	"github.com/pkg/profile"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/dlm"
-	"github.com/swiftstack/ProxyFS/evtlog"
-	"github.com/swiftstack/ProxyFS/fs"
-	"github.com/swiftstack/ProxyFS/fuse"
-	"github.com/swiftstack/ProxyFS/halter"
-	"github.com/swiftstack/ProxyFS/headhunter"
-	"github.com/swiftstack/ProxyFS/httpserver"
-	"github.com/swiftstack/ProxyFS/inode"
-	"github.com/swiftstack/ProxyFS/jrpcfs"
 	"github.com/swiftstack/ProxyFS/logger"
-	"github.com/swiftstack/ProxyFS/stats"
-	"github.com/swiftstack/ProxyFS/statslogger"
-	"github.com/swiftstack/ProxyFS/swiftclient"
+	"github.com/swiftstack/ProxyFS/transitions"
+
+	// Force importing of the following "top-most" packages
+	_ "github.com/swiftstack/ProxyFS/fuse"
+	_ "github.com/swiftstack/ProxyFS/httpserver"
+	_ "github.com/swiftstack/ProxyFS/jrpcfs"
 )
 
 // Daemon is launched as a GoRoutine that launches ProxyFS. During startup, the parent should read errChan
@@ -75,9 +69,9 @@ func Daemon(confFile string, confStrings []string, errChan chan error, wg *sync.
 	}
 	// If not specified in conf map or type doesn't match one of the above, don't do profiling.
 
-	// Start up dæmon packages (logging starts first (followed by event logging) and finishes last)
+	// Start up dæmon packages
 
-	err = logger.Up(confMap)
+	err = transitions.Up(confMap)
 	if nil != err {
 		errChan <- err
 		return
@@ -87,196 +81,12 @@ func Daemon(confFile string, confStrings []string, errChan chan error, wg *sync.
 		os.Getpid(), strings.Join(execArgs, "' '"))
 	defer func() {
 		logger.Infof("proxyfsd logger is shutting down (PID %d)", os.Getpid())
-		err = logger.Down()
+		err = transitions.Down(confMap)
 		if nil != err {
 			logger.Errorf("logger.Down() failed: %v", err) // Oddly, if logger.Down() fails, will this work?
 		}
 		wg.Done()
 	}()
-
-	err = evtlog.Up(confMap)
-	if nil != err {
-		logger.Errorf("evtlog.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = evtlog.Down()
-		if nil != err {
-			logger.Errorf("evtlog.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = halter.Up(confMap)
-	if nil != err {
-		logger.Errorf("halter.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = halter.Down()
-		if nil != err {
-			logger.Errorf("halter.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	evtlog.Record(evtlog.FormatUpSequenceStart)
-
-	err = stats.Up(confMap)
-	if nil != err {
-		logger.Errorf("stats.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = stats.Down()
-		if nil != err {
-			logger.Errorf("stats.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = dlm.Up(confMap)
-	if nil != err {
-		logger.Errorf("dlm.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = dlm.Down()
-		if nil != err {
-			logger.Errorf("dlm.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = swiftclient.Up(confMap)
-	if nil != err {
-		logger.Errorf("swiftclient.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = swiftclient.Down()
-		if nil != err {
-			logger.Errorf("swiftclient.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = statslogger.Up(confMap)
-	if nil != err {
-		logger.Errorf("statslogger.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = statslogger.Down()
-		if nil != err {
-			logger.Errorf("statslogger.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = headhunter.Up(confMap)
-	if nil != err {
-		logger.Errorf("headhunter.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = headhunter.Down()
-		if nil != err {
-			logger.Errorf("headhunter.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = inode.Up(confMap)
-	if nil != err {
-		logger.Errorf("inode.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = inode.Down()
-		if nil != err {
-			logger.Errorf("inode.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = fs.Up(confMap)
-	if nil != err {
-		logger.Errorf("fs.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = fs.Down()
-		if nil != err {
-			logger.Errorf("fs.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = fuse.Up(confMap)
-	if nil != err {
-		logger.Errorf("fuse.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = fuse.Down()
-		if nil != err {
-			logger.Errorf("fuse.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = jrpcfs.Up(confMap)
-	if nil != err {
-		logger.Errorf("jrpcfs.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = jrpcfs.Down()
-		if nil != err {
-			logger.Errorf("jrpcfs.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	err = httpserver.Up(confMap) // Note: Must be the last .Up() step as it is used to indicate "up" status via HTTP
-	if nil != err {
-		logger.Errorf("httpserver.Up() failed: %v", err)
-		errChan <- err
-		return
-	}
-	wg.Add(1)
-	defer func() {
-		err = httpserver.Down()
-		if nil != err {
-			logger.Errorf("httpserver.Down() failed: %v", err)
-		}
-		wg.Done()
-	}()
-
-	evtlog.Record(evtlog.FormatUpSequenceEnd)
 
 	// Arm signal handler used to indicate termination and wait on it
 	//
@@ -313,219 +123,38 @@ func Daemon(confFile string, confStrings []string, errChan chan error, wg *sync.
 
 		// SIGHUP means reconfig but any other signal means time to exit
 		if unix.SIGHUP != signalReceived {
+			logger.Infof("signal catcher is shutting down proxyfsd (PID %d)", os.Getpid())
 
-			err = nil
 			if signalReceived != unix.SIGTERM && signalReceived != unix.SIGINT {
 				logger.Errorf("proxyfsd received unexpected signal: %v", signalReceived)
 				err = fmt.Errorf("proxyfsd received unexpected signal: %v", signalReceived)
 			}
 
-			// if the following message doesn't appear in the log,
-			// it may be because the caller has not called wg.Wait()
-			// to wait for all of the defer'ed routines (above) to
-			// finish before it exits
-			evtlog.Record(evtlog.FormatDownSequenceStart) // Note: no opportunity to log ...End step alas
-			logger.Infof("signal catcher is shutting down proxyfsd (PID %d)", os.Getpid())
+			err = transitions.Down(confMap)
 
 			errChan <- err
 			return
 		}
 
 		// caught SIGHUP -- recompute confMap and re-apply
-		// break out of loop at first error and handle it
-		for {
-			logger.Infof("Reconfig started; pausing daemons")
 
-			confMap, err = conf.MakeConfMapFromFile(confFile)
-			if nil != err {
-				err = fmt.Errorf("failed to load updated config: %v", err)
-				break
-			}
-
-			err = confMap.UpdateFromStrings(confStrings)
-			if nil != err {
-				err = fmt.Errorf("failed to reapply config overrides: %v", err)
-				break
-			}
-
-			// tell each daemon to pause and apply "contracting" confMap changes
-
-			evtlog.Record(evtlog.FormatPauseAndContractSequenceStart)
-
-			err = httpserver.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("httpserver.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = jrpcfs.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("jrpcfs.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = fuse.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("fuse.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = fs.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("fs.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = inode.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("inode.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = headhunter.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("headhunter.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = statslogger.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("statslogger.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = swiftclient.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("swiftclient.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = dlm.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("dlm.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = stats.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("stats.PauseAndContract(): %v", err)
-				break
-			}
-
-			evtlog.Record(evtlog.FormatPauseAndContractSequenceEnd)
-
-			err = evtlog.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("evtlog.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = halter.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("halter.PauseAndContract(): %v", err)
-				break
-			}
-
-			err = logger.PauseAndContract(confMap)
-			if nil != err {
-				err = fmt.Errorf("logger.PauseAndContract(): %v", err)
-				break
-			}
-
-			// tell each daemon to apply "expanding" confMap changes and result
-
-			logger.Infof("Reconfig starting; resuming daemons")
-
-			err = logger.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("logger.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = halter.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("halter.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = evtlog.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("evtlog.ExpandAndResume(): %v", err)
-				break
-			}
-
-			evtlog.Record(evtlog.FormatExpandAndResumeSequenceStart)
-
-			err = stats.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("stats.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = dlm.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("dlm.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = swiftclient.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("swiftclient.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = statslogger.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("statslogger.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = headhunter.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("headhunter.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = inode.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("inode.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = fs.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("fs.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = fuse.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("fuse.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = jrpcfs.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("jrpcfs.ExpandAndResume(): %v", err)
-				break
-			}
-
-			err = httpserver.ExpandAndResume(confMap)
-			if nil != err {
-				err = fmt.Errorf("httpserver.ExpandAndResume(): %v", err)
-				break
-			}
-
-			logger.Infof("Reconfig finished successfully")
-
-			evtlog.Record(evtlog.FormatExpandAndResumeSequenceEnd)
-
-			break
+		confMap, err = conf.MakeConfMapFromFile(confFile)
+		if nil != err {
+			err = fmt.Errorf("failed to load updated config: %v", err)
+			errChan <- err
+			return
 		}
 
-		// if one of the daemons didn't make it, log the error
+		err = confMap.UpdateFromStrings(confStrings)
 		if nil != err {
-			logger.Errorf("Reconfig failed: %v", err)
+			err = fmt.Errorf("failed to reapply config overrides: %v", err)
+			errChan <- err
+			return
+		}
+
+		err = transitions.Signaled(confMap)
+		if nil != err {
+			err = fmt.Errorf("transitions.Signaled() failed: %v", err)
 			errChan <- err
 			return
 		}

--- a/proxyfsd/default.conf
+++ b/proxyfsd/default.conf
@@ -34,13 +34,6 @@ RetryExpBackoffObject:        2.0
 ChunkedConnectionPoolSize:    512
 NonChunkedConnectionPoolSize: 128
 
-# A flow control specification driving Recover Point Objective (RPO) support... potentially common to multiple shares
-[FlowControl:CommonFlowControl]
-MaxFlushSize:       10485760
-MaxFlushTime:       10s
-ReadCacheLineSize:  1048576
-ReadCacheWeight:    100
-
 # A storage policy into which the chunks of files and directories will go
 [PhysicalContainerLayout:CommonVolumePhysicalContainerLayoutReplicated3Way]
 ContainerStoragePolicy:      silver
@@ -106,9 +99,8 @@ FSID:                                    1
 FUSEMountPointName:                      CommonMountPoint
 NFSExportName:                           CommonExport
 SMBShareName:                            CommonShare
-PrimaryPeer:                             Peer0
-StandbyPeerList:
 AccountName:                             AUTH_test
+AutoFormat:                              false
 NonceValuesToReserve:                    100
 MaxEntriesPerDirNode:                    32
 MaxExtentsPerFileNode:                   32
@@ -121,15 +113,23 @@ CheckpointContainerStoragePolicy:        gold
 CheckpointInterval:                      10s
 #ReplayLogFileName:                       CommonVolume.rlog
 DefaultPhysicalContainerLayout:          CommonVolumePhysicalContainerLayoutReplicated3Way
-FlowControl:                             CommonFlowControl
+MaxFlushSize:                            10485760
+MaxFlushTime:                            10s
 SnapShotIDNumBits:                       10
 MaxBytesInodeCache:                      10485760
 InodeCacheEvictInterval:                 1s
 #SnapShotPolicy:                          CommonSnapShotPolicy # Optional
 
+[VolumeGroup:CommonVolumeGroup]
+VolumeList:         CommonVolume
+VirtualIPAddr:
+PrimaryPeer:        Peer0
+ReadCacheLineSize:  1048576
+ReadCacheWeight:    100
+
 # Describes the set of volumes of the file system listed above
 [FSGlobals]
-VolumeList:                               CommonVolume
+VolumeGroupList:                          CommonVolumeGroup
 InodeRecCacheEvictLowLimit:               10000
 InodeRecCacheEvictHighLimit:              10010
 LogSegmentRecCacheEvictLowLimit:          10000

--- a/proxyfsd/file_server.conf
+++ b/proxyfsd/file_server.conf
@@ -1,11 +1,4 @@
 # File Server description
-#
-# Note: All Volumes referencing the same FlowControl section share pooled capacities
-[FlowControl:CommonFlowControl]
-MaxFlushSize:                             10485760
-MaxFlushTime:                             10s
-ReadCacheLineSize:                        1048576
-ReadCacheWeight:                          100
 
 [PhysicalContainerLayout:CommonVolumePhysicalContainerLayoutReplicated3Way]
 ContainerStoragePolicy:                   silver
@@ -59,6 +52,7 @@ SMBShareName:                             CommonShare
 PrimaryPeer:                              Peer0
 StandbyPeerList:
 AccountName:                              AUTH_test
+AutoFormat:                               false
 NonceValuesToReserve:                     100
 MaxEntriesPerDirNode:                     32
 MaxExtentsPerFileNode:                    32
@@ -71,15 +65,23 @@ CheckpointContainerStoragePolicy:         gold
 CheckpointInterval:                       10s
 #ReplayLogFileName:                        CommonVolume.rlog
 DefaultPhysicalContainerLayout:           CommonVolumePhysicalContainerLayoutReplicated3Way
-FlowControl:                              CommonFlowControl
+MaxFlushSize:                             10485760
+MaxFlushTime:                             10s
 SnapShotIDNumBits:                        10
 MaxBytesInodeCache:                       10485760
 InodeCacheEvictInterval:                  1s
 #SnapShotPolicy:                           CommonSnapShotPolicy # Optional
 #SnapShotPolicy:                           TestSnapShotPolicy
 
+[VolumeGroup:CommonVolumeGroup]
+VolumeList:         CommonVolume
+VirtualIPAddr:
+PrimaryPeer:        Peer0
+ReadCacheLineSize:  1048576
+ReadCacheWeight:    100
+
 [FSGlobals]
-VolumeList:                               CommonVolume
+VolumeGroupList:                          CommonVolumeGroup
 InodeRecCacheEvictLowLimit:               10000
 InodeRecCacheEvictHighLimit:              10010
 LogSegmentRecCacheEvictLowLimit:          10000

--- a/proxyfsd/swift_client.conf
+++ b/proxyfsd/swift_client.conf
@@ -10,5 +10,5 @@ RetryDelay:                   1s
 RetryDelayObject:             1s
 RetryExpBackoff:              1.2
 RetryExpBackoffObject:        2.0
-ChunkedConnectionPoolSize:    512 # 1
-NonChunkedConnectionPoolSize: 128 # 1
+ChunkedConnectionPoolSize:    512
+NonChunkedConnectionPoolSize: 128

--- a/ramswift/daemon_test.go
+++ b/ramswift/daemon_test.go
@@ -23,7 +23,7 @@ func TestViaNoAuthClient(t *testing.T) {
 			"SwiftClient.NoAuthTCPPort=" + noAuthTCPPort,
 			"SwiftClient.NoAuthIPAddr=127.0.0.1",
 			"Cluster.WhoAmI=Peer0",
-			"FSGlobals.VolumeList=",
+			"FSGlobals.VolumeGroupList=",
 			"Peer:Peer0.ReadCacheQuotaFraction=0.20",
 			"RamSwiftInfo.MaxAccountNameLength=256",
 			"RamSwiftInfo.MaxContainerNameLength=256",

--- a/stats/api_test.go
+++ b/stats/api_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 type testGlobalsStruct struct {
@@ -73,6 +74,9 @@ func TestStatsAPIviaUDP(t *testing.T) {
 	go testStatsd()
 
 	confStrings = []string{
+		"Logging.LogFilePath=/dev/null",
+		"Cluster.WhoAmI=nobody",
+		"FSGlobals.VolumeGroupList=",
 		"Stats.IPAddr=localhost",
 		"Stats.UDPPort=" + portString,
 		"Stats.BufferLength=1000",
@@ -84,17 +88,17 @@ func TestStatsAPIviaUDP(t *testing.T) {
 		t.Fatalf("conf.MakeConfMapFromStrings(confStrings) returned error: %v", err)
 	}
 
-	err = Up(confMap)
+	err = transitions.Up(confMap)
 	if nil != err {
-		t.Fatalf("stats.Up(confMap) returned error: %v", err)
+		t.Fatalf("transitions.Up(confMap) returned error: %v", err)
 	}
 
 	testSendStats()
 	testVerifyStats()
 
-	err = Down()
+	err = transitions.Down(confMap)
 	if nil != err {
-		t.Fatalf("stats.Down() returned error: %v", err)
+		t.Fatalf("transitions.Down() returned error: %v", err)
 	}
 
 	testGlobals.stopPending = true
@@ -148,6 +152,9 @@ func TestStatsAPIviaTCP(t *testing.T) {
 	go testStatsd()
 
 	confStrings = []string{
+		"Logging.LogFilePath=/dev/null",
+		"Cluster.WhoAmI=nobody",
+		"FSGlobals.VolumeGroupList=",
 		"Stats.IPAddr=localhost",
 		"Stats.TCPPort=" + portString,
 		"Stats.BufferLength=1000",
@@ -159,17 +166,17 @@ func TestStatsAPIviaTCP(t *testing.T) {
 		t.Fatalf("conf.MakeConfMapFromStrings(confStrings) returned error: %v", err)
 	}
 
-	err = Up(confMap)
+	err = transitions.Up(confMap)
 	if nil != err {
-		t.Fatalf("stats.Up(confMap) returned error: %v", err)
+		t.Fatalf("transitions.Up() returned error: %v", err)
 	}
 
 	testSendStats()
 	testVerifyStats()
 
-	err = Down()
+	err = transitions.Down(confMap)
 	if nil != err {
-		t.Fatalf("stats.Down() returned error: %v", err)
+		t.Fatalf("transitions.Down() returned error: %v", err)
 	}
 
 	testGlobals.stopPending = true

--- a/stats/config.go
+++ b/stats/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 const (
@@ -49,8 +50,11 @@ type globalsStruct struct {
 
 var globals globalsStruct
 
-// Up initializes the package and must successfully return before any API functions are invoked
-func Up(confMap conf.ConfMap) (err error) {
+func init() {
+	transitions.Register("stats", &globals)
+}
+
+func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	var (
 		errFetchingTCPPort error
 		errFetchingUDPPort error
@@ -129,22 +133,35 @@ func Up(confMap conf.ConfMap) (err error) {
 	return
 }
 
-// PauseAndContract pauses the stats package and applies any removals from the supplied confMap
-func PauseAndContract(confMap conf.ConfMap) (err error) {
-	// Nothing to do here
-	err = nil
-	return
+func (dummy *globalsStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) Signaled(confMap conf.ConfMap) (err error) {
+	return nil
 }
 
-// ExpandAndResume applies any additions from the supplied confMap and resumes the stats package
-func ExpandAndResume(confMap conf.ConfMap) (err error) {
-	// Nothing to do here
-	err = nil
-	return
-}
-
-// Down terminates statsd logging and should only be called once no API functions are active or subsequently invoked
-func Down() (err error) {
+func (dummy *globalsStruct) Down(confMap conf.ConfMap) (err error) {
 	globals.statChan = nil
 
 	globals.stopChan <- true

--- a/swiftclient/config.go
+++ b/swiftclient/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/swiftstack/ProxyFS/bucketstats"
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/logger"
+	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 type connectionStruct struct {
@@ -184,8 +185,11 @@ type globalsStruct struct {
 
 var globals globalsStruct
 
-// Up reads the Swift configuration to enable subsequent communication
-func Up(confMap conf.ConfMap) (err error) {
+func init() {
+	transitions.Register("swiftclient", &globals)
+}
+
+func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	var (
 		chunkedConnectionPoolSize    uint16
 		freeConnectionIndex          uint16
@@ -317,24 +321,39 @@ func Up(confMap conf.ConfMap) (err error) {
 	return
 }
 
-// PauseAndContract pauses the swiftclient package and applies any removals from the supplied confMap
-func PauseAndContract(confMap conf.ConfMap) (err error) {
+func (dummy *globalsStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+
+func (dummy *globalsStruct) Signaled(confMap conf.ConfMap) (err error) {
 	drainConnections()
 	globals.connectionNonce++
 	err = nil
 	return
 }
 
-// ExpandAndResume applies any additions from the supplied confMap and resumes the swiftclient package
-func ExpandAndResume(confMap conf.ConfMap) (err error) {
-	drainConnections()
-	globals.connectionNonce++
-	err = nil
-	return
-}
-
-// Down terminates all outstanding communications as part of process shutdown
-func Down() (err error) {
+func (dummy *globalsStruct) Down(confMap conf.ConfMap) (err error) {
 	drainConnections()
 	globals.connectionNonce++
 	bucketstats.UnRegister("proxyfs.swiftclient", "")

--- a/transitions/Makefile
+++ b/transitions/Makefile
@@ -1,0 +1,3 @@
+gosubdir := github.com/swiftstack/ProxyFS/transitions
+
+include ../GoMakefile

--- a/transitions/api.go
+++ b/transitions/api.go
@@ -1,0 +1,151 @@
+package transitions
+
+import (
+	"github.com/swiftstack/ProxyFS/conf"
+)
+
+// Callbacks is the interface implemented by each package desiring notification of
+// configuration changes. Each such package should implement a struct with pointer
+// receivers for each API listed below even when there is no interest in being
+// notified of a particular condition.
+//
+// By calling transitions.Register() in the package's init() func, the proper order
+// of registration will be ensured. In specific, the following callbacks will be
+// issued in the same order as package init() func calls have registered:
+//
+//   Up()
+//   VolumeGroupCreated()
+//   VolumeCreated()
+//   ServeVolume()
+//
+// By contrast, the following callbacks will be issued in the reverse order as package
+// init() func calls have registered:
+//
+//   VolumeGroupDestroyed()
+//   VolumeDestroyed()
+//   UnserveVolume()
+//   Down()
+//
+// The remaining APIs should be implemented such that order is not required. Nevertheless,
+// the following callbacks will also be issued in the same order as package init() func
+// calls have registered:
+//
+//   VolumeGroupMoved()
+//   VolumeMoved()
+//   Signaled()
+//
+type Callbacks interface {
+	Up(confMap conf.ConfMap) (err error)
+	VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error)
+	VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error)
+	VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error)
+	VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error)
+	VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error)
+	VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error)
+	ServeVolume(confMap conf.ConfMap, volumeName string) (err error)
+	UnserveVolume(confMap conf.ConfMap, volumeName string) (err error)
+	Signaled(confMap conf.ConfMap) (err error)
+	Down(confMap conf.ConfMap) (err error)
+}
+
+// Register should be called from a package's init() func should the package be interested
+// in one or more of the callbacks that they will receive. Each callback func should receive
+// a struct implementing the Callbacks interface by reference.
+//
+// As an example, consider the following:
+//
+//   package foo
+//
+//   import "github.com/swiftstack/ProxyFS/conf"
+//   import "github.com/swiftstack/ProxyFS/transitions"
+//
+//   type transitionsCallbackInterfaceStruct struct {
+//   }
+//
+//   var transitionsCallbackInterface transitionsCallbackInterfaceStruct
+//
+//   func init() {
+//       transitions.Register("foo", &transitionsCallbackInterface)
+//   }
+//
+//   func (transitionsCallbackInterface *transitionsCallbackInterfaceStruct) Up(confMap conf.ConfMap) (err error) {
+//       // Perform start-up initialization derived from confMap
+//       // ...set err at some point
+//       return
+//   }
+//
+//   ...
+//
+// Package foo would also have to provide callbacks for each of the other APIs in
+// the transitions.Callbacks interface (returning nil if simply not interested).
+//
+// A special exception to the need for registration is the package logger. Package
+// transitions makes an explicit reference to logging functions in package logger and,
+// as such, will perform the registration for package logger itself.
+//
+func Register(packageName string, callbacks Callbacks) {
+	register(packageName, callbacks)
+}
+
+// Up should be called at startup by the main() (or setup func) of each program including
+// any of the packages needing callback notifications. This will trigger Up() callbacks
+// to each of the packages that have registered with package transitions starting with
+// package logger (that was registered automatically by package transitions).
+//
+// Following the Up() callbacks, the following subset of the callbacks triggered
+// by a call to Signaled() will be made as if the prior confMap were empty:
+//
+//   VolumeGroupCreated() - registration order (for each such volume group)
+//   VolumeCreated()      - registration order (for each such volume)
+//   ServeVolume()        - registration order (for each such volume)
+//   Signaled()           - registration order
+//
+func Up(confMap conf.ConfMap) (err error) {
+	return up(confMap)
+}
+
+// Signaled should be called during execution of a signal handler for e.g. SIGHUP by the
+// main() (or monitoring func) of each program including any of the packages needing
+// callback notifications. This will potentially trigger multiple of the following
+// callbacks to each of the packages that have registered with package transitions.
+//
+// As part of this call, a determination will be made as to which volumes have migrated
+// as well as which volumes have either been created or destroyed. Upon determining
+// these volume sets, the following callbacks will be issued to each of the packages
+// that have registered with package transitions:
+//
+//   VolumeGroupCreated()   -         registration order (for each such volume group)
+//   VolumeCreated()        -         registration order (for each such volume)
+//   UnserveVolume()        - reverse registration order (for each such volume)
+//   VolumeGroupMoved()     -         registration order (for each such volume group)
+//   VolumeMoved()          -         registration order (for each such volume)
+//   ServeVolume()          -         registration order (for each such volume)
+//   VolumeDestroyed()      - reverse registration order (for each such volume)
+//   VolumeGroupDestroyed() - reverse registration order (for each such volume group)
+//   Signaled()             -         registration order
+//
+func Signaled(confMap conf.ConfMap) (err error) {
+	return signaled(confMap)
+}
+
+// Down should be called just before shutdown by the main() (or teardown func) of each
+// program including any of the packages needing callback notifications. This will trigger
+// Down() callbacks to each of the packages that have registered with package transitions
+// ending with package logger (that was registered automatically by package transitions).
+//
+// Prior to the Down() callbacks, the following subset of the callbacks triggered
+// by a call to Signaled() will be made as if the prior confMap were empty:
+//
+//   UnserveVolume()        - reverse registration order (for each such volume group)
+//   VolumeDestroyed()      - reverse registration order (for each such volume)
+//   VolumeGroupDestroyed() - reverse registration order (for each such volume)
+//
+func Down(confMap conf.ConfMap) (err error) {
+	return down(confMap)
+}
+
+// UpgradeConfMapIfNeeded should be removed once backwards compatibility is no longer required...
+//
+func UpgradeConfMapIfNeeded(confMap conf.ConfMap) (err error) {
+	return upgradeConfMapIfNeeded(confMap)
+}

--- a/transitions/api_internal.go
+++ b/transitions/api_internal.go
@@ -1,0 +1,1128 @@
+package transitions
+
+import (
+	"container/list"
+	"fmt"
+
+	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/logger"
+)
+
+type loggerCallbacksInterfaceStruct struct {
+}
+
+var loggerCallbacksInterface loggerCallbacksInterfaceStruct
+
+type registrationListElementValueStruct struct {
+	packageName string
+	callbacks   Callbacks
+}
+
+type volumeStruct struct {
+	name        string
+	served      bool
+	volumeGroup *volumeGroupStruct
+}
+
+type volumeGroupStruct struct {
+	name          string
+	served        bool
+	activePeer    string
+	virtualIPAddr string
+	volumeList    map[string]*volumeStruct // Key: volumeStruct.name
+}
+
+type globalsStruct struct {
+	registrationList         *list.List
+	currentVolumeGroupList   map[string]*volumeGroupStruct // Key: volumeGroupStruct.name
+	servedVolumeGroupList    map[string]*volumeGroupStruct // Key: volumeGroupStruct.name
+	remoteVolumeGroupList    map[string]*volumeGroupStruct // Key: volumeGroupStruct.name
+	createdVolumeGroupList   map[string]*volumeGroupStruct // Key: volumeGroupStruct.name
+	movedVolumeGroupList     map[string]*volumeGroupStruct // Key: volumeGroupStruct.name
+	destroyedVolumeGroupList map[string]*volumeGroupStruct // Key: volumeGroupStruct.name
+	currentVolumeList        map[string]*volumeStruct      // Key: volumeStruct.name
+	servedVolumeList         map[string]*volumeStruct      // Key: volumeStruct.name
+	remoteVolumeList         map[string]*volumeStruct      // Key: volumeStruct.name
+	createdVolumeList        map[string]*volumeStruct      // Key: volumeStruct.name
+	movedVolumeList          map[string]*volumeStruct      // Key: volumeStruct.name
+	destroyedVolumeList      map[string]*volumeStruct      // Key: volumeStruct.name
+	toStopServingVolumeList  map[string]*volumeStruct      // Key: volumeStruct.name
+	toStartServingVolumeList map[string]*volumeStruct      // Key: volumeStruct.name
+}
+
+var globals globalsStruct
+
+func init() {
+	globals.registrationList = list.New()
+
+	Register("logger", &loggerCallbacksInterface)
+}
+
+func register(packageName string, callbacks Callbacks) {
+	_ = globals.registrationList.PushBack(&registrationListElementValueStruct{packageName, callbacks})
+}
+
+func up(confMap conf.ConfMap) (err error) {
+	var (
+		registrationListElement      *list.Element
+		registrationListElementValue *registrationListElementValueStruct
+		volume                       *volumeStruct
+		volumeGroup                  *volumeGroupStruct
+		volumeGroupName              string
+		volumeName                   string
+	)
+
+	logger.Tracef("transitions.Up() called")
+	defer func() {
+		if nil == err {
+			logger.Tracef("transitions.Up() returning successfully")
+		} else {
+			logger.Errorf("transitions.Up() returning with failure: %v", err)
+		}
+	}()
+
+	globals.currentVolumeGroupList = make(map[string]*volumeGroupStruct)
+	globals.servedVolumeGroupList = make(map[string]*volumeGroupStruct)
+	globals.remoteVolumeGroupList = make(map[string]*volumeGroupStruct)
+
+	globals.currentVolumeList = make(map[string]*volumeStruct)
+	globals.servedVolumeList = make(map[string]*volumeStruct)
+	globals.remoteVolumeList = make(map[string]*volumeStruct)
+
+	err = computeConfMapDelta(confMap)
+	if nil != err {
+		return
+	}
+
+	if 0 != len(globals.movedVolumeGroupList) {
+		err = fmt.Errorf("transitions.Up() did not expect movedVolumeGroupList to be non-empty")
+		return
+	}
+	if 0 != len(globals.destroyedVolumeGroupList) {
+		err = fmt.Errorf("transitions.Up() did not expect destroyedVolumeGroupList to be non-empty")
+		return
+	}
+	if 0 != len(globals.movedVolumeList) {
+		err = fmt.Errorf("transitions.Up() did not expect movedVolumeList to be non-empty")
+		return
+	}
+	if 0 != len(globals.destroyedVolumeList) {
+		err = fmt.Errorf("transitions.Up() did not expect destroyedVolumeList to be non-empty")
+		return
+	}
+
+	// Issue Callbacks.Up() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		logger.Tracef("transitions.Up() calling %s.Up()", registrationListElementValue.packageName)
+		err = registrationListElementValue.callbacks.Up(confMap)
+		if nil != err {
+			logger.Errorf("transitions.Up() call to %s.Up() failed: %v", registrationListElementValue.packageName, err)
+			err = fmt.Errorf("%s.Up() failed: %v", registrationListElementValue.packageName, err)
+			return
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.VolumeGroupCreated() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeGroupName, volumeGroup = range globals.createdVolumeGroupList {
+			logger.Tracef("transitions.Up() calling %s.VolumeGroupCreated(,%s,%s,%s)", registrationListElementValue.packageName, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr)
+			err = registrationListElementValue.callbacks.VolumeGroupCreated(confMap, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr)
+			if nil != err {
+				logger.Errorf("transitions.Up() call to %s.VolumeGroupCreated(,%s,%s,%s) failed: %v", registrationListElementValue.packageName, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr, err)
+				err = fmt.Errorf("%s.VolumeGroupCreated(,%s,,) failed: %v", registrationListElementValue.packageName, volumeGroupName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.VolumeCreated() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName, volume = range globals.createdVolumeList {
+			logger.Tracef("transitions.Up() calling %s.VolumeCreated(,%s,%s)", registrationListElementValue.packageName, volumeName, volume.volumeGroup.name)
+			err = registrationListElementValue.callbacks.VolumeCreated(confMap, volumeName, volume.volumeGroup.name)
+			if nil != err {
+				logger.Errorf("transitions.Up() call to %s.VolumeCreated(,%s,%s) failed: %v", registrationListElementValue.packageName, volumeName, volume.volumeGroup.name, err)
+				err = fmt.Errorf("%s.VolumeCreated(,%s,) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.ServeVolume() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName, volume = range globals.servedVolumeList {
+			logger.Tracef("transitions.Up() calling %s.ServeVolume(,%s)", registrationListElementValue.packageName, volumeName)
+			err = registrationListElementValue.callbacks.ServeVolume(confMap, volumeName)
+			if nil != err {
+				logger.Errorf("transitions.Up() call to %s.ServeVolume(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				err = fmt.Errorf("%s.VolumeCreated(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.Signaled() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		logger.Tracef("transitions.Signaled() calling %s.Signaled()", registrationListElementValue.packageName)
+		err = registrationListElementValue.callbacks.Signaled(confMap)
+		if nil != err {
+			logger.Errorf("transitions.Signaled() call to %s.Signaled() failed: %v", registrationListElementValue.packageName, err)
+			err = fmt.Errorf("%s.Signaled() failed: %v", registrationListElementValue.packageName, err)
+			return
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	return
+}
+
+func signaled(confMap conf.ConfMap) (err error) {
+	var (
+		registrationListElement      *list.Element
+		registrationListElementValue *registrationListElementValueStruct
+		volume                       *volumeStruct
+		volumeGroup                  *volumeGroupStruct
+		volumeGroupName              string
+		volumeName                   string
+	)
+
+	logger.Tracef("transitions.Signaled() called")
+	defer func() {
+		if nil == err {
+			logger.Tracef("transitions.Signaled() returning successfully")
+		} else {
+			logger.Errorf("transitions.Signaled() returning with failure: %v", err)
+		}
+	}()
+
+	err = computeConfMapDelta(confMap)
+	if nil != err {
+		return
+	}
+
+	// Issue Callbacks.UnserveVolume() calls from Back() to Front() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Back()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName = range globals.toStopServingVolumeList {
+			logger.Tracef("transitions.Signaled() calling %s.UnserveVolume(,%s)", registrationListElementValue.packageName, volumeName)
+			err = registrationListElementValue.callbacks.UnserveVolume(confMap, volumeName)
+			if nil != err {
+				logger.Errorf("transitions.Signaled() call to %s.UnserveVolume(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				err = fmt.Errorf("%s.UnserveVolume(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Prev()
+	}
+
+	// Issue Callbacks.VolumeGroupCreated() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeGroupName, volumeGroup = range globals.createdVolumeGroupList {
+			logger.Tracef("transitions.Signaled() calling %s.VolumeGroupCreated(,%s,%s,%s)", registrationListElementValue.packageName, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr)
+			err = registrationListElementValue.callbacks.VolumeGroupCreated(confMap, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr)
+			if nil != err {
+				logger.Errorf("transitions.Signaled() call to %s.VolumeGroupCreated(,%s,%s,%s) failed: %v", registrationListElementValue.packageName, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr, err)
+				err = fmt.Errorf("%s.VolumeGroupCreated(,%s,,) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.VolumeCreated() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName, volume = range globals.createdVolumeList {
+			logger.Tracef("transitions.Signaled() calling %s.VolumeCreated(,%s,%s)", registrationListElementValue.packageName, volumeName, volume.volumeGroup.name)
+			err = registrationListElementValue.callbacks.VolumeCreated(confMap, volumeName, volume.volumeGroup.name)
+			if nil != err {
+				logger.Errorf("transitions.Signaled() call to %s.VolumeCreated(,%s,%s) failed: %v", registrationListElementValue.packageName, volumeName, volume.volumeGroup.name, err)
+				err = fmt.Errorf("%s.VolumeCreated(,%s,) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.VolumeGroupMoved() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeGroupName, volumeGroup = range globals.movedVolumeGroupList {
+			logger.Tracef("transitions.Signaled() calling %s.VolumeGroupMoved(,%s,%s,%s)", registrationListElementValue.packageName, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr)
+			err = registrationListElementValue.callbacks.VolumeGroupMoved(confMap, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr)
+			if nil != err {
+				logger.Errorf("transitions.Signaled() call to %s.VolumeGroupMoved(,%s,%s,%s) failed: %v", registrationListElementValue.packageName, volumeGroupName, volumeGroup.activePeer, volumeGroup.virtualIPAddr, err)
+				err = fmt.Errorf("%s.VolumeGroupMoved(,%s,,) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.VolumeMoved() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName, volume = range globals.movedVolumeList {
+			logger.Tracef("transitions.Signaled() calling %s.VolumeMoved(,%s,%s)", registrationListElementValue.packageName, volumeName, volume.volumeGroup.name)
+			err = registrationListElementValue.callbacks.VolumeMoved(confMap, volumeName, volume.volumeGroup.name)
+			if nil != err {
+				logger.Errorf("transitions.Signaled() call to %s.VolumeMoved(,%s,%s) failed: %v", registrationListElementValue.packageName, volumeName, volume.volumeGroup.name, err)
+				err = fmt.Errorf("%s.VolumeMoved(,%s,) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.VolumeDestroyed() calls from Back() to Front() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Back()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName, volume = range globals.destroyedVolumeList {
+			logger.Tracef("transitions.Signaled() calling %s.VolumeDestroyed(,%s)", registrationListElementValue.packageName, volumeName)
+			err = registrationListElementValue.callbacks.VolumeDestroyed(confMap, volumeName)
+			if nil != err {
+				logger.Errorf("transitions.Signaled() call to %s.VolumeDestroyed(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				err = fmt.Errorf("%s.VolumeDestroyed(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Prev()
+	}
+
+	// Issue Callbacks.VolumeGroupDestroyed() calls from Back() to Front() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Back()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeGroupName = range globals.destroyedVolumeGroupList {
+			logger.Tracef("transitions.Signaled() calling %s.VolumeGroupDestroyed(,%s)", registrationListElementValue.packageName, volumeGroupName)
+			err = registrationListElementValue.callbacks.VolumeGroupDestroyed(confMap, volumeGroupName)
+			if nil != err {
+				logger.Errorf("transitions.Signaled() call to %s.VolumeGroupDestroyed(,%s) failed: %v", registrationListElementValue.packageName, volumeGroupName, err)
+				err = fmt.Errorf("%s.VolumeGroupDestroyed(,%s) failed: %v", registrationListElementValue.packageName, volumeGroupName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Prev()
+	}
+
+	// Issue Callbacks.ServeVolume() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName, volume = range globals.toStartServingVolumeList {
+			if volume.served {
+				logger.Tracef("transitions.Signaled() calling %s.ServeVolume(,%s)", registrationListElementValue.packageName, volumeGroupName)
+				err = registrationListElementValue.callbacks.ServeVolume(confMap, volumeName)
+				if nil != err {
+					logger.Errorf("transitions.Signaled() call to %s.ServeVolume(,%s) failed: %v", registrationListElementValue.packageName, volumeGroupName, err)
+					err = fmt.Errorf("%s.ServeVolume(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+					return
+				}
+			}
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	// Issue Callbacks.Signaled() calls from Front() to Back() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Front()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		logger.Tracef("transitions.Signaled() calling %s.Signaled()", registrationListElementValue.packageName)
+		err = registrationListElementValue.callbacks.Signaled(confMap)
+		if nil != err {
+			logger.Errorf("transitions.Signaled() call to %s.Signaled() failed: %v", registrationListElementValue.packageName, err)
+			err = fmt.Errorf("%s.Signaled() failed: %v", registrationListElementValue.packageName, err)
+			return
+		}
+		registrationListElement = registrationListElement.Next()
+	}
+
+	return
+}
+
+func down(confMap conf.ConfMap) (err error) {
+	var (
+		registrationListElement      *list.Element
+		registrationListElementValue *registrationListElementValueStruct
+		volumeGroupName              string
+		volumeName                   string
+	)
+
+	logger.Tracef("transitions.Down() called")
+	defer func() {
+		if nil == err {
+			logger.Tracef("transitions.Down() returning successfully")
+		} else {
+			logger.Errorf("transitions.Down() returning with failure: %v", err)
+		}
+	}()
+
+	err = computeConfMapDelta(confMap)
+	if nil != err {
+		return
+	}
+
+	if 0 != len(globals.createdVolumeGroupList) {
+		err = fmt.Errorf("transitions.Down() did not expect createdVolumeGroupList to be non-empty")
+		return
+	}
+	if 0 != len(globals.movedVolumeGroupList) {
+		err = fmt.Errorf("transitions.Down() did not expect movedVolumeGroupList to be non-empty")
+		return
+	}
+	if 0 != len(globals.destroyedVolumeGroupList) {
+		err = fmt.Errorf("transitions.Down() did not expect destroyedVolumeGroupList to be non-empty")
+		return
+	}
+	if 0 != len(globals.createdVolumeList) {
+		err = fmt.Errorf("transitions.Down() did not expect createdVolumeList to be non-empty")
+		return
+	}
+	if 0 != len(globals.movedVolumeList) {
+		err = fmt.Errorf("transitions.Down() did not expect movedVolumeList to be non-empty")
+		return
+	}
+	if 0 != len(globals.destroyedVolumeList) {
+		err = fmt.Errorf("transitions.Down() did not expect destroyedVolumeList to be non-empty")
+		return
+	}
+
+	// Issue Callbacks.UnserveVolume() calls from Back() to Front() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Back()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName = range globals.servedVolumeList {
+			logger.Tracef("transitions.Down() calling %s.UnserveVolume(,%s)", registrationListElementValue.packageName, volumeName)
+			err = registrationListElementValue.callbacks.UnserveVolume(confMap, volumeName)
+			if nil != err {
+				logger.Errorf("transitions.Down() call to %s.UnserveVolume(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				err = fmt.Errorf("%s.UnserveVolume(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Prev()
+	}
+
+	// Issue Callbacks.VolumeDestroyed() calls from Back() to Front() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Back()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeName = range globals.currentVolumeList {
+			logger.Tracef("transitions.Down() calling %s.VolumeDestroyed(,%s)", registrationListElementValue.packageName, volumeName)
+			err = registrationListElementValue.callbacks.VolumeDestroyed(confMap, volumeName)
+			if nil != err {
+				logger.Errorf("transitions.Down() call to %s.VolumeDestroyed(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				err = fmt.Errorf("%s.VolumeDestroyed(,%s) failed: %v", registrationListElementValue.packageName, volumeName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Prev()
+	}
+
+	// Issue Callbacks.VolumeGroupDestroyed() calls from Back() to Front() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Back()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		for volumeGroupName = range globals.currentVolumeGroupList {
+			logger.Tracef("transitions.Down() calling %s.VolumeGroupDestroyed(,%s)", registrationListElementValue.packageName, volumeGroupName)
+			err = registrationListElementValue.callbacks.VolumeGroupDestroyed(confMap, volumeGroupName)
+			if nil != err {
+				logger.Errorf("transitions.Down() call to %s.VolumeGroupDestroyed(,%s) failed: %v", registrationListElementValue.packageName, volumeGroupName, err)
+				err = fmt.Errorf("%s.VolumeGroupDestroyed(,%s) failed: %v", registrationListElementValue.packageName, volumeGroupName, err)
+				return
+			}
+		}
+		registrationListElement = registrationListElement.Prev()
+	}
+
+	// Issue Callbacks.Down() calls from Back() to Front() of globals.registrationList
+
+	registrationListElement = globals.registrationList.Back()
+
+	for nil != registrationListElement {
+		registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+		logger.Tracef("transitions.Down() calling %s.Down()", registrationListElementValue.packageName)
+		err = registrationListElementValue.callbacks.Down(confMap)
+		if nil != err {
+			logger.Errorf("transitions.Down() call to %s.Down() failed: %v", registrationListElementValue.packageName, err)
+			err = fmt.Errorf("%s.Down() failed: %v", registrationListElementValue.packageName, err)
+			return
+		}
+		registrationListElement = registrationListElement.Prev()
+	}
+
+	return
+}
+
+func computeConfMapDelta(confMap conf.ConfMap) (err error) {
+	var (
+		fsGlobalsVolumeGroupList  []string
+		newCurrentVolumeGroupList map[string]*volumeGroupStruct
+		newCurrentVolumeList      map[string]*volumeStruct
+		newRemoteVolumeGroupList  map[string]*volumeGroupStruct
+		newRemoteVolumeList       map[string]*volumeStruct
+		newServedVolumeGroupList  map[string]*volumeGroupStruct
+		newServedVolumeList       map[string]*volumeStruct
+		ok                        bool
+		volume                    *volumeStruct
+		volumeGroup               *volumeGroupStruct
+		volumeGroupName           string
+		volumeGroupVolumeList     []string
+		volumeGroupPreviously     *volumeGroupStruct
+		volumeName                string
+		volumePreviously          *volumeStruct
+		whoAmI                    string
+	)
+
+	// TODO: Remove call to upgradeConfMapIfNeeded() once backwards compatibility is no longer required
+
+	err = upgradeConfMapIfNeeded(confMap)
+	if nil != err {
+		return
+	}
+
+	// Initialize lists used in computation (those in globalsStruct are actually the func output)
+
+	newCurrentVolumeGroupList = make(map[string]*volumeGroupStruct)
+	newServedVolumeGroupList = make(map[string]*volumeGroupStruct)
+	newRemoteVolumeGroupList = make(map[string]*volumeGroupStruct)
+
+	globals.createdVolumeGroupList = make(map[string]*volumeGroupStruct)
+	globals.movedVolumeGroupList = make(map[string]*volumeGroupStruct)
+	globals.destroyedVolumeGroupList = make(map[string]*volumeGroupStruct)
+
+	newCurrentVolumeList = make(map[string]*volumeStruct)
+	newServedVolumeList = make(map[string]*volumeStruct)
+	newRemoteVolumeList = make(map[string]*volumeStruct)
+
+	globals.createdVolumeList = make(map[string]*volumeStruct)
+	globals.movedVolumeList = make(map[string]*volumeStruct)
+	globals.destroyedVolumeList = make(map[string]*volumeStruct)
+
+	globals.toStopServingVolumeList = make(map[string]*volumeStruct)
+	globals.toStartServingVolumeList = make(map[string]*volumeStruct)
+
+	// Injest confMap
+
+	whoAmI, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
+	if nil != err {
+		return
+	}
+
+	fsGlobalsVolumeGroupList, err = confMap.FetchOptionValueStringSlice("FSGlobals", "VolumeGroupList")
+	if nil != err {
+		return
+	}
+
+	for _, volumeGroupName = range fsGlobalsVolumeGroupList {
+		volumeGroup = &volumeGroupStruct{name: volumeGroupName, volumeList: make(map[string]*volumeStruct)}
+
+		newCurrentVolumeGroupList[volumeGroupName] = volumeGroup
+
+		volumeGroup.activePeer, err = confMap.FetchOptionValueString("VolumeGroup:"+volumeGroupName, "PrimaryPeer")
+		if nil != err {
+			return
+		}
+
+		volumeGroup.served = (whoAmI == volumeGroup.activePeer)
+
+		if volumeGroup.served {
+			newServedVolumeGroupList[volumeGroupName] = volumeGroup
+		} else {
+			newRemoteVolumeGroupList[volumeGroupName] = volumeGroup
+		}
+
+		volumeGroup.virtualIPAddr, err = confMap.FetchOptionValueString("VolumeGroup:"+volumeGroupName, "VirtualIPAddr")
+		if nil != err {
+			if nil == confMap.VerifyOptionValueIsEmpty("VolumeGroup:"+volumeGroupName, "VirtualIPAddr") {
+				volumeGroup.virtualIPAddr = ""
+			} else {
+				return
+			}
+		}
+
+		volumeGroupVolumeList, err = confMap.FetchOptionValueStringSlice("VolumeGroup:"+volumeGroupName, "VolumeList")
+		if nil != err {
+			return
+		}
+
+		for _, volumeName = range volumeGroupVolumeList {
+			volume = &volumeStruct{name: volumeName, served: volumeGroup.served, volumeGroup: volumeGroup}
+
+			newCurrentVolumeList[volumeName] = volume
+
+			if volume.served {
+				newServedVolumeList[volumeName] = volume
+			} else {
+				newRemoteVolumeList[volumeName] = volume
+			}
+
+			volumeGroup.volumeList[volumeName] = volume
+		}
+	}
+
+	// Compute changes to VolumeGroupList
+
+	for volumeGroupName, volumeGroup = range newCurrentVolumeGroupList {
+		volumeGroupPreviously, ok = globals.currentVolumeGroupList[volumeGroupName]
+		if ok {
+			if volumeGroupPreviously.activePeer != volumeGroup.activePeer {
+				globals.movedVolumeGroupList[volumeGroupName] = volumeGroup
+			}
+		} else {
+			globals.createdVolumeGroupList[volumeGroupName] = volumeGroup
+		}
+	}
+
+	for volumeGroupName, volumeGroup = range globals.currentVolumeGroupList {
+		_, ok = newCurrentVolumeGroupList[volumeGroupName]
+		if !ok {
+			globals.destroyedVolumeGroupList[volumeGroupName] = volumeGroup
+		}
+	}
+
+	// Compute changes to VolumeList
+
+	for volumeName, volume = range newCurrentVolumeList {
+		volumePreviously, ok = globals.currentVolumeList[volumeName]
+		if ok {
+			if volumePreviously.volumeGroup.name != volume.volumeGroup.name {
+				globals.movedVolumeList[volumeName] = volume
+			}
+		} else {
+			globals.createdVolumeList[volumeName] = volume
+		}
+	}
+
+	for volumeName, volume = range globals.currentVolumeList {
+		_, ok = newCurrentVolumeList[volumeName]
+		if !ok {
+			globals.destroyedVolumeList[volumeName] = volume
+		}
+	}
+
+	// Compute to{Stop|Start}ServingVolumeList
+
+	for volumeName, volume = range globals.destroyedVolumeList {
+		_, ok = globals.servedVolumeList[volumeName]
+		if ok {
+			globals.toStopServingVolumeList[volumeName] = volume
+		}
+	}
+	for volumeName, volume = range globals.movedVolumeList {
+		_, ok = globals.servedVolumeList[volumeName]
+		if ok {
+			globals.toStopServingVolumeList[volumeName] = volume
+		}
+	}
+	for _, volumeGroup = range globals.movedVolumeGroupList {
+		for volumeName, volume = range volumeGroup.volumeList {
+			_, ok = globals.servedVolumeList[volumeName]
+			if ok {
+				globals.toStopServingVolumeList[volumeName] = volume
+			}
+		}
+	}
+
+	for _, volumeGroup = range globals.movedVolumeGroupList {
+		for volumeName, volume = range volumeGroup.volumeList {
+			_, ok = newServedVolumeList[volumeName]
+			if ok {
+				globals.toStartServingVolumeList[volumeName] = volume
+			}
+		}
+	}
+	for volumeName, volume = range globals.movedVolumeList {
+		_, ok = newServedVolumeList[volumeName]
+		if ok {
+			globals.toStartServingVolumeList[volumeName] = volume
+		}
+	}
+	for volumeName, volume = range globals.createdVolumeList {
+		_, ok = newServedVolumeList[volumeName]
+		if ok {
+			globals.toStartServingVolumeList[volumeName] = volume
+		}
+	}
+
+	// Finally, update {current|served|remote}Volume{|Group}List fields in globalsStruct
+
+	globals.currentVolumeGroupList = newCurrentVolumeGroupList
+	globals.servedVolumeGroupList = newServedVolumeGroupList
+	globals.remoteVolumeGroupList = newRemoteVolumeGroupList
+	globals.currentVolumeList = newCurrentVolumeList
+	globals.servedVolumeList = newServedVolumeList
+	globals.remoteVolumeList = newRemoteVolumeList
+
+	return
+}
+
+// upgradeConfMapIfNeeded should be removed once backwards compatibility is no longer required...
+//
+// In the meantime, the changes are:
+//
+//   MaxFlushSize moves from FlowControl: section to the Volume: section (for each Volume referencing it)
+//   MaxFlushTime moves from FlowControl: section to the Volume: section (for each Volume referencing it)
+//
+//   VolumeList in FSGlobals is renamed VolumeGroupList
+//
+//   VolumeGroup: section is created for every Volume: section
+//   VolumeList in VolumeGroup: section references the identically named Volume
+//   VirtualIPAddr in VolumeGroup: section is empty
+//   PrimaryPeer moves from Volume: section to VolumeGroup: section
+//   ReadCacheLineSize moves from FlowControl: section to VolumeGroup: section (for each Volume referencing it)
+//   ReadCacheWeight   moves from FlowControl: section to VolumeGroup: section (for each Volume referencing it)
+//
+//   PrimaryPeer is removed from Volume: section
+//   FlowControl is removed from Volume: section
+//
+//   FlowControl: section is removed
+//
+//   Generation of the name of the created VolumeGroup for each Volume
+//   is computed by prepending an optional prefix and appending an
+//   optional suffix as specified in the conf.ConfMap
+//
+// The upgrade will commence if FSGlobals section contains a VolumeList
+// The upgrade is unnecessary if FSGlobals section already container a VolumeGroupList
+//
+func upgradeConfMapIfNeeded(confMap conf.ConfMap) (err error) {
+	var (
+		autoVolumeGroupNamePrefix      string
+		autoVolumeGroupNamePrefixOK    bool
+		autoVolumeGroupNamePrefixSlice []string
+		autoVolumeGroupNameSuffix      string
+		autoVolumeGroupNameSuffixOK    bool
+		autoVolumeGroupNameSuffixSlice []string
+		flowControl                    conf.ConfMapSection
+		flowControlName                conf.ConfMapOption
+		flowControlNameOK              bool
+		flowControlOK                  bool
+		flowControlSet                 map[string]struct{}
+		flowControlSetElement          string
+		fsGlobals                      conf.ConfMapSection
+		fsGlobalsOK                    bool
+		maxFlushSize                   conf.ConfMapOption
+		maxFlushSizeOK                 bool
+		maxFlushTime                   conf.ConfMapOption
+		maxFlushTimeOK                 bool
+		primaryPeer                    conf.ConfMapOption
+		primaryPeerOK                  bool
+		readCacheLineSize              conf.ConfMapOption
+		readCacheLineSizeOK            bool
+		readCacheWeight                conf.ConfMapOption
+		readCacheWeightOK              bool
+		transitions                    conf.ConfMapSection
+		transitionsOK                  bool
+		volume                         conf.ConfMapSection
+		volumeGroup                    conf.ConfMapSection
+		volumeGroupList                conf.ConfMapOption
+		volumeGroupListOK              bool
+		volumeOK                       bool
+		volumeList                     conf.ConfMapOption
+		volumeListOK                   bool
+		volumeName                     string
+	)
+
+	fsGlobals, fsGlobalsOK = confMap["FSGlobals"]
+
+	if !fsGlobalsOK {
+		err = fmt.Errorf("confMap must contain an FSGlobals section")
+		return
+	}
+
+	volumeList, volumeListOK = fsGlobals["VolumeList"]
+	_, volumeGroupListOK = fsGlobals["VolumeGroupList"]
+
+	if (!volumeListOK && !volumeGroupListOK) || (volumeListOK && volumeGroupListOK) {
+		err = fmt.Errorf("confMap must contain precisely one of FSGlobals.VolumeList or FSGlobals.VolumeGroupList")
+		return
+	}
+
+	if volumeGroupListOK {
+		// No need to upgrade confMap
+		err = nil
+		return
+	}
+
+	transitions, transitionsOK = confMap["Transitions"]
+	if transitionsOK {
+		autoVolumeGroupNamePrefixSlice, autoVolumeGroupNamePrefixOK = transitions["AutoVolumeGroupPrefix"]
+		if autoVolumeGroupNamePrefixOK {
+			switch len(autoVolumeGroupNamePrefixSlice) {
+			case 0:
+				autoVolumeGroupNamePrefix = ""
+			case 1:
+				autoVolumeGroupNamePrefix = autoVolumeGroupNamePrefixSlice[0]
+			default:
+				err = fmt.Errorf("confMap must not contain a multi-valued Transitions:AutoVolumeGroupPrefix key")
+				return
+			}
+		}
+		autoVolumeGroupNameSuffixSlice, autoVolumeGroupNameSuffixOK = transitions["AutoVolumeGroupSuffix"]
+		if autoVolumeGroupNameSuffixOK {
+			switch len(autoVolumeGroupNameSuffixSlice) {
+			case 0:
+				autoVolumeGroupNameSuffix = ""
+			case 1:
+				autoVolumeGroupNameSuffix = autoVolumeGroupNameSuffixSlice[0]
+			default:
+				err = fmt.Errorf("confMap must not contain a multi-valued Transitions:AutoVolumeGroupSuffix key")
+				return
+			}
+		}
+	} else {
+		autoVolumeGroupNamePrefix = ""
+		autoVolumeGroupNameSuffix = ""
+	}
+
+	volumeGroupList = make(conf.ConfMapOption, 0, len(volumeList))
+	for _, volumeName = range volumeList {
+		volumeGroupList = append(volumeGroupList, autoVolumeGroupNamePrefix+volumeName+autoVolumeGroupNameSuffix)
+	}
+	fsGlobals["VolumeGroupList"] = volumeGroupList
+
+	delete(fsGlobals, "VolumeList")
+
+	flowControlSet = make(map[string]struct{})
+
+	for _, volumeName = range volumeList {
+		volume, volumeOK = confMap["Volume:"+volumeName]
+		if !volumeOK {
+			err = fmt.Errorf("confMap must contain a Volume:%s section", volumeName)
+			return
+		}
+
+		primaryPeer, primaryPeerOK = volume["PrimaryPeer"]
+		if !primaryPeerOK {
+			err = fmt.Errorf("confMap must contain a Volume:%s.PrimaryPeer key", volumeName)
+			return
+		}
+
+		flowControlName, flowControlNameOK = volume["FlowControl"]
+		if !flowControlNameOK || (1 != len(flowControlName)) {
+			err = fmt.Errorf("confMap must contain a single-valued Volume:%s.FlowControl key", volumeName)
+			return
+		}
+
+		flowControlSet[flowControlName[0]] = struct{}{}
+
+		flowControl, flowControlOK = confMap["FlowControl:"+flowControlName[0]]
+		if !flowControlOK {
+			err = fmt.Errorf("confMap must contain a FlowControl:%s section", flowControlName)
+			return
+		}
+
+		maxFlushSize, maxFlushSizeOK = flowControl["MaxFlushSize"]
+		if !maxFlushSizeOK {
+			err = fmt.Errorf("confMap must contain a FlowControl:%s.MaxFlushSize key", flowControlName[0])
+			return
+		}
+
+		maxFlushTime, maxFlushTimeOK = flowControl["MaxFlushTime"]
+		if !maxFlushTimeOK {
+			err = fmt.Errorf("confMap must contain a FlowControl:%s.MaxFlushTime key", flowControlName[0])
+			return
+		}
+
+		readCacheLineSize, readCacheLineSizeOK = flowControl["ReadCacheLineSize"]
+		if !readCacheLineSizeOK {
+			err = fmt.Errorf("confMap must contain a FlowControl:%s.ReadCacheLineSize key", flowControlName[0])
+			return
+		}
+
+		readCacheWeight, readCacheWeightOK = flowControl["ReadCacheWeight"]
+		if !readCacheWeightOK {
+			err = fmt.Errorf("confMap must contain a FlowControl:%s.ReadCacheWeight key", flowControlName[0])
+			return
+		}
+
+		volumeGroup = make(conf.ConfMapSection)
+
+		volumeGroup["VolumeList"] = []string{volumeName}
+		volumeGroup["VirtualIPAddr"] = []string{}
+		volumeGroup["PrimaryPeer"] = primaryPeer
+		volumeGroup["ReadCacheLineSize"] = readCacheLineSize
+		volumeGroup["ReadCacheWeight"] = readCacheWeight
+
+		confMap["VolumeGroup:"+autoVolumeGroupNamePrefix+volumeName+autoVolumeGroupNameSuffix] = volumeGroup
+
+		volume["MaxFlushSize"] = maxFlushSize
+		volume["MaxFlushTime"] = maxFlushTime
+
+		delete(volume, "PrimaryPeer")
+		delete(volume, "FlowControl")
+	}
+
+	for flowControlSetElement = range flowControlSet {
+		delete(confMap, "FlowControl:"+flowControlSetElement)
+	}
+
+	err = nil
+	return
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) Up(confMap conf.ConfMap) (err error) {
+	return logger.Up(confMap)
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	return nil
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error) {
+	return nil
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	return nil
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) ServeVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	return nil
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) Signaled(confMap conf.ConfMap) (err error) {
+	return logger.Signaled(confMap)
+}
+
+func (loggerCallbacksInterface *loggerCallbacksInterfaceStruct) Down(confMap conf.ConfMap) (err error) {
+	return logger.Down(confMap)
+}
+
+func dumpGlobals(indent string) {
+	var (
+		registrationListElement      *list.Element
+		registrationListElementValue *registrationListElementValueStruct
+		volume                       *volumeStruct
+		volumeGroup                  *volumeGroupStruct
+		volumeGroupName              string
+		volumeName                   string
+	)
+
+	registrationListElement = globals.registrationList.Front()
+
+	if nil == registrationListElement {
+		fmt.Printf("%sregistrationList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%sregistrationList:", indent)
+		for nil != registrationListElement {
+			registrationListElementValue = registrationListElement.Value.(*registrationListElementValueStruct)
+			fmt.Printf(" %s", registrationListElementValue.packageName)
+			registrationListElement = registrationListElement.Next()
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.currentVolumeGroupList) {
+		fmt.Printf("%scurrentVolumeGroupList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%scurrentVolumeGroupList:\n", indent)
+		for volumeGroupName, volumeGroup = range globals.currentVolumeGroupList {
+			fmt.Printf("%s  %+v [volumeList:", indent, volumeGroup)
+			for volumeName = range volumeGroup.volumeList {
+				fmt.Printf(" %s", volumeName)
+			}
+			fmt.Printf("]\n")
+		}
+	}
+
+	if 0 == len(globals.servedVolumeGroupList) {
+		fmt.Printf("%sservedVolumeGroupList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%sservedVolumeGroupList:", indent)
+		for volumeGroupName = range globals.servedVolumeGroupList {
+			fmt.Printf(" %s", volumeGroupName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.remoteVolumeGroupList) {
+		fmt.Printf("%sremoteVolumeGroupList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%sremoteVolumeGroupList:", indent)
+		for volumeGroupName = range globals.remoteVolumeGroupList {
+			fmt.Printf(" %s", volumeGroupName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.createdVolumeGroupList) {
+		fmt.Printf("%screatedVolumeGroupList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%screatedVolumeGroupList:", indent)
+		for volumeGroupName = range globals.createdVolumeGroupList {
+			fmt.Printf(" %s", volumeGroupName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.movedVolumeGroupList) {
+		fmt.Printf("%smovedVolumeGroupList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%smovedVolumeGroupList:", indent)
+		for volumeGroupName = range globals.movedVolumeGroupList {
+			fmt.Printf(" %s", volumeGroupName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.destroyedVolumeGroupList) {
+		fmt.Printf("%sdestroyedVolumeGroupList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%sdestroyedVolumeGroupList:", indent)
+		for volumeGroupName = range globals.destroyedVolumeGroupList {
+			fmt.Printf(" %s", volumeGroupName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.currentVolumeList) {
+		fmt.Printf("%scurrentVolumeList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%scurrentVolumeList:\n", indent)
+		for volumeName, volume = range globals.currentVolumeList {
+			fmt.Printf("%s  %+v [volumeGroup: %s]\n", indent, volume, volume.volumeGroup.name)
+		}
+	}
+
+	if 0 == len(globals.servedVolumeList) {
+		fmt.Printf("%sservedVolumeList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%sservedVolumeList:", indent)
+		for volumeName = range globals.servedVolumeList {
+			fmt.Printf(" %s", volumeName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.remoteVolumeList) {
+		fmt.Printf("%sremoteVolumeList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%sremoteVolumeList:", indent)
+		for volumeName = range globals.remoteVolumeList {
+			fmt.Printf(" %s", volumeName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.createdVolumeList) {
+		fmt.Printf("%screatedVolumeList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%screatedVolumeList:", indent)
+		for volumeName = range globals.createdVolumeList {
+			fmt.Printf(" %s", volumeName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.movedVolumeList) {
+		fmt.Printf("%smovedVolumeList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%smovedVolumeList:", indent)
+		for volumeName = range globals.movedVolumeList {
+			fmt.Printf(" %s", volumeName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.destroyedVolumeList) {
+		fmt.Printf("%sdestroyedVolumeList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%sdestroyedVolumeList:", indent)
+		for volumeName = range globals.destroyedVolumeList {
+			fmt.Printf(" %s", volumeName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.toStopServingVolumeList) {
+		fmt.Printf("%stoStopServingVolumeList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%stoStopServingVolumeList:", indent)
+		for volumeName = range globals.toStopServingVolumeList {
+			fmt.Printf(" %s", volumeName)
+		}
+		fmt.Println()
+	}
+
+	if 0 == len(globals.toStartServingVolumeList) {
+		fmt.Printf("%stoStartServingVolumeList: <empty>\n", indent)
+	} else {
+		fmt.Printf("%stoStartServingVolumeList:", indent)
+		for volumeName = range globals.toStartServingVolumeList {
+			fmt.Printf(" %s", volumeName)
+		}
+		fmt.Println()
+	}
+}

--- a/transitions/api_test.go
+++ b/transitions/api_test.go
@@ -1,0 +1,826 @@
+package transitions
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/swiftstack/ProxyFS/conf"
+)
+
+type testCallbacksInterfaceStruct struct {
+	name string
+	t    *testing.T
+}
+
+var testConfStrings = []string{
+	"Logging.LogFilePath=/dev/null",
+	"Logging.LogToConsole=false",
+	"FlowControl:FlowControlX.MaxFlushSize=10000000",
+	"FlowControl:FlowControlX.MaxFlushTime=10s",
+	"FlowControl:FlowControlX.ReadCacheLineSize=1000000",
+	"FlowControl:FlowControlX.ReadCacheWeight=100",
+	"FlowControl:FlowControlY.MaxFlushSize=20000000",
+	"FlowControl:FlowControlY.MaxFlushTime=20s",
+	"FlowControl:FlowControlY.ReadCacheLineSize=2000000",
+	"FlowControl:FlowControlY.ReadCacheWeight=200",
+	"Volume:VolumeA.PrimaryPeer=Peer0",
+	"Volume:VolumeA.FlowControl=FlowControlX",
+	"Volume:VolumeB.PrimaryPeer=Peer0", // Will migrate to Peer1
+	"Volume:VolumeB.FlowControl=FlowControlY",
+	"Volume:VolumeC.PrimaryPeer=Peer1", // Will migrate to Peer2...then destroyed
+	"Volume:VolumeC.FlowControl=FlowControlX",
+	"Volume:VolumeD.PrimaryPeer=Peer2", // Will migrate to Peer0...then destroyed
+	"Volume:VolumeD.FlowControl=FlowControlY",
+	//                                     VolumeE will be created on Peer0
+	//                                     VolumeF will be created on Peer1
+	//                                     VolumeG will be created on Peer2...then migrate to VolumeF's VolumeGroup
+	"FSGlobals.VolumeList=VolumeA,VolumeB,VolumeC,VolumeD",
+	"Cluster.Peers=Peer0,Peer1,Peer2,Peer3",
+	"Cluster.WhoAmI=Peer0",
+	"Transitions.AutoVolumeGroupPrefix=V_",
+	"Transitions.AutoVolumeGroupSuffix=_G",
+}
+
+var testConfStringsToAddVolumeE = []string{
+	"Volume:VolumeE.MaxFlushSize=30000000",
+	"Volume:VolumeE.MaxFlushTime=30s",
+	"VolumeGroup:VG_One.PrimaryPeer=Peer0",
+	"VolumeGroup:VG_One.ReadCacheLineSize=3000000",
+	"VolumeGroup:VG_One.ReadCacheWeight=300",
+	"VolumeGroup:VG_One.VirtualIPAddr=",
+	"VolumeGroup:VG_One.VolumeList=VolumeE",
+	"FSGlobals.VolumeGroupList=V_VolumeA_G,V_VolumeB_G,VG_One",
+}
+
+var testConfStringsToAddVolumeF = []string{
+	"Volume:VolumeF.MaxFlushSize=40000000",
+	"Volume:VolumeF.MaxFlushTime=40s",
+	"VolumeGroup:VG_Two.PrimaryPeer=Peer1",
+	"VolumeGroup:VG_Two.ReadCacheLineSize=4000000",
+	"VolumeGroup:VG_Two.ReadCacheWeight=400",
+	"VolumeGroup:VG_Two.VirtualIPAddr=",
+	"VolumeGroup:VG_Two.VolumeList=VolumeF",
+	"FSGlobals.VolumeGroupList=V_VolumeA_G,V_VolumeB_G,VG_One,VG_Two",
+}
+
+var testConfStringsToAddVolumeG = []string{
+	"Volume:VolumeG.MaxFlushSize=50000000",
+	"Volume:VolumeG.MaxFlushTime=50s",
+	"VolumeGroup:VG_Three.PrimaryPeer=Peer2",
+	"VolumeGroup:VG_Three.ReadCacheLineSize=5000000",
+	"VolumeGroup:VG_Three.ReadCacheWeight=500",
+	"VolumeGroup:VG_Three.VirtualIPAddr=",
+	"VolumeGroup:VG_Three.VolumeList=VolumeG",
+	"FSGlobals.VolumeGroupList=V_VolumeA_G,V_VolumeB_G,VG_One,VG_Two,VG_Three",
+}
+
+var testConfStringsToMoveVolumeG = []string{
+	"VolumeGroup:VG_Two.VolumeList=VolumeF,VolumeG",
+	"VolumeGroup:VG_Three.VolumeList=",
+	"FSGlobals.VolumeGroupList=V_VolumeA_G,V_VolumeB_G,VG_One,VG_Two,VG_Three",
+}
+
+var testCallbackLog []string // Accumulates log messages output by transitions.Callbacks implementations
+
+func testValidateUpgradedConfMap(t *testing.T, testConfMap conf.ConfMap) {
+	var (
+		fsGlobals           conf.ConfMapSection
+		fsGlobalsOK         bool
+		maxFlushSize        conf.ConfMapOption
+		maxFlushSizeOK      bool
+		maxFlushTime        conf.ConfMapOption
+		maxFlushTimeOK      bool
+		primaryPeer         conf.ConfMapOption
+		primaryPeerOK       bool
+		readCacheLineSize   conf.ConfMapOption
+		readCacheLineSizeOK bool
+		readCacheWeight     conf.ConfMapOption
+		readCacheWeightOK   bool
+		testVolume          conf.ConfMapSection
+		testVolumeGroup     conf.ConfMapSection
+		testVolumeGroupOK   bool
+		testVolumeOK        bool
+		virtualIPAddr       conf.ConfMapOption
+		virtualIPAddrOK     bool
+		volumeGroupList     conf.ConfMapOption
+		volumeGroupListOK   bool
+		volumeList          conf.ConfMapOption
+		volumeListOK        bool
+	)
+
+	// Validate FSGlobals
+
+	fsGlobals, fsGlobalsOK = testConfMap["FSGlobals"]
+	if !fsGlobalsOK {
+		t.Fatalf("testConfMap must contain an FSGlobals section")
+	}
+
+	volumeGroupList, volumeGroupListOK = fsGlobals["VolumeGroupList"]
+	if !volumeGroupListOK || (4 != len(volumeGroupList)) || ("V_VolumeA_G" != volumeGroupList[0]) || ("V_VolumeB_G" != volumeGroupList[1]) || ("V_VolumeC_G" != volumeGroupList[2]) || ("V_VolumeD_G" != volumeGroupList[3]) {
+		t.Fatalf("testConfMap missing FSGlobals.VolumeGroupList=V_VolumeA_G,V_VolumeB_G,V_VolumeC_G,V_VolumeD_G")
+	}
+
+	// Validate VolumeGroup:V_VolumeA_G
+
+	testVolumeGroup, testVolumeGroupOK = testConfMap["VolumeGroup:V_VolumeA_G"]
+	if !testVolumeGroupOK {
+		t.Fatalf("testConfMap must contain a VolumeGroup:V_VolumeA_G section")
+	}
+
+	volumeList, volumeListOK = testVolumeGroup["VolumeList"]
+	if !volumeListOK || (1 != len(volumeList)) || ("VolumeA" != volumeList[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeA.VolumeList=VolumeA")
+	}
+	virtualIPAddr, virtualIPAddrOK = testVolumeGroup["VirtualIPAddr"]
+	if !virtualIPAddrOK || (0 != len(virtualIPAddr)) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeA.VirtualIPAddr=")
+	}
+	primaryPeer, primaryPeerOK = testVolumeGroup["PrimaryPeer"]
+	if !primaryPeerOK || (1 != len(primaryPeer)) || ("Peer0" != primaryPeer[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeA.PrimaryPeer=Peer0")
+	}
+	readCacheLineSize, readCacheLineSizeOK = testVolumeGroup["ReadCacheLineSize"]
+	if !readCacheLineSizeOK || (1 != len(readCacheLineSize)) || ("1000000" != readCacheLineSize[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeA.ReadCacheLineSize=1000000")
+	}
+	readCacheWeight, readCacheWeightOK = testVolumeGroup["ReadCacheWeight"]
+	if !readCacheWeightOK || (1 != len(readCacheWeight)) || ("100" != readCacheWeight[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeA.ReadCacheWeight=100")
+	}
+
+	testVolume, testVolumeOK = testConfMap["Volume:VolumeA"]
+	if !testVolumeOK {
+		t.Fatalf("testConfMap must contain a Volume:VolumeA section")
+	}
+
+	maxFlushSize, maxFlushSizeOK = testVolume["MaxFlushSize"]
+	if !maxFlushSizeOK || (1 != len(maxFlushSize)) || ("10000000" != maxFlushSize[0]) {
+		t.Fatalf("testConfMap missing Volume:VolumeA.MaxFlushSize=10000000")
+	}
+	maxFlushTime, maxFlushTimeOK = testVolume["MaxFlushTime"]
+	if !maxFlushTimeOK || (1 != len(maxFlushTime)) || ("10s" != maxFlushTime[0]) {
+		t.Fatalf("testConfMap missing Volume:VolumeA.MaxFlushTime=10s")
+	}
+
+	// Validate VolumeGroup:V_VolumeB_G
+
+	testVolumeGroup, testVolumeGroupOK = testConfMap["VolumeGroup:V_VolumeB_G"]
+	if !testVolumeGroupOK {
+		t.Fatalf("testConfMap must contain a VolumeGroup:V_VolumeB_G section")
+	}
+
+	volumeList, volumeListOK = testVolumeGroup["VolumeList"]
+	if !volumeListOK || (1 != len(volumeList)) || ("VolumeB" != volumeList[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeB.VolumeList=VolumeB")
+	}
+	virtualIPAddr, virtualIPAddrOK = testVolumeGroup["VirtualIPAddr"]
+	if !virtualIPAddrOK || (0 != len(virtualIPAddr)) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeB.VirtualIPAddr=")
+	}
+	primaryPeer, primaryPeerOK = testVolumeGroup["PrimaryPeer"]
+	if !primaryPeerOK || (1 != len(primaryPeer)) || ("Peer0" != primaryPeer[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeB.PrimaryPeer=Peer0")
+	}
+	readCacheLineSize, readCacheLineSizeOK = testVolumeGroup["ReadCacheLineSize"]
+	if !readCacheLineSizeOK || (1 != len(readCacheLineSize)) || ("2000000" != readCacheLineSize[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeB.ReadCacheLineSize=2000000")
+	}
+	readCacheWeight, readCacheWeightOK = testVolumeGroup["ReadCacheWeight"]
+	if !readCacheWeightOK || (1 != len(readCacheWeight)) || ("200" != readCacheWeight[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeB.ReadCacheWeight=200")
+	}
+
+	testVolume, testVolumeOK = testConfMap["Volume:VolumeB"]
+	if !testVolumeOK {
+		t.Fatalf("testConfMap must contain a Volume:VolumeB section")
+	}
+
+	maxFlushSize, maxFlushSizeOK = testVolume["MaxFlushSize"]
+	if !maxFlushSizeOK || (1 != len(maxFlushSize)) || ("20000000" != maxFlushSize[0]) {
+		t.Fatalf("testConfMap missing Volume:VolumeB.MaxFlushSize=20000000")
+	}
+	maxFlushTime, maxFlushTimeOK = testVolume["MaxFlushTime"]
+	if !maxFlushTimeOK || (1 != len(maxFlushTime)) || ("20s" != maxFlushTime[0]) {
+		t.Fatalf("testConfMap missing Volume:VolumeB.MaxFlushTime=20s")
+	}
+
+	// Validate VolumeGroup:V_VolumeC_G
+
+	testVolumeGroup, testVolumeGroupOK = testConfMap["VolumeGroup:V_VolumeC_G"]
+	if !testVolumeGroupOK {
+		t.Fatalf("testConfMap must contain a VolumeGroup:V_VolumeC_G section")
+	}
+
+	volumeList, volumeListOK = testVolumeGroup["VolumeList"]
+	if !volumeListOK || (1 != len(volumeList)) || ("VolumeC" != volumeList[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeC.VolumeList=VolumeC")
+	}
+	virtualIPAddr, virtualIPAddrOK = testVolumeGroup["VirtualIPAddr"]
+	if !virtualIPAddrOK || (0 != len(virtualIPAddr)) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeC.VirtualIPAddr=")
+	}
+	primaryPeer, primaryPeerOK = testVolumeGroup["PrimaryPeer"]
+	if !primaryPeerOK || (1 != len(primaryPeer)) || ("Peer1" != primaryPeer[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeA.PrimaryPeer=Peer1")
+	}
+	readCacheLineSize, readCacheLineSizeOK = testVolumeGroup["ReadCacheLineSize"]
+	if !readCacheLineSizeOK || (1 != len(readCacheLineSize)) || ("1000000" != readCacheLineSize[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeC.ReadCacheLineSize=1000000")
+	}
+	readCacheWeight, readCacheWeightOK = testVolumeGroup["ReadCacheWeight"]
+	if !readCacheWeightOK || (1 != len(readCacheWeight)) || ("100" != readCacheWeight[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeC.ReadCacheWeight=100")
+	}
+
+	testVolume, testVolumeOK = testConfMap["Volume:VolumeC"]
+	if !testVolumeOK {
+		t.Fatalf("testConfMap must contain a Volume:VolumeC section")
+	}
+
+	maxFlushSize, maxFlushSizeOK = testVolume["MaxFlushSize"]
+	if !maxFlushSizeOK || (1 != len(maxFlushSize)) || ("10000000" != maxFlushSize[0]) {
+		t.Fatalf("testConfMap missing Volume:VolumeC.MaxFlushSize=10000000")
+	}
+	maxFlushTime, maxFlushTimeOK = testVolume["MaxFlushTime"]
+	if !maxFlushTimeOK || (1 != len(maxFlushTime)) || ("10s" != maxFlushTime[0]) {
+		t.Fatalf("testConfMap missing Volume:VolumeC.MaxFlushTime=10s")
+	}
+
+	// Validate VolumeGroup:V_VolumeD_G
+
+	testVolumeGroup, testVolumeGroupOK = testConfMap["VolumeGroup:V_VolumeD_G"]
+	if !testVolumeGroupOK {
+		t.Fatalf("testConfMap must contain a VolumeGroup:V_VolumeD_G section")
+	}
+
+	volumeList, volumeListOK = testVolumeGroup["VolumeList"]
+	if !volumeListOK || (1 != len(volumeList)) || ("VolumeD" != volumeList[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeD.VolumeList=VolumeD")
+	}
+	virtualIPAddr, virtualIPAddrOK = testVolumeGroup["VirtualIPAddr"]
+	if !virtualIPAddrOK || (0 != len(virtualIPAddr)) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeD.VirtualIPAddr=")
+	}
+	primaryPeer, primaryPeerOK = testVolumeGroup["PrimaryPeer"]
+	if !primaryPeerOK || (1 != len(primaryPeer)) || ("Peer2" != primaryPeer[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeD.PrimaryPeer=Peer2")
+	}
+	readCacheLineSize, readCacheLineSizeOK = testVolumeGroup["ReadCacheLineSize"]
+	if !readCacheLineSizeOK || (1 != len(readCacheLineSize)) || ("2000000" != readCacheLineSize[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeD.ReadCacheLineSize=2000000")
+	}
+	readCacheWeight, readCacheWeightOK = testVolumeGroup["ReadCacheWeight"]
+	if !readCacheWeightOK || (1 != len(readCacheWeight)) || ("200" != readCacheWeight[0]) {
+		t.Fatalf("testConfMap missing VolumeGroup:VolumeD.ReadCacheWeight=200")
+	}
+
+	testVolume, testVolumeOK = testConfMap["Volume:VolumeD"]
+	if !testVolumeOK {
+		t.Fatalf("testConfMap must contain a Volume:VolumeD section")
+	}
+
+	maxFlushSize, maxFlushSizeOK = testVolume["MaxFlushSize"]
+	if !maxFlushSizeOK || (1 != len(maxFlushSize)) || ("20000000" != maxFlushSize[0]) {
+		t.Fatalf("testConfMap missing Volume:VolumeD.MaxFlushSize=20000000")
+	}
+	maxFlushTime, maxFlushTimeOK = testVolume["MaxFlushTime"]
+	if !maxFlushTimeOK || (1 != len(maxFlushTime)) || ("20s" != maxFlushTime[0]) {
+		t.Fatalf("testConfMap missing Volume:VolumeD.MaxFlushTime=20s")
+	}
+}
+
+// testValidateCallbackLog compares the global testCallbackLog to the
+// provided expectedCallbackLog. Note that testCallbackLog is a time
+// ordered []string of log messages. It is expected that some have
+// order dependency (e.g. one cannot destroy a volume unless it has
+// been unserved if it was previously served by this peer). As such,
+// the structure of expectedCallbackLog is a time ordered list of
+// []string. Within each []string, order is not required...though each
+// element must match precisely once. In the slice of []string's, order
+// is strictly required.
+//
+func testValidateCallbackLog(t *testing.T, testcase string, expectedCallbackLog [][]string) {
+	var (
+		expectedCallbackLogSliceElement []string
+		numLogMessages                  int
+		testCallbackLogIndex            int
+		testCallbackLogSubset           []string
+		testCallbackLogSubsetElement    string
+		testCallbackLogSubsetIndex      int
+	)
+	// First ensure we have the expected number of log messages
+
+	numLogMessages = 0
+
+	for _, expectedCallbackLogSliceElement = range expectedCallbackLog {
+		numLogMessages += len(expectedCallbackLogSliceElement)
+	}
+
+	if len(testCallbackLog) != numLogMessages {
+		t.Fatalf("In testcase \"%s\", unexpected testCallbackLog", testcase)
+	}
+
+	testCallbackLogIndex = 0
+
+	for _, expectedCallbackLogSliceElement = range expectedCallbackLog {
+		testCallbackLogSubset = testCallbackLog[testCallbackLogIndex : testCallbackLogIndex+len(expectedCallbackLogSliceElement)]
+
+		sort.Strings(testCallbackLogSubset)
+		sort.Strings(expectedCallbackLogSliceElement)
+
+		for testCallbackLogSubsetIndex, testCallbackLogSubsetElement = range testCallbackLogSubset {
+			if testCallbackLogSubsetElement != expectedCallbackLogSliceElement[testCallbackLogSubsetIndex] {
+				t.Fatalf("In testcase \"%s\", unexpected testCallbackLog", testcase)
+			}
+		}
+
+		testCallbackLogIndex += len(testCallbackLogSubset)
+	}
+}
+
+func TestAPI(t *testing.T) {
+	var (
+		err                     error
+		testCallbacksInterface1 *testCallbacksInterfaceStruct
+		testCallbacksInterface2 *testCallbacksInterfaceStruct
+		testConfMap             conf.ConfMap
+	)
+
+	testCallbacksInterface1 = &testCallbacksInterfaceStruct{name: "1", t: t}
+	testCallbacksInterface2 = &testCallbacksInterfaceStruct{name: "2", t: t}
+
+	Register(testCallbacksInterface1.name, testCallbacksInterface1)
+	Register(testCallbacksInterface2.name, testCallbacksInterface2)
+
+	testConfMap, err = conf.MakeConfMapFromStrings(testConfStrings)
+	if nil != err {
+		t.Fatalf("conf.MakeConfMapFromStrings() failed: %v", err)
+	}
+
+	t.Log("Verify old->new conf.ConfMap conversion")
+
+	err = upgradeConfMapIfNeeded(testConfMap)
+	if nil != err {
+		t.Fatalf("upgradeConfMapIfNeeded(<old confMap contents) failed: %v", err)
+	}
+
+	testValidateUpgradedConfMap(t, testConfMap)
+
+	err = upgradeConfMapIfNeeded(testConfMap)
+	if nil != err {
+		t.Fatalf("upgradeConfMapIfNeeded(<new confMap contents) failed: %v", err)
+	}
+
+	testValidateUpgradedConfMap(t, testConfMap)
+
+	t.Log("Perform Up() sequence")
+
+	testCallbackLog = make([]string, 0, 22)
+
+	err = Up(testConfMap)
+	if nil != err {
+		t.Fatalf("Up() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Perform Up() sequence",
+		[][]string{
+			[]string{
+				"testCallbacksInterface1.Up() called"},
+			[]string{
+				"testCallbacksInterface2.Up() called"},
+			[]string{
+				"testCallbacksInterface1.VolumeGroupCreated(,V_VolumeA_G,Peer0,) called",
+				"testCallbacksInterface1.VolumeGroupCreated(,V_VolumeB_G,Peer0,) called",
+				"testCallbacksInterface1.VolumeGroupCreated(,V_VolumeC_G,Peer1,) called",
+				"testCallbacksInterface1.VolumeGroupCreated(,V_VolumeD_G,Peer2,) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupCreated(,V_VolumeA_G,Peer0,) called",
+				"testCallbacksInterface2.VolumeGroupCreated(,V_VolumeB_G,Peer0,) called",
+				"testCallbacksInterface2.VolumeGroupCreated(,V_VolumeC_G,Peer1,) called",
+				"testCallbacksInterface2.VolumeGroupCreated(,V_VolumeD_G,Peer2,) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeCreated(,VolumeA,V_VolumeA_G) called",
+				"testCallbacksInterface1.VolumeCreated(,VolumeB,V_VolumeB_G) called",
+				"testCallbacksInterface1.VolumeCreated(,VolumeC,V_VolumeC_G) called",
+				"testCallbacksInterface1.VolumeCreated(,VolumeD,V_VolumeD_G) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeCreated(,VolumeA,V_VolumeA_G) called",
+				"testCallbacksInterface2.VolumeCreated(,VolumeB,V_VolumeB_G) called",
+				"testCallbacksInterface2.VolumeCreated(,VolumeC,V_VolumeC_G) called",
+				"testCallbacksInterface2.VolumeCreated(,VolumeD,V_VolumeD_G) called"},
+			[]string{
+				"testCallbacksInterface1.ServeVolume(,VolumeA) called",
+				"testCallbacksInterface1.ServeVolume(,VolumeB) called"},
+			[]string{
+				"testCallbacksInterface2.ServeVolume(,VolumeA) called",
+				"testCallbacksInterface2.ServeVolume(,VolumeB) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"},
+		})
+
+	t.Log("Perform Signaled() sequence with no changes")
+
+	testCallbackLog = make([]string, 0, 2)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Perform Signaled() sequence with no changes",
+		[][]string{
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Move VolumeB from Peer0 to Peer1")
+
+	testConfMap["VolumeGroup:V_VolumeB_G"]["PrimaryPeer"] = []string{"Peer1"}
+
+	testCallbackLog = make([]string, 0, 6)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Move VolumeB from Peer0 to Peer1",
+		[][]string{
+			[]string{
+				"testCallbacksInterface2.UnserveVolume(,VolumeB) called"},
+			[]string{
+				"testCallbacksInterface1.UnserveVolume(,VolumeB) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeGroupMoved(,V_VolumeB_G,Peer1,) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupMoved(,V_VolumeB_G,Peer1,) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Move VolumeC from Peer1 to Peer2")
+
+	testConfMap["VolumeGroup:V_VolumeC_G"]["PrimaryPeer"] = []string{"Peer2"}
+
+	testCallbackLog = make([]string, 0, 4)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Move VolumeC from Peer1 to Peer2",
+		[][]string{
+			[]string{
+				"testCallbacksInterface1.VolumeGroupMoved(,V_VolumeC_G,Peer2,) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupMoved(,V_VolumeC_G,Peer2,) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Destroy VolumeC")
+
+	testConfMap["FSGlobals"]["VolumeGroupList"] = []string{"V_VolumeA_G", "V_VolumeB_G", "V_VolumeD_G"}
+
+	delete(testConfMap, "VolumeGroup:V_VolumeC_G")
+	delete(testConfMap, "Volume:VolumeC")
+
+	testCallbackLog = make([]string, 0, 6)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Destroy VolumeC",
+		[][]string{
+			[]string{
+				"testCallbacksInterface2.VolumeDestroyed(,VolumeC) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeDestroyed(,VolumeC) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupDestroyed(,V_VolumeC_G) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeGroupDestroyed(,V_VolumeC_G) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Move VolumeD from Peer2 to Peer0")
+
+	testConfMap["VolumeGroup:V_VolumeD_G"]["PrimaryPeer"] = []string{"Peer0"}
+
+	testCallbackLog = make([]string, 0, 6)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Move VolumeD from Peer2 to Peer0",
+		[][]string{
+			[]string{
+				"testCallbacksInterface1.VolumeGroupMoved(,V_VolumeD_G,Peer0,) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupMoved(,V_VolumeD_G,Peer0,) called"},
+			[]string{
+				"testCallbacksInterface1.ServeVolume(,VolumeD) called"},
+			[]string{
+				"testCallbacksInterface2.ServeVolume(,VolumeD) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Destroy VolumeD")
+
+	testConfMap["FSGlobals"]["VolumeGroupList"] = []string{"V_VolumeA_G", "V_VolumeB_G"}
+
+	delete(testConfMap, "VolumeGroup:V_VolumeD_G")
+	delete(testConfMap, "Volume:VolumeD")
+
+	testCallbackLog = make([]string, 0, 8)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Destroy VolumeD",
+		[][]string{
+			[]string{
+				"testCallbacksInterface2.UnserveVolume(,VolumeD) called"},
+			[]string{
+				"testCallbacksInterface1.UnserveVolume(,VolumeD) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeDestroyed(,VolumeD) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeDestroyed(,VolumeD) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupDestroyed(,V_VolumeD_G) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeGroupDestroyed(,V_VolumeD_G) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Create VolumeE on Peer0")
+
+	err = testConfMap.UpdateFromStrings(testConfStringsToAddVolumeE)
+	if nil != err {
+		t.Fatalf("testConfMap.UpdateFromStrings(testConfStringsToAddVolumeE) failed: %v", err)
+	}
+
+	testCallbackLog = make([]string, 0, 8)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Create VolumeE on Peer0",
+		[][]string{
+			[]string{
+				"testCallbacksInterface1.VolumeGroupCreated(,VG_One,Peer0,) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupCreated(,VG_One,Peer0,) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeCreated(,VolumeE,VG_One) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeCreated(,VolumeE,VG_One) called"},
+			[]string{
+				"testCallbacksInterface1.ServeVolume(,VolumeE) called"},
+			[]string{
+				"testCallbacksInterface2.ServeVolume(,VolumeE) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Create VolumeF on Peer1")
+
+	err = testConfMap.UpdateFromStrings(testConfStringsToAddVolumeF)
+	if nil != err {
+		t.Fatalf("testConfMap.UpdateFromStrings(testConfStringsToAddVolumeF) failed: %v", err)
+	}
+
+	testCallbackLog = make([]string, 0, 6)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Create VolumeF on Peer1",
+		[][]string{
+			[]string{
+				"testCallbacksInterface1.VolumeGroupCreated(,VG_Two,Peer1,) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupCreated(,VG_Two,Peer1,) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeCreated(,VolumeF,VG_Two) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeCreated(,VolumeF,VG_Two) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Create VolumeG on Peer2")
+
+	err = testConfMap.UpdateFromStrings(testConfStringsToAddVolumeG)
+	if nil != err {
+		t.Fatalf("testConfMap.UpdateFromStrings(testConfStringsToAddVolumeG) failed: %v", err)
+	}
+
+	testCallbackLog = make([]string, 0, 6)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Create VolumeG on Peer2",
+		[][]string{
+			[]string{
+				"testCallbacksInterface1.VolumeGroupCreated(,VG_Three,Peer2,) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupCreated(,VG_Three,Peer2,) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeCreated(,VolumeG,VG_Three) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeCreated(,VolumeG,VG_Three) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Move VolumeG to VolumeF's VolumeGroup")
+
+	err = testConfMap.UpdateFromStrings(testConfStringsToMoveVolumeG)
+	if nil != err {
+		t.Fatalf("testConfMap.UpdateFromStrings(testConfStringsToMoveVolumeG) failed: %v", err)
+	}
+
+	testCallbackLog = make([]string, 0, 4)
+
+	err = Signaled(testConfMap)
+	if nil != err {
+		t.Fatalf("Signaled() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Move VolumeG to VolumeF's VolumeGroup",
+		[][]string{
+			[]string{
+				"testCallbacksInterface1.VolumeMoved(,VolumeG,VG_Two) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeMoved(,VolumeG,VG_Two) called"},
+			[]string{
+				"testCallbacksInterface1.Signaled() called"},
+			[]string{
+				"testCallbacksInterface2.Signaled() called"}})
+
+	t.Log("Perform Down() sequence")
+
+	testCallbackLog = make([]string, 0, 26)
+
+	err = Down(testConfMap)
+	if nil != err {
+		t.Fatalf("Down() failed: %v", err)
+	}
+
+	testValidateCallbackLog(t,
+		"Perform Down() sequence",
+		[][]string{
+			[]string{
+				"testCallbacksInterface2.UnserveVolume(,VolumeA) called",
+				"testCallbacksInterface2.UnserveVolume(,VolumeE) called"},
+			[]string{
+				"testCallbacksInterface1.UnserveVolume(,VolumeA) called",
+				"testCallbacksInterface1.UnserveVolume(,VolumeE) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeDestroyed(,VolumeA) called",
+				"testCallbacksInterface2.VolumeDestroyed(,VolumeB) called",
+				"testCallbacksInterface2.VolumeDestroyed(,VolumeE) called",
+				"testCallbacksInterface2.VolumeDestroyed(,VolumeF) called",
+				"testCallbacksInterface2.VolumeDestroyed(,VolumeG) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeDestroyed(,VolumeA) called",
+				"testCallbacksInterface1.VolumeDestroyed(,VolumeB) called",
+				"testCallbacksInterface1.VolumeDestroyed(,VolumeE) called",
+				"testCallbacksInterface1.VolumeDestroyed(,VolumeF) called",
+				"testCallbacksInterface1.VolumeDestroyed(,VolumeG) called"},
+			[]string{
+				"testCallbacksInterface2.VolumeGroupDestroyed(,V_VolumeA_G) called",
+				"testCallbacksInterface2.VolumeGroupDestroyed(,V_VolumeB_G) called",
+				"testCallbacksInterface2.VolumeGroupDestroyed(,VG_One) called",
+				"testCallbacksInterface2.VolumeGroupDestroyed(,VG_Two) called",
+				"testCallbacksInterface2.VolumeGroupDestroyed(,VG_Three) called"},
+			[]string{
+				"testCallbacksInterface1.VolumeGroupDestroyed(,V_VolumeA_G) called",
+				"testCallbacksInterface1.VolumeGroupDestroyed(,V_VolumeB_G) called",
+				"testCallbacksInterface1.VolumeGroupDestroyed(,VG_One) called",
+				"testCallbacksInterface1.VolumeGroupDestroyed(,VG_Two) called",
+				"testCallbacksInterface1.VolumeGroupDestroyed(,VG_Three) called"},
+			[]string{
+				"testCallbacksInterface2.Down() called"},
+			[]string{
+				"testCallbacksInterface1.Down() called"}})
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) Up(confMap conf.ConfMap) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.Up() called", testCallbacksInterface.name)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.VolumeGroupCreated(,%s,%s,%s) called", testCallbacksInterface.name, volumeGroupName, activePeer, virtualIPAddr)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) VolumeGroupMoved(confMap conf.ConfMap, volumeGroupName string, activePeer string, virtualIPAddr string) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.VolumeGroupMoved(,%s,%s,%s) called", testCallbacksInterface.name, volumeGroupName, activePeer, virtualIPAddr)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) VolumeGroupDestroyed(confMap conf.ConfMap, volumeGroupName string) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.VolumeGroupDestroyed(,%s) called", testCallbacksInterface.name, volumeGroupName)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) VolumeCreated(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.VolumeCreated(,%s,%s) called", testCallbacksInterface.name, volumeName, volumeGroupName)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) VolumeMoved(confMap conf.ConfMap, volumeName string, volumeGroupName string) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.VolumeMoved(,%s,%s) called", testCallbacksInterface.name, volumeName, volumeGroupName)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) VolumeDestroyed(confMap conf.ConfMap, volumeName string) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.VolumeDestroyed(,%s) called", testCallbacksInterface.name, volumeName)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) ServeVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.ServeVolume(,%s) called", testCallbacksInterface.name, volumeName)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.UnserveVolume(,%s) called", testCallbacksInterface.name, volumeName)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) Signaled(confMap conf.ConfMap) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.Signaled() called", testCallbacksInterface.name)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}
+
+func (testCallbacksInterface *testCallbacksInterfaceStruct) Down(confMap conf.ConfMap) (err error) {
+	logMessage := fmt.Sprintf("testCallbacksInterface%s.Down() called", testCallbacksInterface.name)
+	testCallbacksInterface.t.Logf("  %s", logMessage)
+	testCallbackLog = append(testCallbackLog, logMessage)
+	return nil
+}

--- a/utils/api.go
+++ b/utils/api.go
@@ -4,6 +4,7 @@ package utils
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"runtime"
@@ -639,4 +640,30 @@ func (p *Profiler) Dump() {
 	remainingTime := totalDuration - totalEventTime
 	fmt.Printf("%30s   + %6d us  (%3v %%)\n", "(remaining time)", remainingTime, remainingTime*100/totalDuration)
 	fmt.Printf("%30s   + %6d us  (%3v %%)\n", "total duration", totalDuration, totalDuration*100/totalDuration)
+}
+
+func JSONify(input interface{}, indentify bool) (output string) {
+	var (
+		err             error
+		inputJSON       bytes.Buffer
+		inputJSONPacked []byte
+	)
+
+	inputJSONPacked, err = json.Marshal(input)
+	if nil == err {
+		if indentify {
+			err = json.Indent(&inputJSON, inputJSONPacked, "", "\t")
+			if nil == err {
+				output = inputJSON.String()
+			} else {
+				output = fmt.Sprintf("<<<json.Indent failed: %v>>>", err)
+			}
+		} else {
+			output = string(inputJSONPacked)
+		}
+	} else {
+		output = fmt.Sprintf("<<<json.Marshall failed: %v>>>", err)
+	}
+
+	return
 }


### PR DESCRIPTION
This new package provides a API and a callback mechanism designed to
entirely replace the repetitive code sequence in each main() func
and most of the _test.go files that have to startup (and shutdown)
the various packages they are dependent upon... and do so in the
proper order. Maintenance of these dependencies and sequences will
eventually be totally automated once each such package implements
an init() func to register their callbacks and the main() (and
test) func's replace their package initialization/shutdown sequences
with a simple set of calls to the transitions package.