### PR TITLE
Allow empty PrimaryPeer value in Volume{|Group}

### DIFF
--- a/conf/api.go
+++ b/conf/api.go
@@ -338,7 +338,7 @@ func (confMap ConfMap) UpdateFromFile(confFilePath string) (err error) {
 	return
 }
 
-// VerifyOptionValueIsEmpty returns an error if [sectionName]valueName's string value is empty
+// VerifyOptionValueIsEmpty returns an error if [sectionName]valueName's string value is not empty
 func (confMap ConfMap) VerifyOptionValueIsEmpty(sectionName string, optionName string) (err error) {
 	section, ok := confMap[sectionName]
 	if !ok {

--- a/inode/config.go
+++ b/inode/config.go
@@ -23,8 +23,8 @@ type readCacheKeyStruct struct {
 
 type readCacheElementStruct struct {
 	readCacheKey readCacheKeyStruct
-	next         *readCacheElementStruct // nil if MRU element of flowControlStruct.readCache
-	prev         *readCacheElementStruct // nil if LRU element of flowControlStruct.readCache
+	next         *readCacheElementStruct // nil if MRU element of volumeGroupStruct.readCache
+	prev         *readCacheElementStruct // nil if LRU element of volumeGroupStruct.readCache
 	cacheLine    []byte
 }
 
@@ -559,7 +559,7 @@ func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string)
 	}
 
 	defaultPhysicalContainerLayout = &physicalContainerLayoutStruct{
-		name:                        defaultPhysicalContainerLayoutName,
+		name: defaultPhysicalContainerLayoutName,
 		containerNameSliceNextIndex: 0,
 		containerNameSliceLoopCount: 0,
 	}

--- a/transitions/api_internal.go
+++ b/transitions/api_internal.go
@@ -576,7 +576,11 @@ func computeConfMapDelta(confMap conf.ConfMap) (err error) {
 
 		volumeGroup.activePeer, err = confMap.FetchOptionValueString("VolumeGroup:"+volumeGroupName, "PrimaryPeer")
 		if nil != err {
-			return
+			if nil == confMap.VerifyOptionValueIsEmpty("VolumeGroup:"+volumeGroupName, "PrimaryPeer") {
+				volumeGroup.activePeer = ""
+			} else {
+				return
+			}
 		}
 
 		volumeGroup.served = (whoAmI == volumeGroup.activePeer)
@@ -848,8 +852,8 @@ func upgradeConfMapIfNeeded(confMap conf.ConfMap) (err error) {
 		}
 
 		primaryPeer, primaryPeerOK = volume["PrimaryPeer"]
-		if !primaryPeerOK {
-			err = fmt.Errorf("confMap must contain a Volume:%s.PrimaryPeer key", volumeName)
+		if !primaryPeerOK || (1 < len(primaryPeer)) {
+			err = fmt.Errorf("confMap must contain an empty or single-valued Volume:%s.PrimaryPeer key", volumeName)
 			return
 		}
 


### PR DESCRIPTION
During migrations, it is necessary to remove a volume from one node
before adding it to another node. One way to accomplish this is to
do two SIGHUPs: one after clearing the PrimaryPeer field, a second
after setting the PrimaryPeer field to the desired new node.