### PR TITLE
Updated SAIO VM to include S3 support

### DIFF
--- a/saio/etc/swift/proxy-server.conf
+++ b/saio/etc/swift/proxy-server.conf
@@ -9,7 +9,7 @@ eventlet_debug = true
 [pipeline:main]
 # Yes, proxy-logging appears twice. This is so that
 # middleware-originated requests get logged too.
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache bulk tempurl ratelimit crossdomain container_sync tempauth staticweb copy container-quotas account-quotas slo dlo pfs versioned_writes proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache bulk tempurl ratelimit crossdomain container_sync s3api tempauth staticweb copy container-quotas account-quotas slo dlo pfs versioned_writes proxy-logging proxy-server
 
 [filter:catch_errors]
 use = egg:swift#catch_errors
@@ -41,6 +41,11 @@ use = egg:swift#crossdomain
 [filter:container_sync]
 use = egg:swift#container_sync
 current = //saio/saio_endpoint
+
+[filter:s3api]
+use = egg:swift#s3api
+s3_acl = False
+allow_multipart_uploads = True
 
 [filter:tempauth]
 use = egg:swift#tempauth

--- a/saio/vagrant_provision.sh
+++ b/saio/vagrant_provision.sh
@@ -231,9 +231,11 @@ python setup.py develop
 cd ~swift
 git clone https://github.com/openstack/swift.git
 cd swift
-git checkout 5cf96230c82d4fcbac297775997a7e0abe3e9ff9
+git checkout 184fdf17ef7490038e89fe92a92de0fe4f2b36b7
 pip install --no-binary cryptography -r requirements.txt
 python setup.py develop
+# The following avoid dependency on pip-installed pyOpenSSL being newer than required
+pip install python-openstackclient==3.12.0 python-glanceclient==2.7.0
 pip install -r test-requirements.txt
 
 # [Setup Swift] Setting up rsync
@@ -281,6 +283,24 @@ python setup.py develop
 
 cd /vagrant/src/github.com/swiftstack/ProxyFS/meta_middleware
 python setup.py develop
+
+# Setup AWS access for local vagrant user
+
+pip install awscli-plugin-endpoint
+mkdir -p ~vagrant/.aws
+cat > ~vagrant/.aws/config << EOF
+[plugins]
+endpoint = awscli_plugin_endpoint
+
+[profile default]
+aws_access_key_id = test:tester
+aws_secret_access_key = testing
+s3 =
+     endpoint_url = http://127.0.0.1:8080
+     multipart_threshold = 64MB
+     multipart_chunksize = 16MB
+EOF
+chown -R vagrant:vagrant ~vagrant/.aws
 
 # Ensure proxyfsd logging will work
 


### PR DESCRIPTION
Now that S3 is embedded in Swift itself, we can utilize it here.
The local vagrant user now is setup to use the AWS S3 cli.

Also rolled up Swift version to 2.20.0