### PR TITLE
Unicode listings

### DIFF
--- a/pfs_middleware/pfs_middleware/middleware.py
+++ b/pfs_middleware/pfs_middleware/middleware.py
@@ -913,9 +913,9 @@ class PfsMiddleware(object):
     def _plaintext_account_get_response(self, account_entries):
         chunks = []
         for entry in account_entries:
-            chunks.append(entry["Basename"])
-            chunks.append("\n")
-        return ''.join(chunks)
+            chunks.append(entry["Basename"].encode('utf-8'))
+            chunks.append(b"\n")
+        return b''.join(chunks)
 
     def _json_account_get_response(self, account_entries):
         json_entries = []
@@ -1211,9 +1211,9 @@ class PfsMiddleware(object):
     def _plaintext_container_get_response(self, container_entries):
         chunks = []
         for ent in container_entries:
-            chunks.append(ent["Basename"])
-            chunks.append("\n")
-        return ''.join(chunks)
+            chunks.append(ent["Basename"].encode('utf-8'))
+            chunks.append(b"\n")
+        return b''.join(chunks)
 
     def _json_container_get_response(self, container_entries, account_name,
                                      delimiter):
@@ -1286,7 +1286,7 @@ class PfsMiddleware(object):
             container_node.append(bytes_node)
 
             ct_node = ET.Element('content_type')
-            ct_node.text = content_type
+            ct_node.text = content_type.decode('utf-8')
             container_node.append(ct_node)
 
             lm_node = ET.Element('last_modified')

--- a/pfs_middleware/tests/test_pfs_middleware.py
+++ b/pfs_middleware/tests/test_pfs_middleware.py
@@ -1662,15 +1662,15 @@ class TestContainerGet(BaseMiddlewareTest):
                         "NumWrites": 0,
                         "Metadata": "",
                     }, {
-                        "Basename": "images/avocado.png",
+                        "Basename": u"images/\xE1vocado.png",
                         "FileSize": 70,
                         "ModificationTime": 1471915816859209471,
                         "IsDir": False,
                         "InodeNumber": 9213768,
                         "NumWrites": 2,
                         "Metadata": base64.b64encode(json.dumps({
-                            "Content-Type": "snack/millenial" +
-                                            ";swift_bytes=3503770"})),
+                            "Content-Type": u"snack/m\xEDllenial" +
+                                            u";swift_bytes=3503770"})),
                     }, {
                         "Basename": "images/banana.png",
                         "FileSize": 2189865,
@@ -1722,12 +1722,12 @@ class TestContainerGet(BaseMiddlewareTest):
 
         self.assertEqual(status, '200 OK')
         self.assertEqual(headers["Content-Type"], "text/plain; charset=utf-8")
-        self.assertEqual(body, ("images\n"
-                                "images/avocado.png\n"
-                                "images/banana.png\n"
-                                "images/cherimoya.png\n"
-                                "images/durian.png\n"
-                                "images/elderberry.png\n"))
+        self.assertEqual(body, (b"images\n"
+                                b"images/\xC3\xA1vocado.png\n"
+                                b"images/banana.png\n"
+                                b"images/cherimoya.png\n"
+                                b"images/durian.png\n"
+                                b"images/elderberry.png\n"))
         self.assertEqual(self.fake_rpc.calls[1][1][0]['VirtPath'],
                          '/v1/AUTH_test/a-container')
 
@@ -1825,9 +1825,9 @@ class TestContainerGet(BaseMiddlewareTest):
             "hash": "d41d8cd98f00b204e9800998ecf8427e",
             "last_modified": "2016-08-23T01:30:16.359210"})
         self.assertEqual(resp_data[1], {
-            "name": "images/avocado.png",
+            "name": u"images/\xE1vocado.png",
             "bytes": 3503770,
-            "content_type": "snack/millenial",
+            "content_type": u"snack/m\xEDllenial",
             "hash": mware.construct_etag(
                 "AUTH_test", 9213768, 2),
             "last_modified": "2016-08-23T01:30:16.859210"})
@@ -1880,9 +1880,9 @@ class TestContainerGet(BaseMiddlewareTest):
         self.assertEqual(resp_data[1], {
             "subdir": "images/"})
         self.assertEqual(resp_data[2], {
-            "name": "images/avocado.png",
+            "name": u"images/\xE1vocado.png",
             "bytes": 3503770,
-            "content_type": "snack/millenial",
+            "content_type": u"snack/m\xEDllenial",
             "hash": mware.construct_etag(
                 "AUTH_test", 9213768, 2),
             "last_modified": "2016-08-23T01:30:16.859210"})
@@ -1957,7 +1957,7 @@ class TestContainerGet(BaseMiddlewareTest):
 
         name_node = obj_attr_tags[0]
         self.assertEqual(name_node.tag, 'name')
-        self.assertEqual(name_node.text, 'images/avocado.png')
+        self.assertEqual(name_node.text, u'images/\xE1vocado.png')
         self.assertEqual(name_node.attrib, {})  # nothing extra in there
 
         hash_node = obj_attr_tags[1]
@@ -1973,7 +1973,7 @@ class TestContainerGet(BaseMiddlewareTest):
 
         content_type_node = obj_attr_tags[3]
         self.assertEqual(content_type_node.tag, 'content_type')
-        self.assertEqual(content_type_node.text, 'snack/millenial')
+        self.assertEqual(content_type_node.text, u'snack/m\xEDllenial')
         self.assertEqual(content_type_node.attrib, {})
 
         last_modified_node = obj_attr_tags[4]
@@ -2001,7 +2001,7 @@ class TestContainerGet(BaseMiddlewareTest):
         # Check the names are correct
         all_names = [tag.getchildren()[0].text for tag in objects]
         self.assertEqual(
-            ["images", "images/avocado.png", "images/banana.png",
+            ["images", u"images/\xE1vocado.png", "images/banana.png",
              "images/cherimoya.png", "images/durian.png",
              "images/elderberry.png"],
             all_names)


### PR DESCRIPTION
Building on #261, add some Unicode tests and check that we don't complain about how `WSGI responses must be bytes`. This may be moot (the `listing_formats` change landed before we started enforcing bytes in responses), but it still seems like a good thing to do.