### PR TITLE
Fix VolumeMoved() callback in package headhunter

### DIFF
--- a/headhunter/config.go
+++ b/headhunter/config.go
@@ -437,7 +437,7 @@ func (dummy *globalsStruct) VolumeMoved(confMap conf.ConfMap, volumeName string,
 		return
 	}
 	_, ok = newVolumeGroup.volumeMap[volumeName]
-	if !ok {
+	if ok {
 		globals.Unlock()
 		err = fmt.Errorf("headhunter.VolumeMoved() called for Volume (%s) to be moved to VolumeGroup (%s) already containing the Volume", volumeName, volumeGroupName)
 		return

--- a/logger/api.go
+++ b/logger/api.go
@@ -117,6 +117,7 @@ var packageTraceSettings = map[string]bool{
 	"proxyfsd":    false,
 	"sortedmap":   false,
 	"swiftclient": false,
+	"transitions": false,
 }
 
 func setTraceLoggingLevel(confStrSlice []string) {

--- a/proxyfsd/default.conf
+++ b/proxyfsd/default.conf
@@ -167,8 +167,8 @@ Debug:           false
 [Logging]
 LogFilePath:       proxyfsd.log
 LogToConsole:      false # when true, log to stderr even when LogFilePath is set
-TraceLevelLogging: none  # Enable trace logging on a per-package basis. Supported values: jrpcfs, inode, none (default)
-DebugLevelLogging: none  # Enable debug logging on a per-package basis. Supported values: ldlm, fs, jrpcfs, inode, none (default)
+TraceLevelLogging: none  # Enable trace logging on a per-package basis. Supported values: dlm, fs, fuse, headhunter, inode, jrpcfs, logger, proxyfsd, sortedmap, swiftclient, and transitions...or none (default).
+DebugLevelLogging: none  # Enable debug logging on a per-package basis. Supported values: ldlm, fs, jrpcfs, and inode...or none (default).
 # NOTE: Log levels other than Trace and Debug are always on.
 
 [EventLog]

--- a/proxyfsd/logging.conf
+++ b/proxyfsd/logging.conf
@@ -4,11 +4,11 @@ LogFilePath: proxyfsd.log
 # NOTE: Log levels other than Trace and Debug are always on.
 
 # Enable trace logging on a per-package basis. Trace logs are disabled by default unless enabled here.
-# Supported values: jrpcfs, inode, none (default).
+# Supported values: dlm, fs, fuse, headhunter, inode, jrpcfs, logger, proxyfsd, sortedmap, swiftclient, and transitions...or none (default).
 TraceLevelLogging: none
 
 # Enable debug logging on a per-package basis. Debug logs are disabled by default unless enabled here.
-# Supported values: ldlm, fs, jrpcfs, inode, none (default).
+# Supported values: ldlm, fs, jrpcfs, and inode...or none (default).
 DebugLevelLogging: none
 
 # when true, log to stderr even when LogFilePath is set

--- a/proxyfsd/saio_logging.conf
+++ b/proxyfsd/saio_logging.conf
@@ -6,21 +6,7 @@ LogFilePath: /var/log/proxyfsd/proxyfsd.log
 # Enable trace logging on a per-package basis. Trace logs are disabled by default unless enabled here.
 # Supported values: dlm, fs, fuse, headhunter, inode, jrpcfs, logger, proxyfsd, sortedmap, swiftclient, and transitions...or none (default).
 TraceLevelLogging: none
-/*
-var packageTraceSettings = map[string]bool{
-	"dlm":         false,
-	"fs":          false,
-	"fuse":        false,
-	"headhunter":  false,
-	"inode":       false,
-	"jrpcfs":      false,
-	"logger":      false,
-	"proxyfsd":    false,
-	"sortedmap":   false,
-	"swiftclient": false,
-	"transitions": false,
-}
-*/
+
 # Enable debug logging on a per-package basis. Debug logs are disabled by default unless enabled here.
 # Supported values: ldlm, fs, jrpcfs, and inode...or none (default).
 DebugLevelLogging: none

--- a/proxyfsd/saio_logging.conf
+++ b/proxyfsd/saio_logging.conf
@@ -4,11 +4,25 @@ LogFilePath: /var/log/proxyfsd/proxyfsd.log
 # NOTE: Log levels other than Trace and Debug are always on.
 
 # Enable trace logging on a per-package basis. Trace logs are disabled by default unless enabled here.
-# Supported values: jrpcfs, inode, none (default).
+# Supported values: dlm, fs, fuse, headhunter, inode, jrpcfs, logger, proxyfsd, sortedmap, swiftclient, and transitions...or none (default).
 TraceLevelLogging: none
-
+/*
+var packageTraceSettings = map[string]bool{
+	"dlm":         false,
+	"fs":          false,
+	"fuse":        false,
+	"headhunter":  false,
+	"inode":       false,
+	"jrpcfs":      false,
+	"logger":      false,
+	"proxyfsd":    false,
+	"sortedmap":   false,
+	"swiftclient": false,
+	"transitions": false,
+}
+*/
 # Enable debug logging on a per-package basis. Debug logs are disabled by default unless enabled here.
-# Supported values: ldlm, fs, jrpcfs, inode, none (default).
+# Supported values: ldlm, fs, jrpcfs, and inode...or none (default).
 DebugLevelLogging: none
 
 # when true, log to stderr even when LogFilePath is set—


### PR DESCRIPTION
Previously, the check for moving a Volume to a different VolumeGroup
would report that the Volume was already there when it wasn't.