### PR TITLE
Extend trackedlock checking to jrpcfs and ramswift.

### DIFF
--- a/jrpcfs/config.go
+++ b/jrpcfs/config.go
@@ -9,13 +9,14 @@ import (
 	"github.com/swiftstack/ProxyFS/conf"
 	"github.com/swiftstack/ProxyFS/fs"
 	"github.com/swiftstack/ProxyFS/logger"
+	"github.com/swiftstack/ProxyFS/trackedlock"
 	"github.com/swiftstack/ProxyFS/transitions"
 )
 
 type globalsStruct struct {
-	mapsLock sync.Mutex   // protects volumeMap/mountIDMap/lastMountID/bimodalMountMap
-	gate     sync.RWMutex // API Requests RLock()/RUnlock()
-	//                       confMap changes Lock()/Unlock()
+	mapsLock trackedlock.Mutex   // protects volumeMap/mountIDMap/lastMountID/bimodalMountMap
+	gate     trackedlock.RWMutex // API Requests RLock()/RUnlock()
+	//                              confMap changes Lock()/Unlock()
 
 	whoAmI          string
 	ipAddr          string
@@ -36,7 +37,7 @@ type globalsStruct struct {
 
 	// Connection list and listener list to close during shutdown:
 	halting     bool
-	connLock    sync.Mutex
+	connLock    trackedlock.Mutex
 	connections *list.List
 	connWG      sync.WaitGroup
 	listeners   []net.Listener

--- a/jrpcfs/io.go
+++ b/jrpcfs/io.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"sync"
 	"time"
 	"unsafe"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/swiftstack/ProxyFS/inode"
 	"github.com/swiftstack/ProxyFS/logger"
 	"github.com/swiftstack/ProxyFS/stats"
+	"github.com/swiftstack/ProxyFS/trackedlock"
 	"github.com/swiftstack/ProxyFS/utils"
 )
 
@@ -81,7 +81,7 @@ func ioServerDown() {
 
 var debugConcurrency = false
 
-var concWorkerLock sync.Mutex
+var concWorkerLock trackedlock.Mutex
 var numConcWorkers int = 0 // number of concurrent workers
 var hwmConcWorkers int = 0 // high water mark of concurrent workers
 

--- a/ramswift/ramswift/main.go
+++ b/ramswift/ramswift/main.go
@@ -16,6 +16,9 @@ func main() {
 
 	doneChan := make(chan bool, 1) // Must be buffered to avoid race
 
+	// indicate that ramswift is running in a separate process
+	ramswift.StandAloneMode = true
+
 	go ramswift.Daemon(os.Args[1], os.Args[2:], nil, doneChan, unix.SIGINT, unix.SIGTERM, unix.SIGHUP)
 
 	_ = <-doneChan

--- a/ramswift/saioramswift0.conf
+++ b/ramswift/saioramswift0.conf
@@ -5,3 +5,7 @@
 .include ./chaos_settings.conf
 
 .include ./swift_info.conf
+
+# Disable logging to /var/log/proxyfsd/proxyfsd.log  for unit tests
+[Logging]
+LogFilePath:


### PR DESCRIPTION
The jrpcfs package was missed in the original conversion of
sync.Mutex --> trackedlock.Mutex.  catch it now.

ramswift already uses trackedlock, but if it was invoked as a
standalone daemon (as jrpcclient tests do), then trackedlocks
cannot be enabled from a config file.  Fix that.  When ramswift
is embedded in another test, it was already possible to enable
lock tracking for that test.