### PR TITLE
pfs_middleware: Add config option for bypass/get-read-plan

### DIFF
--- a/pfs_middleware/tests/test_pfs_middleware.py
+++ b/pfs_middleware/tests/test_pfs_middleware.py
@@ -53,7 +53,9 @@ class BaseMiddlewareTest(unittest.TestCase):
     def setUp(self):
         super(BaseMiddlewareTest, self).setUp()
         self.app = helpers.FakeProxy()
-        self.pfs = mware.PfsMiddleware(self.app, {}, FakeLogger())
+        self.pfs = mware.PfsMiddleware(self.app, {
+            'bypass_mode': 'read-only',
+        }, FakeLogger())
         self.bimodal_checker = bimodal_checker.BimodalChecker(self.pfs, {
             'bimodal_recheck_interval': 'inf',  # avoid timing dependencies
         }, FakeLogger())


### PR DESCRIPTION
We don't necessarily want to expose all of ProxyFS's internals to the world, even in some read-only mode. Add a `bypass_mode` config option that defaults to `off` (to reflect pre-bypass behavior) but may be set to `read-only` or `read-write`.