### PR TITLE
Made some pinned packages not pinned

### DIFF
--- a/ci/ansible/check_pinned_packages
+++ b/ci/ansible/check_pinned_packages
@@ -14,7 +14,10 @@ with open(json_path, "r") as json_file:
 
 everything_ok = True
 for section, packages in versions_data.items():
-    for package, pinned_version in packages:
+    for package_info in packages:
+        if len(package_info) == 1:
+            continue
+        package, pinned_version = package_info
         yum_versions = subprocess.check_output(
             "repoquery {} --queryformat '%{{vr}}'".format(package), shell=True)
         yum_versions = yum_versions.strip().split("\n")

--- a/ci/ansible/chef_files/packages/rhel_ss.json
+++ b/ci/ansible/chef_files/packages/rhel_ss.json
@@ -17,21 +17,21 @@
     ["fuse", "2.9.3-5.el7"]
   ],
   "wireshark_packages": [
-    ["wireshark", "1.10.14-16.el7"],
-    ["libcap", "2.22-9.el7"]
+    ["wireshark"],
+    ["libcap"]
   ],
   "ssh_packages": [
-    ["sshpass", "1.06-2.el7"]
+    ["sshpass"]
   ],
   "nfs_packages": [
     ["nfs-utils", "1.3.0-0.61.el7"]
   ],
   "gdb_packages": [
     ["gdb", "7.6.1-114.el7"],
-    ["yum-utils", "1.1.31-50.el7"]
+    ["yum-utils"]
   ],
   "utils_packages": [
-    ["atop", "2.3.0-8.el7"],
-    ["vim-common", "7.4.160-5.el7"]
+    ["atop"],
+    ["vim-common"]
   ]
 }


### PR DESCRIPTION
They're just utilities for which we don't care what exact version is
installed.

Also changed the pinned packages checker to be able to understand the
versions JSON file when one or more packages are not pinned.