### PR TITLE
Cannot hold globals.Lock() while up()'ing/down()'ing a Volume

### DIFF
--- a/headhunter/config.go
+++ b/headhunter/config.go
@@ -485,13 +485,12 @@ func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string)
 		return
 	}
 	volume.served = true
+	globals.Unlock()
 	err = volume.up(confMap)
 	if nil != err {
-		globals.Unlock()
 		err = fmt.Errorf("headhunter.ServeVolume() failed to \"up\" Volume (%s): %v", volumeName, err)
 		return
 	}
-	globals.Unlock()
 	err = nil
 	return
 }
@@ -509,14 +508,13 @@ func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName strin
 		err = fmt.Errorf("headhunter.UnserveVolume() called for Volume (%s) not being served", volumeName)
 		return
 	}
+	volume.served = false
+	globals.Unlock()
 	err = volume.down(confMap)
 	if nil != err {
-		globals.Unlock()
 		err = fmt.Errorf("headhunter.UnserveVolume() failed to \"down\" Volume (%s): %v", volumeName, err)
 		return
 	}
-	volume.served = false
-	globals.Unlock()
 	err = nil
 	return
 }


### PR DESCRIPTION
This was causing a deadlock particularly in the down()'ing case.
Here, a final checkpoint is requested. If we then wait for the
checkpoint to complete - while holding the globals.Lock(), it is
possible for a prior checkpoint, having been completed, to attempt
to grab the globals.Lock() [to update some stats] and block. It
will then, therefore, never get back to the point where it reads
this final checkpoint request and, hence, never complete it.