### PR TITLE
Avoid use of colons in scheduled snapshot names

### DIFF
--- a/inode/cron.go
+++ b/inode/cron.go
@@ -3,6 +3,7 @@ package inode
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -258,7 +259,7 @@ func (snapShotPolicy *snapShotPolicyStruct) daemon() {
 				// If time.After() returned a bit too soon, loop until it is our time
 				time.Sleep(100 * time.Millisecond)
 			}
-			snapShotName = nextTime.Format(time.RFC3339)
+			snapShotName = strings.Replace(nextTime.Format(time.RFC3339), ":", ".", -1)
 			_, err = snapShotPolicy.volume.SnapShotCreate(snapShotName)
 			if nil != err {
 				logger.WarnWithError(err)
@@ -294,7 +295,7 @@ func (snapShotPolicy *snapShotPolicyStruct) prune() {
 	// Now walk snapShotList looking for snapshots to prune
 
 	for _, snapShot = range snapShotList {
-		snapShotTime, err = time.Parse(time.RFC3339, snapShot.Name)
+		snapShotTime, err = time.Parse(time.RFC3339, strings.Replace(snapShot.Name, ".", ":", -1))
 		if nil != err {
 			// SnapShot was not formatted to match a potential SnapShotPolicy/Schedule...skip it
 			continue


### PR DESCRIPTION
SMB Clients normally prohibit the use of colons in file/directory names.
As each scheduled snapshot bears a name of the time it was taken, such
snapshots will appear in the /.snapshot directory with those names.

Prior to this change, the format chosen for the snapshot names was simply
RFC3339 (equivalent to ISO 8601). This format nicely encodes the timezone
in addition to the date and time. Alas, it specifies the use of colons to
separate hours from minutes and minutes from seconds. This presents quite
a challenge for SMB clients given the colon prohibition.

As a workaround, scheduled snapshot names will take the RFC3339-formatted
time and replace colons with dots (periods). This is a nod to the pre-EU
German (DIN) standard practice and avoids the SMB probibited character
set for file/directory names.