### PR TITLE
Changed SnapShotPolicy to respond to SIGHUP

### DIFF
--- a/inode/cron.go
+++ b/inode/cron.go
@@ -64,7 +64,7 @@ func (vS *volumeStruct) loadSnapShotPolicy(confMap conf.ConfMap) (err error) {
 
 	snapShotPolicyName, err = confMap.FetchOptionValueString(volumeSectionName, "SnapShotPolicy")
 	if nil != err {
-		// For now, we will default to setting snapShotPolicy to nil and returning success
+		// Default to setting snapShotPolicy to nil and returning success
 		err = nil
 		return
 	}

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,6 +14,11 @@ other path and Inode-based APIs. This release addresses in a much more encompass
 way all the contentions that could arise within and amongst all of the path and
 Inode-based APIs.
 
+The SnapShotPolicy feature introduced in 1.8.0 was inadvertantly disabled in 1.9.5
+due to the conversion to the new transitions package mechanism introduction. As such,
+only explicitly created SnapShots would be created. This release restores the ability
+to schedule SnapShots via a per-Volume SnapShotPolicy.
+
 ### Notes:
 
 Lock tracking capabilities have been significantly enhanced that will provide


### PR DESCRIPTION
Previously, a change to a Volume's SnapShotPolicy specification would
only be picked up on a Volume newly served (including restart of course).
This change makes to interpretation of the SnapShotPolicy occur on SIGHUP
as well.

In addition, this change also halts the taking of SnapShots based on an
existing SnapShotPolicy during SIGHUP handling (that also occurs during
the shutdown sequence).