### PR TITLE
Resolve 500 Errors on GetContainer Swift3 CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,21 @@ machine = $(shell uname -m)
 ifeq ($(uname),Linux)
     ifeq ($(machine),armv7l)
         all: version fmt pre-generate generate install test
+
+        minimal: pre-generate generate install
     else
         distro := $(shell python -c "import platform; print platform.linux_distribution()[0]")
 
         all: version fmt pre-generate generate install test python-test c-clean c-build c-install c-test
 
         all-deb-builder: version fmt pre-generate generate install c-clean c-build c-install-deb-builder
+
+        minimal: pre-generate generate install c-clean c-build c-install
     endif
 else
     all: version fmt pre-generate generate install test
+
+    minimal: pre-generate generate install
 endif
 
 .PHONY: all all-deb-builder bench c-build c-clean c-install c-install-deb-builder c-test clean cover fmt generate install pre-generate python-test test version

--- a/fs/api_internal.go
+++ b/fs/api_internal.go
@@ -1724,6 +1724,7 @@ func (mS *mountStruct) MiddlewareGetContainer(vContainerName string, maxEntries 
 	} else {
 		markerPath, markerPathDirInodeIndex, err = mS.canonicalizePathAndLocateLeafDirInode(vContainerName + "/" + marker)
 		if nil != err {
+			err = blunder.AddError(err, blunder.InvalidArgError)
 			return
 		}
 
@@ -1744,6 +1745,7 @@ func (mS *mountStruct) MiddlewareGetContainer(vContainerName string, maxEntries 
 	} else {
 		endmarkerPath, _, err = mS.canonicalizePathAndLocateLeafDirInode(vContainerName + "/" + endmarker)
 		if nil != err {
+			err = blunder.AddError(err, blunder.InvalidArgError)
 			return
 		}
 
@@ -1760,10 +1762,11 @@ func (mS *mountStruct) MiddlewareGetContainer(vContainerName string, maxEntries 
 
 	prefixPath, prefixPathDirInodeIndex, err = mS.canonicalizePathAndLocateLeafDirInode(vContainerName + "/" + prefix)
 	if nil != err {
+		err = blunder.AddError(err, blunder.InvalidArgError)
 		return
 	}
 	if prefixPathDirInodeIndex < 0 {
-		err = blunder.NewError(blunder.InvalidArgError, "MiddlewareGetContainer() only supports querying an existing Container")
+		err = blunder.NewError(blunder.NotFoundError, "MiddlewareGetContainer() only supports querying an existing Container")
 		return
 	}
 

--- a/fs/resolve_path.go
+++ b/fs/resolve_path.go
@@ -868,8 +868,6 @@ RestartAfterFollowingSymlink:
 		}
 	}
 
-	// Finally, return with values already set from above
-
 	return
 }
 

--- a/jrpcfs/middleware_test.go
+++ b/jrpcfs/middleware_test.go
@@ -943,8 +943,12 @@ func TestRpcGetContainerSymlink(t *testing.T) {
 	response := GetContainerReply{}
 	err := server.RpcGetContainer(&request, &response)
 
+	// Note: We are not supporting GetContainer *thru* a symlink
+	//       In other words, the Container itself cannot be a SymlinkInode
+	//       This aligns with GetAccount which will only return DirInode dir_entry's
+
 	assert.NotNil(err)
-	assert.Equal(fmt.Sprintf("errno: %d", blunder.InvalidArgError), err.Error())
+	assert.Equal(fmt.Sprintf("errno: %d", blunder.NotFoundError), err.Error())
 }
 
 func TestRpcGetAccount(t *testing.T) {

--- a/pfs_middleware/pfs_middleware/pfs_errno.py
+++ b/pfs_middleware/pfs_middleware/pfs_errno.py
@@ -27,6 +27,7 @@ errorcode = {
     17: "FileExistsError",
     20: "NotDirError",
     21: "IsDirError",
+    22: "InvalidArgError",
     31: "TooManyLinksError",
     39: "NotEmptyError",
 }


### PR DESCRIPTION
Also:
  Corrected error returned on GetContainer() of a symlink
  Update makefile to provide a handy "minimal" rule