### PR TITLE
Fix python lint errors.

### DIFF
--- a/pfs_middleware/pfs_middleware/utils.py
+++ b/pfs_middleware/pfs_middleware/utils.py
@@ -63,7 +63,7 @@ def parse_path(path):
     return segs
 
 
-PFS_ERRNO_RE = re.compile("^errno: (\d+)$")
+PFS_ERRNO_RE = re.compile(r'^errno: (\d+)$')
 
 
 def extract_errno(errstr):

--- a/pfs_middleware/tox.ini
+++ b/pfs_middleware/tox.ini
@@ -35,6 +35,9 @@ deps =
 # "hacking" adds many different checks, a significant number of which
 # are completely bogus. Fortunately, they have a convention: hacking
 # checks start with "H", so that's what we ignore.
-ignore = H
+ignore = H,
+    # Both stupid binary opeator things
+    W503,
+    W504
 exclude = .venv,.tox,dist,*egg
 show-source = true


### PR DESCRIPTION
tox lint is suddenly complaining about binary operators at the end
of the line.  Change pfs_middleware/tox.ini to ignore that warning.

A regular expression in pfs_middleware/pfs_middleware/utils.py used
double quotes for the RE without escaping `\d`.  Change it to use
a raw string.