### PR TITLE
Upgraded mount mechanism to use cryptocraphically secure MountIDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ gobinsubdirs = \
 	pfs-crash \
 	pfs-stress \
 	pfs-swift-load \
+	pfsagentd \
 	pfsconfjson \
 	pfsconfjsonpacked \
 	pfsworkout \

--- a/cookbooks/proxyfs_swift/recipes/default.rb
+++ b/cookbooks/proxyfs_swift/recipes/default.rb
@@ -66,6 +66,7 @@ ruby_block "update_proxy_server_pipeline" do
       file.insert_line_if_no_match(/egg.pfs_middleware/, "use = egg:pfs_middleware#pfs")
       file.insert_line_if_no_match(/proxyfsd_host/, "proxyfsd_host = 127.0.0.1")
       file.insert_line_if_no_match(/proxyfsd_port/, "proxyfsd_port = 12345")
+      file.insert_line_if_no_match(/bypass_mode/, "bypass_mode = read-write")
       file.write_file
     end
   end

--- a/fs/api.go
+++ b/fs/api.go
@@ -148,8 +148,13 @@ type JobHandle interface {
 
 // Mount handle interface
 
-func Mount(volumeName string, mountOptions MountOptions) (mountHandle MountHandle, err error) {
-	mountHandle, err = mount(volumeName, mountOptions)
+func MountByAccountName(accountName string, mountOptions MountOptions) (mountHandle MountHandle, err error) {
+	mountHandle, err = mountByAccountName(accountName, mountOptions)
+	return
+}
+
+func MountByVolumeName(volumeName string, mountOptions MountOptions) (mountHandle MountHandle, err error) {
+	mountHandle, err = mountByVolumeName(volumeName, mountOptions)
 	return
 }
 

--- a/fs/setup_teardown_test.go
+++ b/fs/setup_teardown_test.go
@@ -145,7 +145,7 @@ func testSetup(t *testing.T, starvationMode bool) {
 		t.Fatalf("transitions.Up() failed: %v", err)
 	}
 
-	mountHandle, err = Mount("TestVolume", MountOptions(0))
+	mountHandle, err = MountByVolumeName("TestVolume", MountOptions(0))
 	if nil != err {
 		t.Fatalf("fs.Mount() failed: %v", err)
 	}

--- a/fsworkout/main.go
+++ b/fsworkout/main.go
@@ -193,9 +193,9 @@ func main() {
 
 	volumeName = volumeList[0]
 
-	mountHandle, err = fs.Mount(volumeName, fs.MountOptions(0))
+	mountHandle, err = fs.MountByVolumeName(volumeName, fs.MountOptions(0))
 	if nil != err {
-		fmt.Fprintf(os.Stderr, "fs.Mount(\"%value\",) failed: %v\n", volumeName, err)
+		fmt.Fprintf(os.Stderr, "fs.MountByVolumeName(\"%value\",) failed: %v\n", volumeName, err)
 		os.Exit(1)
 	}
 

--- a/fuse/config.go
+++ b/fuse/config.go
@@ -262,7 +262,7 @@ func performMount(volume *volumeStruct) (err error) {
 		return
 	}
 
-	mountHandle, err = fs.Mount(volume.volumeName, fs.MountOptions(0))
+	mountHandle, err = fs.MountByVolumeName(volume.volumeName, fs.MountOptions(0))
 	if nil != err {
 		return
 	}

--- a/httpserver/config.go
+++ b/httpserver/config.go
@@ -177,7 +177,7 @@ func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string)
 		scrubJobs:      sortedmap.NewLLRBTree(sortedmap.CompareUint64, nil),
 	}
 
-	volume.fsMountHandle, err = fs.Mount(volume.name, 0)
+	volume.fsMountHandle, err = fs.MountByVolumeName(volume.name, 0)
 	if nil != err {
 		return
 	}

--- a/inode/api.go
+++ b/inode/api.go
@@ -117,6 +117,12 @@ func AccountNameToVolumeName(accountName string) (volumeName string, ok bool) {
 	return
 }
 
+// VolumeNameToAccountName returns the corresponding accountName for the supplied volumeName (if any).
+func VolumeNameToAccountName(volumeName string) (accountName string, ok bool) {
+	accountName, ok = volumeNameToAccountName(volumeName)
+	return
+}
+
 // VolumeNameToActivePeerPrivateIPAddr returns the Peer IP Address serving the specified VolumeName.
 func VolumeNameToActivePeerPrivateIPAddr(volumeName string) (activePeerPrivateIPAddr string, ok bool) {
 	activePeerPrivateIPAddr, ok = volumeNameToActivePeerPrivateIPAddr(volumeName)

--- a/inode/inode.go
+++ b/inode/inode.go
@@ -838,6 +838,23 @@ func accountNameToVolumeName(accountName string) (volumeName string, ok bool) {
 	return
 }
 
+func volumeNameToAccountName(volumeName string) (accountName string, ok bool) {
+	var (
+		volume *volumeStruct
+	)
+
+	globals.Lock()
+
+	volume, ok = globals.volumeMap[volumeName]
+	if ok {
+		accountName = volume.accountName
+	}
+
+	globals.Unlock()
+
+	return
+}
+
 func volumeNameToActivePeerPrivateIPAddr(volumeName string) (activePeerPrivateIPAddr string, ok bool) {
 	var (
 		volume *volumeStruct

--- a/jrpcfs/config.go
+++ b/jrpcfs/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 type globalsStruct struct {
-	mapsLock sync.Mutex   // protects volumeMap/mountIDMap/lastMountID/bimodalMountMap
+	mapsLock sync.Mutex   // protects volumeMap/mountIDMap/bimodalMountMap
 	gate     sync.RWMutex // API Requests RLock()/RUnlock()
 	//                       confMap changes Lock()/Unlock()
 
@@ -28,8 +28,8 @@ type globalsStruct struct {
 
 	// Map used to store volumes by ID already mounted for bimodal support
 	// TODO: These never get purged !!!
-	mountIDMap  map[uint64]fs.MountHandle // key == mountID
-	lastMountID uint64
+	mountIDAsByteArrayMap map[MountIDAsByteArray]fs.MountHandle
+	mountIDAsStringMap    map[MountIDAsString]fs.MountHandle
 
 	// Map used to store volumes by name already mounted for bimodal support
 	bimodalMountMap map[string]fs.MountHandle // key == volumeName
@@ -51,8 +51,8 @@ func init() {
 
 func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	globals.volumeMap = make(map[string]bool)
-	globals.mountIDMap = make(map[uint64]fs.MountHandle)
-	globals.lastMountID = uint64(0) // The only invalid MountID
+	globals.mountIDAsByteArrayMap = make(map[MountIDAsByteArray]fs.MountHandle)
+	globals.mountIDAsStringMap = make(map[MountIDAsString]fs.MountHandle)
 	globals.bimodalMountMap = make(map[string]fs.MountHandle)
 
 	// Fetch IPAddr from config file
@@ -135,22 +135,35 @@ func (dummy *globalsStruct) ServeVolume(confMap conf.ConfMap, volumeName string)
 
 func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName string) (err error) {
 	var (
-		mountHandle        fs.MountHandle
-		mountID            uint64
-		removedMountID     uint64
-		removedMountIDList []uint64
+		mountHandle                    fs.MountHandle
+		mountIDAsByteArray             MountIDAsByteArray
+		mountIDAsString                MountIDAsString
+		toRemoveMountIDAsByteArrayList []MountIDAsByteArray
+		toRemoveMountIDAsStringList    []MountIDAsString
 	)
 
-	removedMountIDList = make([]uint64, 0, len(globals.mountIDMap))
+	toRemoveMountIDAsByteArrayList = make([]MountIDAsByteArray, 0, len(globals.mountIDAsByteArrayMap))
 
-	for mountID, mountHandle = range globals.mountIDMap {
+	for mountIDAsByteArray, mountHandle = range globals.mountIDAsByteArrayMap {
 		if mountHandle.VolumeName() == volumeName {
-			removedMountIDList = append(removedMountIDList, mountID)
+			toRemoveMountIDAsByteArrayList = append(toRemoveMountIDAsByteArrayList, mountIDAsByteArray)
 		}
 	}
 
-	for _, removedMountID = range removedMountIDList {
-		delete(globals.mountIDMap, removedMountID)
+	for _, mountIDAsByteArray = range toRemoveMountIDAsByteArrayList {
+		delete(globals.mountIDAsByteArrayMap, mountIDAsByteArray)
+	}
+
+	toRemoveMountIDAsStringList = make([]MountIDAsString, 0, len(globals.mountIDAsStringMap))
+
+	for mountIDAsString, mountHandle = range globals.mountIDAsStringMap {
+		if mountHandle.VolumeName() == volumeName {
+			toRemoveMountIDAsStringList = append(toRemoveMountIDAsStringList, mountIDAsString)
+		}
+	}
+
+	for _, mountIDAsString = range toRemoveMountIDAsStringList {
+		delete(globals.mountIDAsStringMap, mountIDAsString)
 	}
 
 	delete(globals.volumeMap, volumeName)
@@ -176,15 +189,19 @@ func (dummy *globalsStruct) SignaledFinish(confMap conf.ConfMap) (err error) {
 
 func (dummy *globalsStruct) Down(confMap conf.ConfMap) (err error) {
 	if 0 != len(globals.volumeMap) {
-		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.volumeMap")
+		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.volumeMap)")
 		return
 	}
-	if 0 != len(globals.mountIDMap) {
-		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.mountIDMap")
+	if 0 != len(globals.mountIDAsByteArrayMap) {
+		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.mountIDAsByteArrayMap)")
+		return
+	}
+	if 0 != len(globals.mountIDAsStringMap) {
+		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.mountIDAsStringMap)")
 		return
 	}
 	if 0 != len(globals.bimodalMountMap) {
-		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.bimodalMountMap")
+		err = fmt.Errorf("jrpcfs.Down() called with 0 != len(globals.bimodalMountMap)")
 		return
 	}
 

--- a/jrpcfs/filesystem.go
+++ b/jrpcfs/filesystem.go
@@ -3,6 +3,7 @@ package jrpcfs
 
 import (
 	"container/list"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/rpc"
@@ -198,23 +199,60 @@ var saveChannelSize int = 1000
 // Default values here are false
 var loggedOutOfStatsRoom map[OpType]bool = make(map[OpType]bool)
 
-func allocateMountID(mountHandle fs.MountHandle) (mountID uint64) {
+func allocateMountID(mountHandle fs.MountHandle) (mountIDAsByteArray MountIDAsByteArray, mountIDAsString MountIDAsString) {
+	var (
+		i             int
+		keepTrying    bool
+		randByteSlice []byte
+	)
+
 	globals.mapsLock.Lock()
-	globals.lastMountID++
-	mountID = globals.lastMountID
-	globals.mountIDMap[mountID] = mountHandle
+
+	keepTrying = true
+	for keepTrying {
+		randByteSlice = utils.FetchRandomByteSlice(len(mountIDAsByteArray))
+		for i = 0; i < len(mountIDAsByteArray); i++ {
+			if i != 0 {
+				keepTrying = false // At least one of the bytes is non-zero... so it's a valid MountID
+			}
+			mountIDAsByteArray[i] = randByteSlice[i]
+		}
+		if !keepTrying {
+			_, keepTrying = globals.mountIDAsByteArrayMap[mountIDAsByteArray]
+		}
+	}
+
+	mountIDAsString = MountIDAsString(base64.StdEncoding.EncodeToString(mountIDAsByteArray[:]))
+
+	globals.mountIDAsByteArrayMap[mountIDAsByteArray] = mountHandle
+	globals.mountIDAsStringMap[mountIDAsString] = mountHandle
+
 	globals.mapsLock.Unlock()
+
 	return
 }
 
-func lookupMountHandle(mountID uint64) (mountHandle fs.MountHandle, err error) {
+func lookupMountHandleByMountIDAsByteArray(mountIDAsByteArray MountIDAsByteArray) (mountHandle fs.MountHandle, err error) {
 	globals.mapsLock.Lock()
-	mountHandle, ok := globals.mountIDMap[mountID]
+	mountHandle, ok := globals.mountIDAsByteArrayMap[mountIDAsByteArray]
 	globals.mapsLock.Unlock()
 	if ok {
 		err = nil
 	} else {
-		err = fmt.Errorf("MountID %v not found in jrpcfs globals.mountIDMap", mountID)
+		err = fmt.Errorf("MountID %v not found in jrpcfs globals.mountIDMap", mountIDAsByteArray)
+		err = blunder.AddError(err, blunder.BadMountIDError)
+	}
+	return
+}
+
+func lookupMountHandleByMountIDAsString(mountIDAsString MountIDAsString) (mountHandle fs.MountHandle, err error) {
+	globals.mapsLock.Lock()
+	mountHandle, ok := globals.mountIDAsStringMap[mountIDAsString]
+	globals.mapsLock.Unlock()
+	if ok {
+		err = nil
+	} else {
+		err = fmt.Errorf("MountID %v not found in jrpcfs globals.mountIDMap", mountIDAsString)
 		err = blunder.AddError(err, blunder.BadMountIDError)
 	}
 	return
@@ -679,7 +717,7 @@ func (s *Server) RpcChown(in *ChownRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -706,7 +744,7 @@ func (s *Server) RpcChownPath(in *ChownPathRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -743,7 +781,7 @@ func (s *Server) RpcChmod(in *ChmodRequest, reply *Reply) (err error) {
 	// NOTE: We currently just store and return per-inode ownership info.
 	//       We do not check/enforce it; that is the caller's responsibility.
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -764,7 +802,7 @@ func (s *Server) RpcChmodPath(in *ChmodPathRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -796,7 +834,7 @@ func (s *Server) RpcCreate(in *CreateRequest, reply *InodeReply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -814,7 +852,7 @@ func (s *Server) RpcCreatePath(in *CreatePathRequest, reply *InodeReply) (err er
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -851,7 +889,7 @@ func (s *Server) RpcFlock(in *FlockRequest, reply *FlockReply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -908,7 +946,7 @@ func (s *Server) RpcFlush(in *FlushRequest, reply *Reply) (err error) {
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
 	profiler.AddEventNow("before fs.Flush()")
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil == err {
 		err = mountHandle.Flush(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(in.InodeNumber))
 	}
@@ -953,7 +991,7 @@ func (s *Server) RpcGetStat(in *GetStatRequest, reply *StatStruct) (err error) {
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
 	profiler.AddEventNow("before fs.Getstat()")
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil == err {
 		stat, err = mountHandle.Getstat(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(in.InodeNumber))
 	}
@@ -979,7 +1017,7 @@ func (s *Server) RpcGetStatPath(in *GetStatPathRequest, reply *StatStruct) (err 
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1021,7 +1059,7 @@ func (s *Server) RpcGetXAttr(in *GetXAttrRequest, reply *GetXAttrReply) (err err
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
 	profiler.AddEventNow("before fs.GetXAttr()")
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil == err {
 		reply.AttrValue, err = mountHandle.GetXAttr(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(in.InodeNumber), in.AttrName)
 	}
@@ -1044,7 +1082,7 @@ func (s *Server) RpcGetXAttrPath(in *GetXAttrPathRequest, reply *GetXAttrReply) 
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1091,7 +1129,7 @@ func (s *Server) RpcLookupPath(in *LookupPathRequest, reply *InodeReply) (err er
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1118,7 +1156,7 @@ func (s *Server) RpcLink(in *LinkRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1135,7 +1173,7 @@ func (s *Server) RpcLinkPath(in *LinkPathRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1168,7 +1206,7 @@ func (s *Server) RpcListXAttr(in *ListXAttrRequest, reply *ListXAttrReply) (err 
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1185,7 +1223,7 @@ func (s *Server) RpcListXAttrPath(in *ListXAttrPathRequest, reply *ListXAttrRepl
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1213,7 +1251,7 @@ func (s *Server) RpcLookup(in *LookupRequest, reply *InodeReply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1242,7 +1280,7 @@ func (s *Server) RpcMkdir(in *MkdirRequest, reply *InodeReply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1260,7 +1298,7 @@ func (s *Server) RpcMkdirPath(in *MkdirPathRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1288,7 +1326,7 @@ func (s *Server) RpcMkdirPath(in *MkdirPathRequest, reply *Reply) (err error) {
 	return
 }
 
-func (s *Server) RpcMount(in *MountRequest, reply *MountReply) (err error) {
+func (s *Server) RpcMountByAccountName(in *MountByAccountNameRequest, reply *MountByAccountNameReply) (err error) {
 	enterGate()
 	defer leaveGate()
 
@@ -1296,56 +1334,27 @@ func (s *Server) RpcMount(in *MountRequest, reply *MountReply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := fs.Mount(in.VolumeName, fs.MountOptions(in.MountOptions))
+	mountHandle, err := fs.MountByAccountName(in.AccountName, fs.MountOptions(in.MountOptions))
 	if err == nil {
-		reply.MountID = allocateMountID(mountHandle)
+		_, reply.MountID = allocateMountID(mountHandle)
 		reply.RootDirInodeNumber = int64(uint64(inode.RootDirInodeNumber))
 	}
 	return
 }
 
-func (s *Server) RpcRead(in *ReadRequest, reply *ReadReply) (err error) {
+func (s *Server) RpcMountByVolumeName(in *MountByVolumeNameRequest, reply *MountByVolumeNameReply) (err error) {
 	enterGate()
 	defer leaveGate()
 
-	sendTime := time.Unix(in.SendTimeSec, in.SendTimeNsec)
-	requestRecTime := time.Now()
-	deliveryLatency := requestRecTime.Sub(sendTime)
-	deliveryLatencyUsec := deliveryLatency.Nanoseconds() / int64(time.Microsecond)
-	var flog logger.FuncCtx
-
-	if globals.dataPathLogging {
-		// log function enter and exit, without printing read buffer
-		flog = logger.TraceEnter("in.", in, "deliveryLatencyUsec:"+strconv.FormatInt(deliveryLatencyUsec, 10))
-	}
-
-	stopwatch := utils.NewStopwatch()
-	defer func() {
-		_ = stopwatch.Stop()
-		if globals.dataPathLogging {
-			flog.TraceExitErr("reply.", err,
-				"Buf.size:"+strconv.Itoa(len(reply.Buf))+", Buf.<buffer not printed>",
-				"reply.SendTimeSec:"+strconv.FormatInt(reply.SendTimeSec, 10),
-				"reply.SendTimeNsec:"+strconv.FormatInt(reply.SendTimeNsec, 10),
-				"reply.RequestTimeSec:"+strconv.FormatInt(reply.RequestTimeSec, 10),
-				"reply.RequestTimeNsec:"+strconv.FormatInt(reply.RequestTimeNsec, 10),
-				"duration:"+stopwatch.ElapsedMsString(),
-			)
-		}
-	}()
+	flog := logger.TraceEnter("in.", in)
+	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
-	if nil == err {
-		reply.Buf, err = mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(in.InodeNumber), in.Offset, in.Length, nil)
+	mountHandle, err := fs.MountByVolumeName(in.VolumeName, fs.MountOptions(in.MountOptions))
+	if err == nil {
+		_, reply.MountID = allocateMountID(mountHandle)
+		reply.RootDirInodeNumber = int64(uint64(inode.RootDirInodeNumber))
 	}
-
-	reply.RequestTimeSec = UnixSec(requestRecTime)
-	reply.RequestTimeNsec = UnixNanosec(requestRecTime)
-
-	replySendTime := time.Now()
-	reply.SendTimeSec = UnixSec(replySendTime)
-	reply.SendTimeNsec = UnixNanosec(replySendTime)
 	return
 }
 
@@ -1408,7 +1417,7 @@ func (s *Server) rpcReaddirInternal(in interface{}, reply *ReaddirReply, profile
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err = lookupMountHandle(iH.MountID)
+	mountHandle, err = lookupMountHandleByMountIDAsString(iH.MountID)
 	if nil != err {
 		return
 	}
@@ -1480,7 +1489,7 @@ func (s *Server) rpcReaddirPlusInternal(in interface{}, reply *ReaddirPlusReply,
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err = lookupMountHandle(iH.MountID)
+	mountHandle, err = lookupMountHandleByMountIDAsString(iH.MountID)
 	if err != nil {
 		return
 	}
@@ -1509,7 +1518,7 @@ func (s *Server) RpcReadSymlink(in *ReadSymlinkRequest, reply *ReadSymlinkReply)
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1527,7 +1536,7 @@ func (s *Server) RpcReadSymlinkPath(in *ReadSymlinkPathRequest, reply *ReadSymli
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1551,7 +1560,7 @@ func (s *Server) RpcRemovetXAttr(in *RemoveXAttrRequest, reply *Reply) (err erro
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1568,7 +1577,7 @@ func (s *Server) RpcRemoveAttrPath(in *RemoveXAttrPathRequest, reply *Reply) (er
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1590,7 +1599,7 @@ func (s *Server) RpcRename(in *RenameRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1607,7 +1616,7 @@ func (s *Server) RpcRenamePath(in *RenamePathRequest, reply *Reply) (err error) 
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1643,7 +1652,7 @@ func (s *Server) RpcResize(in *ResizeRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1660,7 +1669,7 @@ func (s *Server) RpcRmdir(in *UnlinkRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1677,7 +1686,7 @@ func (s *Server) RpcRmdirPath(in *UnlinkPathRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1704,7 +1713,7 @@ func (s *Server) RpcSetstat(in *SetstatRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1729,7 +1738,7 @@ func (s *Server) RpcSetTime(in *SetTimeRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1749,7 +1758,7 @@ func (s *Server) RpcSetTimePath(in *SetTimePathRequest, reply *Reply) (err error
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1775,7 +1784,7 @@ func (s *Server) RpcSetXAttr(in *SetXAttrRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1792,7 +1801,7 @@ func (s *Server) RpcSetXAttrPath(in *SetXAttrPathRequest, reply *Reply) (err err
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1814,7 +1823,7 @@ func (s *Server) RpcStatVFS(in *StatVFSRequest, reply *StatVFS) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1848,7 +1857,7 @@ func (s *Server) RpcSymlink(in *SymlinkRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1865,7 +1874,7 @@ func (s *Server) RpcSymlinkPath(in *SymlinkPathRequest, reply *Reply) (err error
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1891,7 +1900,7 @@ func (s *Server) RpcType(in *TypeRequest, reply *TypeReply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1910,7 +1919,7 @@ func (s *Server) RpcUnlink(in *UnlinkRequest, reply *Reply) (err error) {
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1927,7 +1936,7 @@ func (s *Server) RpcUnlinkPath(in *UnlinkPathRequest, reply *Reply) (err error) 
 	defer func() { flog.TraceExitErr("reply.", err, reply) }()
 	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
 
-	mountHandle, err := lookupMountHandle(in.MountID)
+	mountHandle, err := lookupMountHandleByMountIDAsString(in.MountID)
 	if nil != err {
 		return
 	}
@@ -1943,55 +1952,5 @@ func (s *Server) RpcUnlinkPath(in *UnlinkPathRequest, reply *Reply) (err error) 
 
 	// Do the unlink
 	err = mountHandle.Unlink(inode.InodeRootUserID, inode.InodeGroupID(0), nil, ino, basename)
-	return
-}
-
-func (s *Server) RpcWrite(in *WriteRequest, reply *WriteReply) (err error) {
-	var size uint64
-
-	enterGate()
-	defer leaveGate()
-
-	sendTime := time.Unix(in.SendTimeSec, in.SendTimeNsec)
-	requestRecTime := time.Now()
-	deliveryLatency := requestRecTime.Sub(sendTime)
-	deliveryLatencyUsec := deliveryLatency.Nanoseconds() / int64(time.Microsecond)
-	var flog logger.FuncCtx
-
-	if globals.dataPathLogging {
-
-		// log function enter and exit, without printing write buffer
-		flog = logger.TraceEnter("in.", in.InodeHandle,
-			"in.Offset:"+strconv.FormatUint(in.Offset, 10),
-			"in.Buf.size:"+strconv.Itoa(len(in.Buf)),
-			"in.SendTimeSec:"+strconv.FormatInt(in.SendTimeSec, 10),
-			"in.SendTimeNsec:"+strconv.FormatInt(in.SendTimeNsec, 10),
-			"in.ReceiveTimeSec:"+strconv.FormatInt(UnixSec(requestRecTime), 10),
-			"in.RecTimeNs:"+strconv.FormatInt(UnixNanosec(requestRecTime), 10),
-			"deliveryLatencyUsec:"+strconv.FormatInt(deliveryLatencyUsec, 10),
-		)
-	}
-
-	stopwatch := utils.NewStopwatch()
-	defer func() {
-		_ = stopwatch.Stop()
-		if globals.dataPathLogging {
-			flog.TraceExitErr("reply.", err, reply, "duration:"+stopwatch.ElapsedMsString())
-		}
-	}()
-	defer func() { rpcEncodeError(&err) }() // Encode error for return by RPC
-
-	mountHandle, err := lookupMountHandle(in.MountID)
-	if nil == err {
-		size, err = mountHandle.Write(inode.InodeRootUserID, inode.InodeGroupID(0), nil, inode.InodeNumber(in.InodeNumber), in.Offset, in.Buf, nil)
-		reply.Size = uint64(size)
-	}
-
-	reply.RequestTimeSec = UnixSec(requestRecTime)
-	reply.RequestTimeNsec = UnixNanosec(requestRecTime)
-
-	replySendTime := time.Now()
-	reply.SendTimeSec = UnixSec(replySendTime)
-	reply.SendTimeNsec = UnixNanosec(replySendTime)
 	return
 }

--- a/jrpcfs/middleware.go
+++ b/jrpcfs/middleware.go
@@ -50,7 +50,7 @@ func mountIfNotMounted(virtPath string) (accountName string, containerName strin
 
 	// We have not already mounted it, mount it now and store result in bimodalMountMap
 	// TODO - add proper mountOpts
-	mountHandle, err = fs.Mount(volumeName, fs.MountOptions(0))
+	mountHandle, err = fs.MountByVolumeName(volumeName, fs.MountOptions(0))
 	if err != nil {
 		logger.DebugfIDWithError(internalDebug, err, "fs.Mount() of acct: %v container: %v failed!", accountName, containerName)
 		return accountName, containerName, objectName, volumeName, nil, err

--- a/jrpcfs/middleware_test.go
+++ b/jrpcfs/middleware_test.go
@@ -263,7 +263,7 @@ func middlewarePutLocation(t *testing.T, server *Server, newPutPath string, expe
 func makeSomeFilesAndSuch() {
 	// we should have enough stuff up now that we can actually make
 	// some files and directories and such
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -368,7 +368,7 @@ func makeSomeFilesAndSuch() {
 	fsCreateFile(mountHandle, abcInode, "d-2")
 
 	// SomeVolume2 is set up for testing account listings
-	mountHandle2, err := fs.Mount("SomeVolume2", fs.MountOptions(0))
+	mountHandle2, err := fs.MountByVolumeName("SomeVolume2", fs.MountOptions(0))
 	_ = fsMkDir(mountHandle2, inode.RootDirInodeNumber, "alpha")
 	_ = fsMkDir(mountHandle2, inode.RootDirInodeNumber, "bravo")
 	_ = fsMkDir(mountHandle2, inode.RootDirInodeNumber, "charlie")
@@ -1109,7 +1109,7 @@ func TestRpcDeleteSymlinks(t *testing.T) {
 	// d1/crackle
 	// d1/pop
 	// d1-symlink -> d1
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -1295,7 +1295,7 @@ func testPutObjectSetup(t *testing.T) (*assert.Assertions, *Server, string, fs.M
 	// almost certainly okay.)
 	containerName := fmt.Sprintf("mware-TestPutObject-%d", time.Now().UnixNano())
 
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -1692,7 +1692,7 @@ func TestRpcGetObjectMetadata(t *testing.T) {
 	// We're not actually going to test any read plans here; that is tested elsewhere.
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -1735,7 +1735,7 @@ func TestRpcGetObjectSymlinkFollowing(t *testing.T) {
 	// We're not actually going to test any read plans here; that is tested elsewhere.
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -1891,7 +1891,7 @@ func TestRpcGetObjectSymlinkFollowing(t *testing.T) {
 func TestRpcPutContainer(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	_, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	_, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -1953,7 +1953,7 @@ func TestRpcPutContainer(t *testing.T) {
 func TestRpcPutContainerTooLong(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	_, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	_, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -1975,7 +1975,7 @@ func TestRpcPutContainerTooLong(t *testing.T) {
 func TestRpcMiddlewareMkdir(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -2019,7 +2019,7 @@ func TestRpcMiddlewareMkdir(t *testing.T) {
 func TestRpcMiddlewareMkdirNested(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -2052,7 +2052,7 @@ func TestRpcMiddlewareMkdirNested(t *testing.T) {
 func TestRpcCoalesce(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -2121,7 +2121,7 @@ func TestRpcCoalesce(t *testing.T) {
 func TestRpcCoalesceOverwrite(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -2180,7 +2180,7 @@ func TestRpcCoalesceOverwrite(t *testing.T) {
 func TestRpcCoalesceOverwriteDir(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -2223,7 +2223,7 @@ func TestRpcCoalesceOverwriteDir(t *testing.T) {
 func TestRpcCoalesceMakesDirs(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -2273,7 +2273,7 @@ func TestRpcCoalesceMakesDirs(t *testing.T) {
 func TestRpcCoalesceSymlinks(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -2325,7 +2325,7 @@ func TestRpcCoalesceSymlinks(t *testing.T) {
 func TestRpcCoalesceBrokenSymlink(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}
@@ -2374,7 +2374,7 @@ func TestRpcCoalesceBrokenSymlink(t *testing.T) {
 func TestRpcCoalesceSubdirOfAFile(t *testing.T) {
 	server := &Server{}
 	assert := assert.New(t)
-	mountHandle, err := fs.Mount("SomeVolume", fs.MountOptions(0))
+	mountHandle, err := fs.MountByVolumeName("SomeVolume", fs.MountOptions(0))
 	if nil != err {
 		panic(fmt.Sprintf("failed to mount SomeVolume: %v", err))
 	}

--- a/pfsagentd/.gitignore
+++ b/pfsagentd/.gitignore
@@ -1,0 +1,2 @@
+CHOMountPoint
+debug

--- a/pfsagentd/Makefile
+++ b/pfsagentd/Makefile
@@ -1,0 +1,3 @@
+gosubdir := github.com/swiftstack/ProxyFS/pfsagentd
+
+include ../GoMakefile

--- a/pfsagentd/dummy_test.go
+++ b/pfsagentd/dummy_test.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+}

--- a/pfsagentd/fuse.go
+++ b/pfsagentd/fuse.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"reflect"
+	"syscall"
+	"time"
+
+	"bazil.org/fuse"
+
+	"github.com/swiftstack/ProxyFS/utils"
+)
+
+const (
+	maxUnmountRetryCount uint32 = 100
+	unmountRetryGap             = 100 * time.Millisecond
+)
+
+func performMount() {
+	var (
+		curRetryCount                 uint32
+		err                           error
+		lazyUnmountCmd                *exec.Cmd
+		mountPointContainingDirDevice int64
+		mountPointDevice              int64
+	)
+
+	err = fuse.Unmount(globals.config.FUSEMountPointPath)
+	if nil != err {
+		logTracef("pre-fuse.Unmount() in performMount() returned: %v", err)
+	}
+
+	mountPointContainingDirDevice = fetchInodeDevice("path.Dir([Agent]FUSEMountPointPath", path.Dir(globals.config.FUSEMountPointPath))
+	mountPointDevice = fetchInodeDevice("[Agent]FUSEMountPointPath", globals.config.FUSEMountPointPath)
+
+	if mountPointDevice != mountPointContainingDirDevice {
+		// Presumably, the mount point is (still) currently mounted, so attempt to unmount it first
+
+		lazyUnmountCmd = exec.Command("fusermount", "-uz", globals.config.FUSEMountPointPath)
+		err = lazyUnmountCmd.Run()
+		if nil != err {
+			logFatal(err)
+		}
+
+		curRetryCount = 0
+
+		for mountPointDevice != mountPointContainingDirDevice {
+			time.Sleep(unmountRetryGap) // Try again in a bit
+			curRetryCount++
+			if curRetryCount >= maxUnmountRetryCount {
+				logFatalf("mountPointDevice != mountPointContainingDirDevice MaxRetryCount exceeded")
+			}
+			mountPointDevice = fetchInodeDevice("[Agent]FUSEMountPointPath", globals.config.FUSEMountPointPath)
+		}
+	}
+
+	globals.fuseConn, err = fuse.Mount(
+		globals.config.FUSEMountPointPath,
+		fuse.AllowOther(),
+		fuse.AsyncRead(),
+		fuse.DefaultPermissions(), // so handleAccessRequest() should not be called
+		fuse.ExclCreate(),
+		fuse.FSName(globals.config.FUSEVolumeName),
+		fuse.NoAppleDouble(),
+		fuse.NoAppleXattr(),
+		fuse.ReadOnly(),
+		fuse.Subtype("ProxyFS"),
+		fuse.VolumeName(globals.config.FUSEVolumeName),
+	)
+	if nil != err {
+		logFatal(err)
+	}
+
+	<-globals.fuseConn.Ready
+	if nil != globals.fuseConn.MountError {
+		logFatal(globals.fuseConn.MountError)
+	}
+
+	logInfof("%s mounted", globals.config.FUSEMountPointPath)
+
+	go serveFuse()
+}
+
+func fetchInodeDevice(pathTitle string, path string) (inodeDevice int64) {
+	var (
+		err  error
+		fi   os.FileInfo
+		ok   bool
+		stat *syscall.Stat_t
+	)
+
+	fi, err = os.Stat(path)
+	if nil != err {
+		if os.IsNotExist(err) {
+			logFatalf("%s path (%s) not found", pathTitle, path)
+		} else {
+			logFatalf("%s path (%s) os.Stat() failed: %v", pathTitle, path, err)
+		}
+	}
+	if nil == fi.Sys() {
+		logFatalf("%s path (%s) had empty os.Stat()", pathTitle, path)
+	}
+	stat, ok = fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		logFatalf("%s path (%s) fi.Sys().(*syscall.Stat_t) returned !ok", pathTitle, path)
+	}
+
+	inodeDevice = int64(stat.Dev)
+
+	return
+}
+
+func performUnmount() {
+	var (
+		err error
+	)
+
+	err = fuse.Unmount(globals.config.FUSEMountPointPath)
+	if nil != err {
+		logFatal(err)
+	}
+
+	logInfof("%s unmounted", globals.config.FUSEMountPointPath)
+}
+
+func serveFuse() {
+	var (
+		err     error
+		request fuse.Request
+	)
+
+	for {
+		// Fetch next *fuse.Request... exiting on fuseConn error
+
+		request, err = globals.fuseConn.ReadRequest()
+		if nil != err {
+			if io.EOF == err {
+				logTracef("exiting serveFuse() due to io.EOF")
+				return
+			}
+			logErrorf("serveFuse() exiting due to err: %v", err)
+			return
+		}
+		logTracef("serveFuse() got %v", reflect.ValueOf(request).Type())
+		switch request.(type) {
+		case *fuse.AccessRequest:
+			handleAccessRequest(request.(*fuse.AccessRequest))
+		case *fuse.CreateRequest:
+			handleCreateRequest(request.(*fuse.CreateRequest))
+		case *fuse.DestroyRequest:
+			handleDestroyRequest(request.(*fuse.DestroyRequest))
+		case *fuse.ExchangeDataRequest:
+			handleExchangeDataRequest(request.(*fuse.ExchangeDataRequest))
+		case *fuse.FlushRequest:
+			handleFlushRequest(request.(*fuse.FlushRequest))
+		case *fuse.ForgetRequest:
+			handleForgetRequest(request.(*fuse.ForgetRequest))
+		case *fuse.FsyncRequest:
+			handleFsyncRequest(request.(*fuse.FsyncRequest))
+		case *fuse.GetattrRequest:
+			handleGetattrRequest(request.(*fuse.GetattrRequest))
+		case *fuse.GetxattrRequest:
+			handleGetxattrRequest(request.(*fuse.GetxattrRequest))
+		case *fuse.InitRequest:
+			handleInitRequest(request.(*fuse.InitRequest))
+		case *fuse.InterruptRequest:
+			handleInterruptRequest(request.(*fuse.InterruptRequest))
+		case *fuse.LinkRequest:
+			handleLinkRequest(request.(*fuse.LinkRequest))
+		case *fuse.ListxattrRequest:
+			handleListxattrRequest(request.(*fuse.ListxattrRequest))
+		case *fuse.LookupRequest:
+			handleLookupRequest(request.(*fuse.LookupRequest))
+		case *fuse.MkdirRequest:
+			handleMkdirRequest(request.(*fuse.MkdirRequest))
+		case *fuse.MknodRequest:
+			handleMknodRequest(request.(*fuse.MknodRequest))
+		case *fuse.OpenRequest:
+			handleOpenRequest(request.(*fuse.OpenRequest))
+		case *fuse.ReadRequest:
+			handleReadRequest(request.(*fuse.ReadRequest))
+		case *fuse.ReadlinkRequest:
+			handleReadlinkRequest(request.(*fuse.ReadlinkRequest))
+		case *fuse.ReleaseRequest:
+			handleReleaseRequest(request.(*fuse.ReleaseRequest))
+		case *fuse.RemoveRequest:
+			handleRemoveRequest(request.(*fuse.RemoveRequest))
+		case *fuse.RemovexattrRequest:
+			handleRemovexattrRequest(request.(*fuse.RemovexattrRequest))
+		case *fuse.RenameRequest:
+			handleRenameRequest(request.(*fuse.RenameRequest))
+		case *fuse.SetattrRequest:
+			handleSetattrRequest(request.(*fuse.SetattrRequest))
+		case *fuse.SetxattrRequest:
+			handleSetxattrRequest(request.(*fuse.SetxattrRequest))
+		case *fuse.StatfsRequest:
+			handleStatfsRequest(request.(*fuse.StatfsRequest))
+		case *fuse.SymlinkRequest:
+			handleSymlinkRequest(request.(*fuse.SymlinkRequest))
+		case *fuse.WriteRequest:
+			handleWriteRequest(request.(*fuse.WriteRequest))
+		default:
+			logWarnf("recieved unserviced %v", reflect.ValueOf(request).Type())
+			request.RespondError(fuse.ENOTSUP)
+		}
+	}
+}
+
+func handleAccessRequest(request *fuse.AccessRequest) {
+	logFatalf("handleAccessRequest() should not have been called due to DefaultPermissions() passed to fuse.Mount()")
+}
+
+func handleCreateRequest(request *fuse.CreateRequest) {
+	logInfof("TODO: handleCreateRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleDestroyRequest(request *fuse.DestroyRequest) {
+	logInfof("TODO: handleDestroyRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleExchangeDataRequest(request *fuse.ExchangeDataRequest) {
+	logInfof("TODO: handleExchangeDataRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleFlushRequest(request *fuse.FlushRequest) {
+	logInfof("TODO: handleFlushRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleForgetRequest(request *fuse.ForgetRequest) {
+	logInfof("TODO: handleForgetRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleFsyncRequest(request *fuse.FsyncRequest) {
+	logInfof("TODO: handleFsyncRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleGetattrRequest(request *fuse.GetattrRequest) {
+	var (
+		response *fuse.GetattrResponse
+	)
+
+	logInfof("TODO: handleGetattrRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	if fuse.RootID == request.Header.Node {
+		response = &fuse.GetattrResponse{
+			Attr: fuse.Attr{
+				Valid:     time.Duration(10 * time.Second),
+				Inode:     uint64(request.Header.Node),
+				Size:      uint64(0),
+				Blocks:    uint64(0),
+				Atime:     time.Now(),
+				Mtime:     time.Now(),
+				Ctime:     time.Now(),
+				Crtime:    time.Now(),
+				Mode:      os.ModeDir | syscall.S_IRWXU | syscall.S_IRWXG | syscall.S_IRWXO,
+				Nlink:     uint32(2),
+				Uid:       uint32(0),
+				Gid:       uint32(0),
+				Rdev:      uint32(0),
+				Flags:     uint32(0),
+				BlockSize: uint32(4096),
+			},
+		}
+		logInfof("resonding with:\n%s", utils.JSONify(response, true))
+		request.Respond(response)
+	} else {
+		logInfof("Responding with fuse.ENOTSUP")
+		request.RespondError(fuse.ENOTSUP)
+	}
+}
+
+func handleGetxattrRequest(request *fuse.GetxattrRequest) {
+	logInfof("TODO: handleGetxattrRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleInitRequest(request *fuse.InitRequest) {
+	logFatalf("handleInitRequest() should not have been called... fuse.Mount() supposedly took care of it")
+}
+
+func handleInterruptRequest(request *fuse.InterruptRequest) {
+	logInfof("TODO: handleInterruptRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleLinkRequest(request *fuse.LinkRequest) {
+	logInfof("TODO: handleLinkRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleListxattrRequest(request *fuse.ListxattrRequest) {
+	logInfof("TODO: handleListxattrRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleLookupRequest(request *fuse.LookupRequest) {
+	logInfof("TODO: handleLookupRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleMkdirRequest(request *fuse.MkdirRequest) {
+	logInfof("TODO: handleMkdirRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleMknodRequest(request *fuse.MknodRequest) {
+	logInfof("TODO: handleMknodRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleOpenRequest(request *fuse.OpenRequest) {
+	logInfof("TODO: handleOpenRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleReadRequest(request *fuse.ReadRequest) {
+	logInfof("TODO: handleReadRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleReadlinkRequest(request *fuse.ReadlinkRequest) {
+	logInfof("TODO: handleReadlinkRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleReleaseRequest(request *fuse.ReleaseRequest) {
+	logInfof("TODO: handleReleaseRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleRemoveRequest(request *fuse.RemoveRequest) {
+	logInfof("TODO: handleRemoveRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleRemovexattrRequest(request *fuse.RemovexattrRequest) {
+	logInfof("TODO: handleRemovexattrRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleRenameRequest(request *fuse.RenameRequest) {
+	logInfof("TODO: handleRenameRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleSetattrRequest(request *fuse.SetattrRequest) {
+	logInfof("TODO: handleSetattrRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleSetxattrRequest(request *fuse.SetxattrRequest) {
+	logInfof("TODO: handleSetxattrRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleStatfsRequest(request *fuse.StatfsRequest) {
+	var (
+		response *fuse.StatfsResponse
+	)
+
+	logInfof("TODO: handleStatfsRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	response = &fuse.StatfsResponse{
+		Blocks:  uint64(2 * 1024 * 1024 * 1024),
+		Bfree:   uint64(1024 * 1024 * 1024),
+		Bavail:  uint64(1024 * 1024 * 1024),
+		Files:   uint64(2 * 1024 * 1024),
+		Ffree:   uint64(1024 * 1024),
+		Bsize:   uint32(4096),
+		Namelen: uint32(4096),
+		Frsize:  uint32(4096),
+	}
+	logInfof("resonding with:\n%s", utils.JSONify(response, true))
+	request.Respond(response)
+}
+
+func handleSymlinkRequest(request *fuse.SymlinkRequest) {
+	logInfof("TODO: handleSymlinkRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}
+
+func handleWriteRequest(request *fuse.WriteRequest) {
+	logInfof("TODO: handleWriteRequest()")
+	logInfof("Header:\n%s", utils.JSONify(request.Header, true))
+	logInfof("Payload\n%s", utils.JSONify(request, true))
+	logInfof("Responding with fuse.ENOTSUP")
+	request.RespondError(fuse.ENOTSUP)
+}

--- a/pfsagentd/log.go
+++ b/pfsagentd/log.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func logFatal(err error) {
+	logf("FATAL", "%v", err)
+	os.Exit(1)
+}
+
+func logFatalf(format string, args ...interface{}) {
+	logf("FATAL", format, args...)
+	os.Exit(1)
+}
+
+func logErrorf(format string, args ...interface{}) {
+	logf("ERROR", format, args...)
+}
+
+func logWarnf(format string, args ...interface{}) {
+	logf("WARN", format, args...)
+}
+
+func logInfof(format string, args ...interface{}) {
+	logf("INFO", format, args...)
+}
+
+func logTracef(format string, args ...interface{}) {
+	if globals.config.TraceEnabled {
+		logf("TRACE", format, args...)
+	}
+}
+
+func logf(level string, format string, args ...interface{}) {
+	var (
+		enhancedArgs   []interface{}
+		enhancedFormat string
+		err            error
+		logMsg         string
+	)
+
+	enhancedFormat = "%-32s %-5s " + format
+	enhancedArgs = append([]interface{}{time.Now().Format(time.RFC3339Nano), level}, args...)
+
+	logMsg = fmt.Sprintf(enhancedFormat, enhancedArgs[:]...)
+
+	if nil == globals.logFile {
+		if "" != globals.config.LogFilePath {
+			globals.logFile, err = os.OpenFile(globals.config.LogFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+			if nil == err {
+				globals.logFile.WriteString(logMsg + "\n")
+			} else {
+				globals.logFile = nil
+			}
+		}
+	} else {
+		globals.logFile.WriteString(logMsg + "\n")
+	}
+	if globals.config.LogToConsole {
+		fmt.Fprintln(os.Stderr, logMsg)
+	}
+}

--- a/pfsagentd/main.go
+++ b/pfsagentd/main.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"bazil.org/fuse"
+
+	"github.com/swiftstack/ProxyFS/conf"
+	"github.com/swiftstack/ProxyFS/utils"
+)
+
+type configStruct struct {
+	FUSEVolumeName          string
+	FUSEMountPointPath      string // Unless starting with '/', relative to $CWD
+	FUSEUnMountRetryDelay   time.Duration
+	FUSEUnMountRetryCap     uint64
+	SwiftAuthURL            string // If domain name is used, round-robin among all will be used
+	SwiftAuthUser           string
+	SwiftAuthKey            string
+	SwiftAccountName        string // Must be a bi-modal account
+	SwiftTimeout            time.Duration
+	SwiftRetryLimit         uint64
+	SwiftRetryDelay         time.Duration
+	SwiftRetryExpBackoff    float64
+	SwiftConnectionPoolSize uint64
+	ReadCacheLineSize       uint64 // Aligned chunk of a LogSegment
+	ReadCacheLineCount      uint64
+	ReadPlanLineSize        uint64 // ReadPlan covering an aligned chunk of File Data
+	ReadPlanLineCount       uint64
+	LogFilePath             string // Unless starting with '/', relative to $CWD; == "" means disabled
+	LogToConsole            bool
+	TraceEnabled            bool
+}
+
+type globalsStruct struct {
+	sync.Mutex
+	config             configStruct
+	logFile            *os.File // == nil if configStruct.LogFilePath == ""
+	httpClient         *http.Client
+	retryDelay         []time.Duration
+	swiftAuthWaitGroup *sync.WaitGroup
+	swiftAuthToken     string
+	swiftAccountURL    string // swiftStorageURL with AccountName forced to config.SwiftAccountName
+	fuseConn           *fuse.Conn
+}
+
+var globals globalsStruct
+
+func main() {
+	var (
+		signalChan chan os.Signal
+	)
+
+	initializeGlobals()
+
+	signalChan = make(chan os.Signal, 1)
+
+	signal.Notify(signalChan, unix.SIGHUP, unix.SIGINT, unix.SIGTERM)
+
+	performMount()
+
+	_ = <-signalChan // Await SIGHUP, SIGINT, or SIGTERM
+
+	performUnmount()
+}
+
+func initializeGlobals() {
+	var (
+		args             []string
+		confMap          conf.ConfMap
+		configJSONified  string
+		customTransport  *http.Transport
+		defaultTransport *http.Transport
+		err              error
+		nextRetryDelay   time.Duration
+		ok               bool
+		retryIndex       uint64
+	)
+
+	// Default logging related globals
+
+	globals.config.LogFilePath = ""
+	globals.config.LogToConsole = false
+	globals.logFile = nil
+
+	// Parse arguments
+
+	args = os.Args[1:]
+
+	// Read in the program's os.Arg[1]-specified (and required) .conf file
+	if 0 == len(args) {
+		logFatalf("no .conf file specified")
+	}
+
+	confMap, err = conf.MakeConfMapFromFile(args[0])
+	if nil != err {
+		logFatalf("failed to load config: %v", err)
+	}
+
+	// Update confMap with any extra os.Args supplied
+	err = confMap.UpdateFromStrings(args[1:])
+	if nil != err {
+		logFatalf("failed to load config overrides: %v", err)
+	}
+
+	// Process resultant confMap
+
+	globals.config.FUSEVolumeName, err = confMap.FetchOptionValueString("Agent", "FUSEVolumeName")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.FUSEMountPointPath, err = confMap.FetchOptionValueString("Agent", "FUSEMountPointPath")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.FUSEUnMountRetryDelay, err = confMap.FetchOptionValueDuration("Agent", "FUSEUnMountRetryDelay")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.FUSEUnMountRetryCap, err = confMap.FetchOptionValueUint64("Agent", "FUSEUnMountRetryCap")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftAuthURL, err = confMap.FetchOptionValueString("Agent", "SwiftAuthURL")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftAuthUser, err = confMap.FetchOptionValueString("Agent", "SwiftAuthUser")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftAuthKey, err = confMap.FetchOptionValueString("Agent", "SwiftAuthKey")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftAccountName, err = confMap.FetchOptionValueString("Agent", "SwiftAccountName")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftTimeout, err = confMap.FetchOptionValueDuration("Agent", "SwiftTimeout")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftRetryLimit, err = confMap.FetchOptionValueUint64("Agent", "SwiftRetryLimit")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftRetryDelay, err = confMap.FetchOptionValueDuration("Agent", "SwiftRetryDelay")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftRetryExpBackoff, err = confMap.FetchOptionValueFloat64("Agent", "SwiftRetryExpBackoff")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.SwiftConnectionPoolSize, err = confMap.FetchOptionValueUint64("Agent", "SwiftConnectionPoolSize")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.ReadCacheLineSize, err = confMap.FetchOptionValueUint64("Agent", "ReadCacheLineSize")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.ReadCacheLineCount, err = confMap.FetchOptionValueUint64("Agent", "ReadCacheLineCount")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.ReadPlanLineSize, err = confMap.FetchOptionValueUint64("Agent", "ReadPlanLineSize")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.ReadPlanLineCount, err = confMap.FetchOptionValueUint64("Agent", "ReadPlanLineCount")
+	if nil != err {
+		logFatal(err)
+	}
+
+	err = confMap.VerifyOptionValueIsEmpty("Agent", "LogFilePath")
+	if nil == err {
+		globals.config.LogFilePath = ""
+	} else {
+		globals.config.LogFilePath, err = confMap.FetchOptionValueString("Agent", "LogFilePath")
+		if nil != err {
+			logFatal(err)
+		}
+	}
+
+	globals.config.LogToConsole, err = confMap.FetchOptionValueBool("Agent", "LogToConsole")
+	if nil != err {
+		logFatal(err)
+	}
+
+	globals.config.TraceEnabled, err = confMap.FetchOptionValueBool("Agent", "TraceEnabled")
+	if nil != err {
+		logFatal(err)
+	}
+
+	configJSONified = utils.JSONify(globals.config, true)
+
+	logInfof("\n%s", configJSONified)
+
+	defaultTransport, ok = http.DefaultTransport.(*http.Transport)
+	if !ok {
+		log.Fatalf("http.DefaultTransport not a *http.Transport")
+	}
+
+	customTransport = &http.Transport{ // Up-to-date as of Golang 1.11
+		Proxy:                  defaultTransport.Proxy,
+		DialContext:            defaultTransport.DialContext,
+		Dial:                   defaultTransport.Dial,
+		DialTLS:                defaultTransport.DialTLS,
+		TLSClientConfig:        defaultTransport.TLSClientConfig,
+		TLSHandshakeTimeout:    defaultTransport.TLSHandshakeTimeout,
+		DisableKeepAlives:      false,
+		DisableCompression:     defaultTransport.DisableCompression,
+		MaxIdleConns:           int(globals.config.SwiftConnectionPoolSize),
+		MaxIdleConnsPerHost:    int(globals.config.SwiftConnectionPoolSize),
+		MaxConnsPerHost:        int(globals.config.SwiftConnectionPoolSize),
+		IdleConnTimeout:        defaultTransport.IdleConnTimeout,
+		ResponseHeaderTimeout:  defaultTransport.ResponseHeaderTimeout,
+		ExpectContinueTimeout:  defaultTransport.ExpectContinueTimeout,
+		TLSNextProto:           defaultTransport.TLSNextProto,
+		ProxyConnectHeader:     defaultTransport.ProxyConnectHeader,
+		MaxResponseHeaderBytes: defaultTransport.MaxResponseHeaderBytes,
+	}
+
+	globals.httpClient = &http.Client{
+		Transport: customTransport,
+		Timeout:   globals.config.SwiftTimeout,
+	}
+
+	globals.retryDelay = make([]time.Duration, globals.config.SwiftRetryLimit)
+
+	nextRetryDelay = globals.config.SwiftRetryDelay
+
+	for retryIndex = 0; retryIndex < globals.config.SwiftRetryLimit; retryIndex++ {
+		globals.retryDelay[retryIndex] = nextRetryDelay
+		nextRetryDelay = time.Duration(float64(nextRetryDelay) * globals.config.SwiftRetryExpBackoff)
+	}
+
+	globals.swiftAuthWaitGroup = nil
+	globals.swiftAuthToken = ""
+	globals.swiftAccountURL = ""
+
+	updateAuthTokenAndAccountURL()
+}

--- a/pfsagentd/pfsagent.conf
+++ b/pfsagentd/pfsagent.conf
@@ -1,0 +1,21 @@
+[Agent]
+FUSEVolumeName:                             CommonVolume
+FUSEMountPointPath:                     CommonMountPoint # Unless starting with '/', relative to $CWD
+FUSEUnMountRetryDelay:                             100ms
+FUSEUnMountRetryCap:                                 100
+SwiftAuthURL:            http://localhost:8080/auth/v1.0 # If domain name is used, round-robin among all will be used
+SwiftAuthUser:                               test:tester
+SwiftAuthKey:                                    testing
+SwiftAccountName:                              AUTH_test # Must be a bi-modal account
+SwiftTimeout:                                        10s
+SwiftRetryLimit:                                      10
+SwiftRetryDelay:                                      1s
+SwiftRetryExpBackoff:                                1.4
+SwiftConnectionPoolSize:                             100
+ReadCacheLineSize:                               1048576 # Aligned chunk of a LogSegment
+ReadCacheLineCount:                                 1000
+ReadPlanLineSize:                                1048576 # ReadPlan covering an aligned chunk of File Data
+ReadPlanLineCount:                                  1000
+LogFilePath:                                             # Unless starting with '/', relative to $CWD; Blank to disable
+LogToConsole:                                       true
+TraceEnabled:                                      false

--- a/pfsagentd/pfsagentcho.conf
+++ b/pfsagentd/pfsagentcho.conf
@@ -1,0 +1,21 @@
+[Agent]
+FUSEVolumeName:                                smb_share
+FUSEMountPointPath:                        CHOMountPoint # Unless starting with '/', relative to $CWD
+FUSEUnMountRetryDelay:                             100ms
+FUSEUnMountRetryCap:                                 100
+SwiftAuthURL:           http://192.168.201.186/auth/v1.0 # If domain name is used, round-robin among all will be used
+SwiftAuthUser:                                 smb_share
+SwiftAuthKey:                                  smb_share
+SwiftAccountName:                         AUTH_smb_share # Must be a bi-modal account
+SwiftTimeout:                                        10s
+SwiftRetryLimit:                                      10
+SwiftRetryDelay:                                      1s
+SwiftRetryExpBackoff:                                1.4
+SwiftConnectionPoolSize:                             100
+ReadCacheLineSize:                               1048576 # Aligned chunk of a LogSegment
+ReadCacheLineCount:                                 1000
+ReadPlanLineSize:                                1048576 # ReadPlan covering an aligned chunk of File Data
+ReadPlanLineCount:                                  1000
+LogFilePath:                                             # Unless starting with '/', relative to $CWD; Blank to disable
+LogToConsole:                                       true
+TraceEnabled:                                      false

--- a/pfsagentd/request.go
+++ b/pfsagentd/request.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+func doHTTPRequest(request *http.Request, okStatusCodes ...int) (response *http.Response, responseBody []byte, ok bool) {
+	var (
+		err              error
+		okStatusCode     int
+		okStatusCodesSet map[int]struct{}
+		retryIndex       uint64
+		swiftAuthToken   string
+	)
+
+	okStatusCodesSet = make(map[int]struct{})
+	for _, okStatusCode = range okStatusCodes {
+		okStatusCodesSet[okStatusCode] = struct{}{}
+	}
+
+	retryIndex = 0
+
+	for {
+		swiftAuthToken, _ = fetchAuthTokenAndAccountURL()
+
+		request.Header.Add("X-Auth-Token", swiftAuthToken)
+
+		response, err = globals.httpClient.Do(request)
+		if nil != err {
+			logErrorf("doHTTPRequest() failed to submit request: %v", err)
+			ok = false
+			return
+		}
+
+		responseBody, err = ioutil.ReadAll(response.Body)
+		response.Body.Close()
+		if nil != err {
+			logErrorf("doHTTPRequest() failed to read responseBody: %v", err)
+			ok = false
+			return
+		}
+
+		_, ok = okStatusCodesSet[response.StatusCode]
+		if ok {
+			return
+		}
+
+		if retryIndex >= globals.config.SwiftRetryLimit {
+			logWarnf("doHTTPRequest() reached SwiftRetryLimit")
+			ok = false
+			return
+		}
+
+		if http.StatusUnauthorized == response.StatusCode {
+			logInfof("doHTTPRequest() needs to call updateAuthTokenAndAccountURL()")
+			updateAuthTokenAndAccountURL()
+		} else {
+			logWarnf("doHTTPRequest() needs to retry due to unexpected http.Status %s (%d)", response.Status, response.StatusCode)
+		}
+
+		time.Sleep(globals.retryDelay[retryIndex])
+		retryIndex++
+	}
+}
+
+func fetchAuthTokenAndAccountURL() (swiftAuthToken string, swiftAccountURL string) {
+	var (
+		swiftAuthWaitGroup *sync.WaitGroup
+	)
+
+	for {
+		globals.Lock()
+
+		swiftAuthWaitGroup = globals.swiftAuthWaitGroup
+
+		if nil == swiftAuthWaitGroup {
+			swiftAuthToken = globals.swiftAuthToken
+			swiftAccountURL = globals.swiftAccountURL
+			globals.Unlock()
+			return
+		}
+
+		globals.Unlock()
+
+		swiftAuthWaitGroup.Wait()
+	}
+}
+
+func updateAuthTokenAndAccountURL() {
+	var (
+		err                         error
+		getRequest                  *http.Request
+		getResponse                 *http.Response
+		swiftAuthToken              string
+		swiftAccountURL             string
+		swiftStorageAccountURLSplit []string
+		swiftStorageURL             string
+	)
+
+	globals.Lock()
+
+	if nil != globals.swiftAuthWaitGroup {
+		globals.Unlock()
+
+		_, _ = fetchAuthTokenAndAccountURL()
+
+		return
+	}
+
+	globals.swiftAuthWaitGroup = &sync.WaitGroup{}
+	globals.swiftAuthWaitGroup.Add(1)
+
+	globals.Unlock()
+
+	getRequest, err = http.NewRequest("GET", globals.config.SwiftAuthURL, nil)
+	if nil != err {
+		logFatal(err)
+	}
+
+	getRequest.Header.Add("X-Auth-User", globals.config.SwiftAuthUser)
+	getRequest.Header.Add("X-Auth-Key", globals.config.SwiftAuthKey)
+
+	getResponse, err = globals.httpClient.Do(getRequest)
+	if nil != err {
+		logErrorf("updateAuthTokenAndAccountURL() failed to submit request: %v", err)
+		swiftAuthToken = ""
+		swiftAccountURL = ""
+	} else {
+		_, err = ioutil.ReadAll(getResponse.Body)
+		getResponse.Body.Close()
+		if nil != err {
+			logErrorf("updateAuthTokenAndAccountURL() failed to read responseBody: %v", err)
+			swiftAuthToken = ""
+			swiftAccountURL = ""
+		} else {
+			if http.StatusOK != getResponse.StatusCode {
+				logWarnf("updateAuthTokenAndAccountURL() got unexpected http.Status %s (%d)", getResponse.Status, getResponse.StatusCode)
+				swiftAuthToken = ""
+				swiftAccountURL = ""
+			} else {
+				swiftAuthToken = getResponse.Header.Get("X-Auth-Token")
+				swiftStorageURL = getResponse.Header.Get("X-Storage-Url")
+
+				swiftStorageAccountURLSplit = strings.Split(swiftStorageURL, "/")
+				if 0 == len(swiftStorageAccountURLSplit) {
+					swiftAccountURL = ""
+				} else {
+					swiftStorageAccountURLSplit[len(swiftStorageAccountURLSplit)-1] = globals.config.SwiftAccountName
+					swiftAccountURL = strings.Join(swiftStorageAccountURLSplit, "/")
+				}
+			}
+		}
+	}
+
+	globals.Lock()
+
+	globals.swiftAuthToken = swiftAuthToken
+	globals.swiftAccountURL = swiftAccountURL
+
+	globals.swiftAuthWaitGroup.Done()
+	globals.swiftAuthWaitGroup = nil
+
+	globals.Unlock()
+}

--- a/pfsworkout/main.go
+++ b/pfsworkout/main.go
@@ -393,7 +393,7 @@ func main() {
 
 			// If we are doing the operations on the same file for all threads, create the file now.
 			if doSameFile {
-				// Save off MountID and FileInodeNumber in rwSizeEach since all threads need this
+				// Save off MountHandle and FileInodeNumber in rwSizeEach since all threads need this
 				err, rwSizeEach.MountHandle, rwSizeEach.FileInodeNumber, fileName = createFsFile()
 				if nil != err {
 					// In an error, no point in continuing.  Just break from this for loop.
@@ -830,9 +830,9 @@ func fuseWorkout(rwSizeEach *rwSizeEachStruct, threadIndex uint64) {
 }
 
 func createFsFile() (err error, mountHandle fs.MountHandle, fileInodeNumber inode.InodeNumber, fileName string) {
-	mountHandle, err = fs.Mount(volumeName, fs.MountOptions(0))
+	mountHandle, err = fs.MountByVolumeName(volumeName, fs.MountOptions(0))
 	if nil != err {
-		stepErrChan <- fmt.Errorf("fs.Mount(\"%v\", fs.MountOptions(0), \"\") failed: %v\n", volumeName, err)
+		stepErrChan <- fmt.Errorf("fs.MountByVolumeName(\"%v\", fs.MountOptions(0), \"\") failed: %v\n", volumeName, err)
 		return
 	}
 

--- a/proxyfsd/daemon_test.go
+++ b/proxyfsd/daemon_test.go
@@ -188,9 +188,9 @@ func TestDaemon(t *testing.T) {
 
 	// Write to the volume (with no flush so that only time-based/restart flush is performed)
 
-	mountHandle, err = fs.Mount("CommonVolume", fs.MountOptions(0))
+	mountHandle, err = fs.MountByVolumeName("CommonVolume", fs.MountOptions(0))
 	if nil != err {
-		t.Fatalf("fs.Mount() failed [case 1]: %v", err)
+		t.Fatalf("fs.MountByVolumeName() failed [case 1]: %v", err)
 	}
 
 	createdFileInodeNumber, err = mountHandle.Create(
@@ -277,9 +277,9 @@ func TestDaemon(t *testing.T) {
 
 	// Verify written data after restart
 
-	mountHandle, err = fs.Mount("CommonVolume", fs.MountOptions(0))
+	mountHandle, err = fs.MountByVolumeName("CommonVolume", fs.MountOptions(0))
 	if nil != err {
-		t.Fatalf("fs.Mount() failed [case 2]: %v", err)
+		t.Fatalf("fs.MountByVolumeName() failed [case 2]: %v", err)
 	}
 
 	toReadFileInodeNumber, err = mountHandle.Lookup(

--- a/saio/etc/swift/proxy-server.conf
+++ b/saio/etc/swift/proxy-server.conf
@@ -72,10 +72,12 @@ use = egg:swift#slo
 [filter:dlo]
 use = egg:swift#dlo
 
+# For bypass_mode, one of off (default), read-only, or read-write
 [filter:pfs]
 use = egg:pfs_middleware#pfs
 proxyfsd_host = 127.0.0.1
 proxyfsd_port = 12345
+bypass_mode = read-write
 
 [filter:versioned_writes]
 use = egg:swift#versioned_writes

--- a/utils/api.go
+++ b/utils/api.go
@@ -711,19 +711,40 @@ func (p *Profiler) Dump() {
 
 func FetchRandomBool() (randBool bool) {
 	var (
-		err         error
-		randByteBuf []byte
+		randByteSlice []byte
 	)
 
-	randByteBuf = make([]byte, 1)
+	randByteSlice = FetchRandomByteSlice(1)
 
-	_, err = rand.Read(randByteBuf)
+	randBool = (randByteSlice[0] < 0x80)
+
+	return
+}
+
+func FetchRandomUint64() (randUint64 uint64) {
+	var (
+		randByteSlice []byte
+	)
+
+	randByteSlice = FetchRandomByteSlice(8)
+
+	randUint64 = binary.LittleEndian.Uint64(randByteSlice)
+
+	return
+}
+
+func FetchRandomByteSlice(len int) (randByteSlice []byte) {
+	var (
+		err error
+	)
+
+	randByteSlice = make([]byte, len)
+
+	_, err = rand.Read(randByteSlice)
 	if nil != err {
-		err = fmt.Errorf("rand.Read(randByteBuf) failed: %v", err)
+		err = fmt.Errorf("rand.Read(randByteSlice) failed: %v", err)
 		panic(err)
 	}
-
-	randBool = (randByteBuf[0] < 0x80)
 
 	return
 }
@@ -744,7 +765,7 @@ func PerformDelayAndComputeNextDelay(thisDelay time.Duration, nextDelayMin time.
 	if nil == err {
 		nextDelay = time.Duration(int64(nextDelayMin) + randomBigInt.Int64())
 	} else {
-		err = fmt.Errorf("utils.retryBackup() failed in call to rand.Int(): %v", err)
+		err = fmt.Errorf("utils.PerformDelayAndComputeNextDelay() failed in call to rand.Int(): %v", err)
 	}
 
 	return


### PR DESCRIPTION
This update includes:
  Utilizes new Base64-encoded MountIDs for non-Read/Write RPCs
  Utilizes Base64-decoded MountIDs for Read/Write (Fast) RPCs