### PR TITLE
Backed out errant ConfMap upgrade in pfs-{stress|swift-load}

### DIFF
--- a/pfs-stress/main.go
+++ b/pfs-stress/main.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 var (
@@ -77,12 +76,6 @@ func main() {
 	err = confMap.UpdateFromStrings(args[1:])
 	if nil != err {
 		log.Fatalf("failed to load config overrides: %v", err)
-	}
-
-	// Upgrade confMap if necessary
-	err = transitions.UpgradeConfMapIfNeeded(confMap)
-	if nil != err {
-		log.Fatalf("Failed to upgrade config: %v", err)
 	}
 
 	// Process resultant confMap

--- a/pfs-swift-load/main.go
+++ b/pfs-swift-load/main.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/conf"
-	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 const (
@@ -157,12 +156,6 @@ func main() {
 	err = confMap.UpdateFromStrings(args[1:])
 	if nil != err {
 		log.Fatalf("Failed to load config overrides: %v", err)
-	}
-
-	// Upgrade confMap if necessary
-	err = transitions.UpgradeConfMapIfNeeded(confMap)
-	if nil != err {
-		log.Fatalf("Failed to upgrade config: %v", err)
 	}
 
 	// Process resultant confMap


### PR DESCRIPTION
These two tools do not consume a .conf file intended for ProxyFS.
As such, the transitions.UpgradeConfMapIfNeeded() call is not
required (and, indeed, would fail).