### PR TITLE
Fix missing deletion of dereferenced inode in Coalesce overwrite case

### DIFF
--- a/inode/file.go
+++ b/inode/file.go
@@ -966,6 +966,13 @@ func (vS *volumeStruct) Coalesce(containingDirInodeNumber InodeNumber, combinati
 		if err != nil {
 			return
 		}
+
+		if 0 == obstacleInode.LinkCount {
+			err = vS.Destroy(obstacleInodeNumber)
+			if err != nil {
+				return
+			}
+		}
 	}
 
 	// Link the new entry in


### PR DESCRIPTION
If Coalesce ends up targeting an existing file, that file is removed
from the containing directory... but not destroyed when its link count
has now dropped to zero. This change corrects that omission.