### PR TITLE
Updated pfsagentd & saio to work with each other

### DIFF
--- a/pfsagentd/.gitignore
+++ b/pfsagentd/.gitignore
@@ -1,2 +1,1 @@
-CHOMountPoint
 debug

--- a/pfsagentd/fuse.go
+++ b/pfsagentd/fuse.go
@@ -74,14 +74,14 @@ func performMount() {
 		logFatal(err)
 	}
 
+	go serveFuse()
+
 	<-globals.fuseConn.Ready
 	if nil != globals.fuseConn.MountError {
 		logFatal(globals.fuseConn.MountError)
 	}
 
-	logInfof("%s mounted", globals.config.FUSEMountPointPath)
-
-	go serveFuse()
+	logInfof("Now serving %s on %s", globals.config.FUSEVolumeName, globals.config.FUSEMountPointPath)
 }
 
 func fetchInodeDevice(pathTitle string, path string) (inodeDevice int64) {

--- a/pfsagentd/pfsagentsaio.conf
+++ b/pfsagentd/pfsagentsaio.conf
@@ -1,12 +1,12 @@
 [Agent]
-FUSEVolumeName:                                smb_share
-FUSEMountPointPath:                        CHOMountPoint # Unless starting with '/', relative to $CWD
+FUSEVolumeName:                             CommonVolume
+FUSEMountPointPath:                     CommonMountPoint # Unless starting with '/', relative to $CWD
 FUSEUnMountRetryDelay:                             100ms
 FUSEUnMountRetryCap:                                 100
-SwiftAuthURL:           http://192.168.201.186/auth/v1.0 # If domain name is used, round-robin among all will be used
-SwiftAuthUser:                                 smb_share
-SwiftAuthKey:                                  smb_share
-SwiftAccountName:                         AUTH_smb_share # Must be a bi-modal account
+SwiftAuthURL:           http://localhost:28080/auth/v1.0 # If domain name is used, round-robin among all will be used
+SwiftAuthUser:                               test:tester
+SwiftAuthKey:                                    testing
+SwiftAccountName:                              AUTH_test # Must be a bi-modal account
 SwiftTimeout:                                        10s
 SwiftRetryLimit:                                      10
 SwiftRetryDelay:                                      1s

--- a/saio/Vagrantfile
+++ b/saio/Vagrantfile
@@ -24,6 +24,6 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder "../../../../../", "/vagrant", type: "virtualbox"
   config.vm.network "private_network", ip: "172.28.128.2", :name => 'vboxnet0', :adapter => 2
   config.vm.network "forwarded_port", guest: 15346, host: 25346
-  config.vm.network "forwarded_port", guest: 15432, host: 25432
+  config.vm.network "forwarded_port", guest: 8080, host: 28080
   config.vm.provision "shell", path: "vagrant_provision.sh"
 end

--- a/saio/vagrant_provision.sh
+++ b/saio/vagrant_provision.sh
@@ -42,7 +42,7 @@ yum clean all
 
 # Install tools needed above what's in a minimal base box
 
-yum -y install wget git nfs-utils vim
+yum -y install wget git nfs-utils vim lsof
 
 # Install Golang
 


### PR DESCRIPTION
Primarily, this change forwards the normal Swift Proxy's Port 8080
that it is listening on to Port 28080 on the host. The new .conf
file for saio in pfsagentd now targets this forwarded Port.

Also fixed an out-of-order FUSE mount sequence in pfsagentd.