### PR TITLE
pfs_middleware: test under py3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ pre-generate:
 
 python-test:
 	cd meta_middleware && tox -e lint
-	cd pfs_middleware && tox -e py27,py27-old-swift,lint
+	cd pfs_middleware && tox -e py27-release,py27-minver,py36-release,lint
 
 test:
 	@set -e; \

--- a/pfs_middleware/pfs_middleware/rpc.py
+++ b/pfs_middleware/pfs_middleware/rpc.py
@@ -118,14 +118,14 @@ allow_read_write = {
 
 def _encode_binary(data):
     if data:
-        return base64.b64encode(data)
+        return base64.b64encode(data.encode('ascii')).decode('ascii')
     else:
         return ""
 
 
 def _decode_binary(bindata):
     if bindata:
-        return base64.b64decode(bindata)
+        return base64.b64decode(bindata).decode('ascii')
     else:
         # None (happens sometimes) or empty-string (also happens sometimes)
         return ""

--- a/pfs_middleware/pfs_middleware/swift_code.py
+++ b/pfs_middleware/pfs_middleware/swift_code.py
@@ -1061,3 +1061,18 @@ def clean_acls(req):
                 except ValueError as err:
                     return HTTPBadRequest(request=req, body=str(err))
     return None
+
+
+# Taken from swift/common/swob.py, commit a5a6a27
+#
+# Modified to pass through Nones
+def wsgi_to_str(wsgi_str):
+    if six.PY2 or wsgi_str is None:
+        return wsgi_str
+    return wsgi_str.encode('latin1').decode('utf8', errors='surrogateescape')
+
+
+def str_to_wsgi(native_str):
+    if six.PY2 or native_str is None:
+        return native_str
+    return native_str.encode('utf8', errors='surrogateescape').decode('latin1')

--- a/pfs_middleware/test-requirements.txt
+++ b/pfs_middleware/test-requirements.txt
@@ -1,2 +1,1 @@
-flake8
 mock

--- a/pfs_middleware/tests/helpers.py
+++ b/pfs_middleware/tests/helpers.py
@@ -67,7 +67,7 @@ class FakeProxy(object):
         if method in ('PUT', 'COALESCE'):
             bytes_read = 0
             # consume the whole request body, just like a PUT would
-            for chunk in iter(env['wsgi.input'].read, ''):
+            for chunk in iter(env['wsgi.input'].read, b''):
                 bytes_read += len(chunk)
             cl = req.headers.get('Content-Length')
 

--- a/pfs_middleware/tests/test_pfs_middleware.py
+++ b/pfs_middleware/tests/test_pfs_middleware.py
@@ -19,7 +19,7 @@ import hashlib
 import json
 import mock
 import unittest
-from StringIO import StringIO
+from io import BytesIO
 from swift.common import swob
 from xml.etree import ElementTree
 
@@ -46,6 +46,31 @@ class FakeLogger(object):
 
     def debug(fmt, *args):
         pass
+
+
+class TestHelpers(unittest.TestCase):
+    def test_deserialize_metadata(self):
+        self.assertEqual(mware.deserialize_metadata(None), {})
+        self.assertEqual(mware.deserialize_metadata(''), {})
+        self.assertEqual(mware.deserialize_metadata('{}'), {})
+        self.assertEqual(mware.deserialize_metadata('{"foo": "bar"}'),
+                         {"foo": "bar"})
+        self.assertEqual(mware.deserialize_metadata(
+            '{"unicode-\\u1234":"meta \\ud83c\\udf34"}'
+        ), {
+            # NB: WSGI strings
+            'unicode-\xe1\x88\xb4': 'meta \xf0\x9f\x8c\xb4',
+        })
+
+    def test_serialize_metadata(self):
+        self.assertEqual(mware.serialize_metadata({}), '{}')
+        self.assertEqual(
+            mware.serialize_metadata({
+                # NB: WSGI strings
+                'unicode-\xe1\x88\xb4': 'meta \xf0\x9f\x8c\xb4',
+            }),
+            # But it comes out as good Unicode
+            '{"unicode-\\u1234": "meta \\ud83c\\udf34"}')
 
 
 class BaseMiddlewareTest(unittest.TestCase):
@@ -148,7 +173,7 @@ class BaseMiddlewareTest(unittest.TestCase):
             headers[0] = swob.HeaderKeyDict(h)
 
         body_iter = app(req.environ, start_response)
-        body = ''
+        body = b''
         caught_exc = None
         try:
             try:
@@ -242,13 +267,13 @@ class TestAccountGet(BaseMiddlewareTest):
             "X-Bypass-ProxyFS": "true"}, environ={'swift_owner': True})
         status, _, body = self.call_pfs(req)
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, '000000000000DACA\n000000000000DACC\n')
+        self.assertEqual(body, b'000000000000DACA\n000000000000DACC\n')
 
         req = swob.Request.blank("/v1/AUTH_test", environ={
             'swift_owner': True})
         status, _, body = self.call_pfs(req)
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, 'chickens\ncows\ngoats\npigs\n')
+        self.assertEqual(body, b'chickens\ncows\ngoats\npigs\n')
 
         req = swob.Request.blank("/v1/AUTH_test", method='PUT', headers={
             "X-Bypass-ProxyFS": "true"}, environ={'swift_owner': True})
@@ -259,13 +284,13 @@ class TestAccountGet(BaseMiddlewareTest):
             "X-Bypass-ProxyFS": "true"})
         status, _, body = self.call_pfs(req)
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, 'chickens\ncows\ngoats\npigs\n')
+        self.assertEqual(body, b'chickens\ncows\ngoats\npigs\n')
 
     def test_text(self):
         req = swob.Request.blank("/v1/AUTH_test")
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, "chickens\ncows\ngoats\npigs\n")
+        self.assertEqual(body, b"chickens\ncows\ngoats\npigs\n")
 
     def test_json(self):
         self.maxDiff = None
@@ -302,18 +327,18 @@ class TestAccountGet(BaseMiddlewareTest):
         self.assertEqual(headers["Content-Type"],
                          "application/xml; charset=utf-8")
         self.assertTrue(body.startswith(
-            """<?xml version='1.0' encoding='utf-8'?>"""))
+            b"""<?xml version='1.0' encoding='utf-8'?>"""))
 
         root_node = ElementTree.fromstring(body)
         self.assertEqual(root_node.tag, 'account')
         self.assertEqual(root_node.attrib["name"], 'AUTH_test')
 
-        containers = root_node.getchildren()
+        containers = list(root_node)
         self.assertEqual(containers[0].tag, 'container')
 
         # The XML account listing doesn't use XML attributes for data, but
         # rather a sequence of tags like <name>X</name> <bytes>Y</bytes> ...
-        con_attr_tags = containers[0].getchildren()
+        con_attr_tags = list(containers[0])
         self.assertEqual(len(con_attr_tags), 4)
 
         name_node = con_attr_tags[0]
@@ -435,7 +460,7 @@ class TestAccountGet(BaseMiddlewareTest):
         req = swob.Request.blank("/v1/AUTH_test?marker=zzz")
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '204 No Content')
-        self.assertEqual(body, '')
+        self.assertEqual(body, b'')
 
     def test_spaces(self):
         self.bimodal_accounts.add('AUTH_test with spaces')
@@ -480,7 +505,7 @@ class TestAccountHead(BaseMiddlewareTest):
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '204 No Content')
         self.assertEqual(headers.get("ProxyFS-Enabled"), "yes")
-        self.assertEqual(body, '')
+        self.assertEqual(body, b'')
 
     def test_in_transit(self):
 
@@ -516,7 +541,7 @@ class TestObjectGet(BaseMiddlewareTest):
         req = swob.Request.blank('/info')
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, '{"stuff": "yes"}')
+        self.assertEqual(body, b'{"stuff": "yes"}')
 
     def test_non_bimodal_account(self):
         self.app.register(
@@ -527,7 +552,7 @@ class TestObjectGet(BaseMiddlewareTest):
         req = swob.Request.blank('/v1/AUTH_unimodal/c/o')
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, 'squirrel')
+        self.assertEqual(body, b'squirrel')
 
     def test_GET_basic(self):
         # ProxyFS log segments look a lot like actual file contents followed
@@ -572,7 +597,7 @@ class TestObjectGet(BaseMiddlewareTest):
                          "Wed, 07 Dec 2016 23:08:55 GMT")
         self.assertEqual(headers["ETag"],
                          mware.construct_etag("AUTH_test", 1245, 2424))
-        self.assertEqual(body, 'burritos')
+        self.assertEqual(body, b'burritos')
 
         req = swob.Request.blank('/v1/AUTH_test/notes/lunch?get-read-plan=on',
                                  environ={'swift_owner': True})
@@ -597,7 +622,7 @@ class TestObjectGet(BaseMiddlewareTest):
                                  environ={'swift_owner': True})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, 'burritos')
+        self.assertEqual(body, b'burritos')
 
         # Can handle Range requests, too
         def mock_RpcGetObject(get_object_req):
@@ -681,7 +706,7 @@ class TestObjectGet(BaseMiddlewareTest):
                             'X-Object-Sysmeta-Slo-Etag': 'some etag',
                             'X-Object-Sysmeta-Slo-Size': '0',
                             'Content-Type': 'text/plain;swift_bytes=0',
-                        })),
+                        }).encode('ascii')).decode('ascii'),
                     "InodeNumber": 1245,
                     "NumWrites": 2424,
                     "ModificationTime": 1481152134331862558,
@@ -711,7 +736,7 @@ class TestObjectGet(BaseMiddlewareTest):
             'X-Timestamp': '1481152134.33186',
             'Last-Modified': 'Wed, 07 Dec 2016 23:08:55 GMT',
         })
-        self.assertEqual(body, '[]')
+        self.assertEqual(body, b'[]')
 
     def test_GET_authed(self):
         self.app.register(
@@ -777,7 +802,7 @@ class TestObjectGet(BaseMiddlewareTest):
                          "Wed, 07 Dec 2016 23:08:55 GMT")
         self.assertEqual(headers["ETag"],
                          mware.construct_etag("AUTH_test", 1245, 2424))
-        self.assertEqual(body, 'burritos')
+        self.assertEqual(body, b'burritos')
 
     def test_GET_sparse(self):
         # This log segment, except for the obvious fake metadata at the end,
@@ -831,7 +856,7 @@ class TestObjectGet(BaseMiddlewareTest):
         status, headers, body = self.call_pfs(req)
 
         self.assertEqual(status, "200 OK")
-        self.assertEqual(body, "sparse" + ("\x00" * 10000) + "file")
+        self.assertEqual(body, b"sparse" + (b"\x00" * 10000) + b"file")
 
     def test_GET_multiple_segments(self):
         # Typically, a GET request will include data from multiple log
@@ -907,15 +932,15 @@ class TestObjectGet(BaseMiddlewareTest):
 
         self.assertEqual(status, '200 OK')
         self.assertEqual(body, (
-            "There once was an X from place B,\n"
-            "That satisfied predicate P.\n"
-            "He or she did thing A,\n"
-            "In an adjective way,\n"
-            "Resulting in circumstance C."))
+            b"There once was an X from place B,\n"
+            b"That satisfied predicate P.\n"
+            b"He or she did thing A,\n"
+            b"In an adjective way,\n"
+            b"Resulting in circumstance C."))
 
     def test_GET_conditional_if_match(self):
         obj_etag = "42d0f073592cdef8f602cda59fbb270e"
-        obj_body = "annet-pentahydric-nuculoid-defiber"
+        obj_body = b"annet-pentahydric-nuculoid-defiber"
 
         self.app.register(
             'GET', '/v1/AUTH_test/InternalContainerName/000000000097830c',
@@ -930,7 +955,7 @@ class TestObjectGet(BaseMiddlewareTest):
                     "Metadata": base64.b64encode(
                         json.dumps({
                             mware.ORIGINAL_MD5_HEADER: "123:%s" % obj_etag,
-                        })),
+                        }).encode('ascii')).decode('ascii'),
                     "InodeNumber": 1245,
                     "NumWrites": 123,
                     "ModificationTime": 1511222561631497000,
@@ -1015,7 +1040,7 @@ class TestObjectGet(BaseMiddlewareTest):
         self.assertEqual(status, '206 Partial Content')
         self.assertEqual(headers.get('Content-Range'), "bytes 21-69/94")
         self.assertEqual(
-            body, 'Cheshire, Duddleswell, Dunlop, Coquetdale, Derby')
+            body, b'Cheshire, Duddleswell, Dunlop, Coquetdale, Derby')
 
     def test_GET_range_suffix(self):
         self.app.register(
@@ -1057,7 +1082,7 @@ class TestObjectGet(BaseMiddlewareTest):
 
         self.assertEqual(status, '206 Partial Content')
         self.assertEqual(headers.get('Content-Range'), "bytes 84-93/94")
-        self.assertEqual(body, "nitrogen, ")
+        self.assertEqual(body, b"nitrogen, ")
 
     def test_GET_range_prefix(self):
         self.app.register(
@@ -1099,7 +1124,7 @@ class TestObjectGet(BaseMiddlewareTest):
 
         self.assertEqual(status, '206 Partial Content')
         self.assertEqual(headers.get('Content-Range'), "bytes 40-61/62")
-        self.assertEqual(body, "ron, carbon, nitrogen, ")
+        self.assertEqual(body, b"ron, carbon, nitrogen, ")
 
     def test_GET_range_unsatisfiable(self):
         self.app.register(
@@ -1201,22 +1226,22 @@ class TestObjectGet(BaseMiddlewareTest):
             'multipart/byteranges;boundary=f0a9157cb1757bfb124aef22fee31051')
         self.assertEqual(
             body,
-            ('--f0a9157cb1757bfb124aef22fee31051\r\n'
-             'Content-Type: application/octet-stream\r\n'
-             'Content-Range: bytes 2-4/16\r\n'
-             '\r\n'
-             'cd1\r\n'
-             '--f0a9157cb1757bfb124aef22fee31051\r\n'
-             'Content-Type: application/octet-stream\r\n'
-             'Content-Range: bytes 6-8/16\r\n'
-             '\r\n'
-             '34e\r\n'
-             '--f0a9157cb1757bfb124aef22fee31051\r\n'
-             'Content-Type: application/octet-stream\r\n'
-             'Content-Range: bytes 10-12/16\r\n'
-             '\r\n'
-             'gh5\r\n'
-             '--f0a9157cb1757bfb124aef22fee31051--'))
+            (b'--f0a9157cb1757bfb124aef22fee31051\r\n'
+             b'Content-Type: application/octet-stream\r\n'
+             b'Content-Range: bytes 2-4/16\r\n'
+             b'\r\n'
+             b'cd1\r\n'
+             b'--f0a9157cb1757bfb124aef22fee31051\r\n'
+             b'Content-Type: application/octet-stream\r\n'
+             b'Content-Range: bytes 6-8/16\r\n'
+             b'\r\n'
+             b'34e\r\n'
+             b'--f0a9157cb1757bfb124aef22fee31051\r\n'
+             b'Content-Type: application/octet-stream\r\n'
+             b'Content-Range: bytes 10-12/16\r\n'
+             b'\r\n'
+             b'gh5\r\n'
+             b'--f0a9157cb1757bfb124aef22fee31051--'))
 
     def test_GET_metadata(self):
         self.app.register(
@@ -1231,8 +1256,9 @@ class TestObjectGet(BaseMiddlewareTest):
                 "error": None,
                 "result": {
                     "FileSize": 16,
-                    "Metadata": base64.b64encode(
-                        json.dumps({"X-Object-Meta-Cow": "moo"})),
+                    "Metadata": base64.b64encode(json.dumps({
+                        "X-Object-Meta-Cow": "moo",
+                    }).encode('ascii')).decode('ascii'),
                     "InodeNumber": 1245,
                     "NumWrites": 2424,
                     "ModificationTime": 1481152134331862558,
@@ -1251,7 +1277,7 @@ class TestObjectGet(BaseMiddlewareTest):
 
         self.assertEqual(status, '200 OK')
         self.assertEqual(headers.get("X-Object-Meta-Cow"), "moo")
-        self.assertEqual(body, 'abcd1234efgh5678')
+        self.assertEqual(body, b'abcd1234efgh5678')
 
     def test_GET_bad_path(self):
         bad_paths = [
@@ -1398,7 +1424,7 @@ class TestObjectGet(BaseMiddlewareTest):
         status, headers, body = self.call_pfs(req)
 
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, 'abcd1234efgh5678')
+        self.assertEqual(body, b'abcd1234efgh5678')
         self.assertEqual(self.fake_rpc.calls[1][1][0]['VirtPath'],
                          '/v1/AUTH_test/c o n/o b j')
 
@@ -1414,7 +1440,7 @@ class TestObjectGet(BaseMiddlewareTest):
                     "Metadata": base64.b64encode(json.dumps({
                         mware.ORIGINAL_MD5_HEADER:
                         "3:25152b9f7ca24b61eec895be4e89a950",
-                    })),
+                    }).encode('ascii')).decode('ascii'),
                     "ModificationTime": 1506039770222591000,
                     "FileSize": 17,
                     "IsDir": False,
@@ -1465,7 +1491,7 @@ class TestObjectGet(BaseMiddlewareTest):
         status, headers, body = self.call_pfs(req)
 
         self.assertEqual(status, '200 OK')
-        self.assertEqual(body, 'some contents')
+        self.assertEqual(body, b'some contents')
 
         called_rpcs = [c[0] for c in self.fake_rpc.calls]
 
@@ -1495,7 +1521,7 @@ class TestContainerHead(BaseMiddlewareTest):
                 "error": None,
                 "result": {
                     "Metadata": base64.b64encode(
-                        self.serialized_container_metadata),
+                        self.serialized_container_metadata.encode('ascii')),
                     "ModificationTime": 1479240397189581131,
                     "FileSize": 0,
                     "IsDir": True,
@@ -1651,7 +1677,7 @@ class TestContainerGet(BaseMiddlewareTest):
                 "error": None,
                 "result": {
                     "Metadata": base64.b64encode(
-                        self.serialized_container_metadata),
+                        self.serialized_container_metadata.encode('ascii')),
                     "ModificationTime": 1510790796076041000,
                     "ContainerEntries": [{
                         "Basename": "images",
@@ -1670,7 +1696,8 @@ class TestContainerGet(BaseMiddlewareTest):
                         "NumWrites": 2,
                         "Metadata": base64.b64encode(json.dumps({
                             "Content-Type": u"snack/m\xEDllenial" +
-                                            u";swift_bytes=3503770"})),
+                                            u";swift_bytes=3503770",
+                        }).encode('ascii')),
                     }, {
                         "Basename": "images/banana.png",
                         "FileSize": 2189865,
@@ -1692,7 +1719,8 @@ class TestContainerGet(BaseMiddlewareTest):
                         # used.
                         "Metadata": base64.b64encode(json.dumps({
                             mware.ORIGINAL_MD5_HEADER:
-                            "1:552528fbf2366f8a4711ac0a3875188b"})),
+                            "1:552528fbf2366f8a4711ac0a3875188b",
+                        }).encode('ascii')),
                     }, {
                         "Basename": "images/durian.png",
                         "FileSize": 8414281,
@@ -1702,7 +1730,8 @@ class TestContainerGet(BaseMiddlewareTest):
                         "NumWrites": 3,
                         "Metadata": base64.b64encode(json.dumps({
                             mware.ORIGINAL_MD5_HEADER:
-                            "3:34f99f7784c573541e11e5ad66f065c8"})),
+                            "3:34f99f7784c573541e11e5ad66f065c8",
+                        }).encode('ascii')),
                     }, {
                         "Basename": "images/elderberry.png",
                         "FileSize": 3178293,
@@ -1937,13 +1966,13 @@ class TestContainerGet(BaseMiddlewareTest):
         self.assertEqual(headers["Content-Type"],
                          "text/xml; charset=utf-8")
         self.assertTrue(body.startswith(
-            """<?xml version='1.0' encoding='utf-8'?>"""))
+            b"""<?xml version='1.0' encoding='utf-8'?>"""))
 
         root_node = ElementTree.fromstring(body)
         self.assertEqual(root_node.tag, 'container')
         self.assertEqual(root_node.attrib["name"], 'a-container')
 
-        objects = root_node.getchildren()
+        objects = list(root_node)
         self.assertEqual(6, len(objects))
         self.assertEqual(objects[0].tag, 'object')
 
@@ -1952,7 +1981,7 @@ class TestContainerGet(BaseMiddlewareTest):
         #
         # We do an exhaustive check of one object's attributes, then
         # spot-check the rest of the listing for brevity's sake.
-        obj_attr_tags = objects[1].getchildren()
+        obj_attr_tags = list(objects[1])
         self.assertEqual(len(obj_attr_tags), 5)
 
         name_node = obj_attr_tags[0]
@@ -1982,7 +2011,7 @@ class TestContainerGet(BaseMiddlewareTest):
         self.assertEqual(last_modified_node.attrib, {})
 
         # Make sure the directory has the right type
-        obj_attr_tags = objects[0].getchildren()
+        obj_attr_tags = list(objects[0])
         self.assertEqual(len(obj_attr_tags), 5)
 
         name_node = obj_attr_tags[0]
@@ -1999,7 +2028,7 @@ class TestContainerGet(BaseMiddlewareTest):
         self.assertEqual(content_type_node.text, 'application/directory')
 
         # Check the names are correct
-        all_names = [tag.getchildren()[0].text for tag in objects]
+        all_names = [list(tag)[0].text for tag in objects]
         self.assertEqual(
             ["images", u"images/\xE1vocado.png", "images/banana.png",
              "images/cherimoya.png", "images/durian.png",
@@ -2015,7 +2044,7 @@ class TestContainerGet(BaseMiddlewareTest):
         self.assertEqual(headers["Content-Type"],
                          "application/xml; charset=utf-8")
         self.assertTrue(body.startswith(
-            """<?xml version='1.0' encoding='utf-8'?>"""))
+            b"""<?xml version='1.0' encoding='utf-8'?>"""))
 
     def test_xml_query_param(self):
         req = swob.Request.blank('/v1/AUTH_test/a-container?format=xml')
@@ -2025,7 +2054,7 @@ class TestContainerGet(BaseMiddlewareTest):
         self.assertEqual(headers["Content-Type"],
                          "application/xml; charset=utf-8")
         self.assertTrue(body.startswith(
-            """<?xml version='1.0' encoding='utf-8'?>"""))
+            b"""<?xml version='1.0' encoding='utf-8'?>"""))
 
     def test_xml_special_chars(self):
         req = swob.Request.blank('/v1/AUTH_test/c o n',
@@ -2036,7 +2065,7 @@ class TestContainerGet(BaseMiddlewareTest):
         self.assertEqual(headers["Content-Type"],
                          "text/xml; charset=utf-8")
         self.assertTrue(body.startswith(
-            """<?xml version='1.0' encoding='utf-8'?>"""))
+            b"""<?xml version='1.0' encoding='utf-8'?>"""))
 
         root_node = ElementTree.fromstring(body)
         self.assertEqual(root_node.tag, 'container')
@@ -2242,7 +2271,7 @@ class TestContainerGetDelimiter(BaseMiddlewareTest):
             "error": None,
             "result": {
                 "Metadata": base64.b64encode(
-                    self.serialized_container_metadata),
+                    self.serialized_container_metadata.encode('ascii')),
                 "ModificationTime": 1510790796076041000,
                 "ContainerEntries": [{
                     "Basename": "images",
@@ -2260,7 +2289,7 @@ class TestContainerGetDelimiter(BaseMiddlewareTest):
             "error": None,
             "result": {
                 "Metadata": base64.b64encode(
-                    self.serialized_container_metadata),
+                    self.serialized_container_metadata.encode('ascii')),
                 "ModificationTime": 1510790796076041000,
                 "ContainerEntries": [{
                     "Basename": "images/avocado.png",
@@ -2271,7 +2300,8 @@ class TestContainerGetDelimiter(BaseMiddlewareTest):
                     "NumWrites": 2,
                     "Metadata": base64.b64encode(json.dumps({
                         "Content-Type": "snack/millenial" +
-                                        ";swift_bytes=3503770"})),
+                                        ";swift_bytes=3503770",
+                    }).encode('ascii')),
                 }, {
                     "Basename": "images/banana.png",
                     "FileSize": 2189865,
@@ -2293,7 +2323,8 @@ class TestContainerGetDelimiter(BaseMiddlewareTest):
                     # used.
                     "Metadata": base64.b64encode(json.dumps({
                         mware.ORIGINAL_MD5_HEADER:
-                        "1:552528fbf2366f8a4711ac0a3875188b"})),
+                        "1:552528fbf2366f8a4711ac0a3875188b",
+                    }).encode('ascii')),
                 }, {
                     "Basename": "images/durian.png",
                     "FileSize": 8414281,
@@ -2303,7 +2334,8 @@ class TestContainerGetDelimiter(BaseMiddlewareTest):
                     "NumWrites": 3,
                     "Metadata": base64.b64encode(json.dumps({
                         mware.ORIGINAL_MD5_HEADER:
-                        "3:34f99f7784c573541e11e5ad66f065c8"})),
+                        "3:34f99f7784c573541e11e5ad66f065c8",
+                    }).encode('ascii')),
                 }, {
                     "Basename": "images/elderberry.png",
                     "FileSize": 3178293,
@@ -2426,7 +2458,8 @@ class TestContainerPost(BaseMiddlewareTest):
             return {
                 "error": None,
                 "result": {
-                    "Metadata": base64.b64encode(old_meta),
+                    "Metadata": base64.b64encode(
+                        old_meta.encode('ascii')).decode('ascii'),
                     "ModificationTime": 1482280565956671142,
                     "FileSize": 0,
                     "IsDir": True,
@@ -2462,7 +2495,8 @@ class TestContainerPost(BaseMiddlewareTest):
         method, args = rpc_calls[2]
         self.assertEqual(method, "Server.RpcPost")
         self.assertEqual(args[0]["VirtPath"], "/v1/AUTH_test/new-con")
-        self.assertEqual(base64.b64decode(args[0]["OldMetaData"]), old_meta)
+        self.assertEqual(
+            base64.b64decode(args[0]["OldMetaData"]).decode('ascii'), old_meta)
         new_meta = json.loads(base64.b64decode(args[0]["NewMetaData"]))
         self.assertEqual(new_meta["X-Container-Meta-One-Fish"], "two fish")
         self.assertEqual(new_meta["X-Container-Read"], "xcr")
@@ -2511,7 +2545,7 @@ class TestContainerPut(BaseMiddlewareTest):
         self.assertEqual(args[0]["VirtPath"], "/v1/AUTH_test/new-con")
         self.assertEqual(args[0]["OldMetadata"], "")
         self.assertEqual(
-            base64.b64decode(args[0]["NewMetadata"]),
+            base64.b64decode(args[0]["NewMetadata"]).decode('ascii'),
             json.dumps({"X-Container-Meta-Red-Fish": "blue fish"}))
 
     def test_PUT_bad_path(self):
@@ -2523,7 +2557,7 @@ class TestContainerPut(BaseMiddlewareTest):
         for path in bad_container_paths:
             req = swob.Request.blank(path,
                                      environ={"REQUEST_METHOD": "PUT",
-                                              "wsgi.input": StringIO(""),
+                                              "wsgi.input": BytesIO(b""),
                                               "CONTENT_LENGTH": "0"})
             status, headers, body = self.call_pfs(req)
             self.assertEqual(status, '400 Bad Request',
@@ -2604,7 +2638,8 @@ class TestContainerPut(BaseMiddlewareTest):
             return {
                 "error": None,
                 "result": {
-                    "Metadata": base64.b64encode(old_meta),
+                    "Metadata": base64.b64encode(
+                        old_meta.encode('ascii')).decode('ascii'),
                     "ModificationTime": 1482270529646747881,
                     "FileSize": 0,
                     "IsDir": True,
@@ -2637,7 +2672,8 @@ class TestContainerPut(BaseMiddlewareTest):
         method, args = rpc_calls[2]
         self.assertEqual(method, "Server.RpcPutContainer")
         self.assertEqual(args[0]["VirtPath"], "/v1/AUTH_test/new-con")
-        self.assertEqual(base64.b64decode(args[0]["OldMetadata"]), old_meta)
+        self.assertEqual(
+            base64.b64decode(args[0]["OldMetadata"]).decode('ascii'), old_meta)
         new_meta = json.loads(base64.b64decode(args[0]["NewMetadata"]))
         self.assertEqual(expected_meta, new_meta)
 
@@ -2693,7 +2729,8 @@ class TestContainerPut(BaseMiddlewareTest):
             return {
                 "error": None,
                 "result": {
-                    "Metadata": base64.b64encode(old_meta),
+                    "Metadata": base64.b64encode(
+                        old_meta.encode('ascii')).decode('ascii'),
                     "ModificationTime": 1511224700123739000,
                     "FileSize": 0,
                     "IsDir": True,
@@ -2714,7 +2751,8 @@ class TestContainerPut(BaseMiddlewareTest):
         method, args = rpc_calls[-1]
         self.assertEqual(method, "Server.RpcPutContainer")
         self.assertEqual(args[0]["VirtPath"], "/v1/AUTH_test/new-con")
-        self.assertEqual(base64.b64decode(args[0]["OldMetadata"]), old_meta)
+        self.assertEqual(
+            base64.b64decode(args[0]["OldMetadata"]).decode('ascii'), old_meta)
         new_meta = json.loads(base64.b64decode(args[0]["NewMetadata"]))
         self.assertEqual(expected_meta, new_meta)
 
@@ -2861,7 +2899,8 @@ class TestObjectPut(BaseMiddlewareTest):
             # Give a different sequence of physical paths for each object
             # name
             virt_path = put_location_req["VirtPath"]
-            obj_name = hashlib.sha1(virt_path).hexdigest().upper()
+            obj_name = hashlib.sha1(
+                virt_path.encode('utf8')).hexdigest().upper()
             phys_path = "/v1/AUTH_test/PhysContainer_1/" + obj_name
             if put_loc_count[virt_path] > 0:
                 phys_path += "-%02x" % put_loc_count[virt_path]
@@ -2899,7 +2938,7 @@ class TestObjectPut(BaseMiddlewareTest):
             "Server.RpcMiddlewareMkdir", mock_RpcMiddlewareMkdir)
 
     def test_basic(self):
-        wsgi_input = StringIO("sparkleberry-displeasurably")
+        wsgi_input = BytesIO(b"sparkleberry-displeasurably")
         cl = str(len(wsgi_input.getvalue()))
 
         req = swob.Request.blank("/v1/AUTH_test/a-container/an-object",
@@ -2972,7 +3011,7 @@ class TestObjectPut(BaseMiddlewareTest):
         self.fake_rpc.register_handler(
             "Server.RpcPutComplete", mock_RpcPutComplete)
 
-        wsgi_input = StringIO("Rhodothece-cholesterinuria")
+        wsgi_input = BytesIO(b"Rhodothece-cholesterinuria")
         cl = str(len(wsgi_input.getvalue()))
 
         req = swob.Request.blank("/v1/AUTH_test/a-container/an-object",
@@ -2985,7 +3024,7 @@ class TestObjectPut(BaseMiddlewareTest):
                          "Fri, 09 Dec 2016 19:20:46 GMT")
 
     def test_special_chars(self):
-        wsgi_input = StringIO("pancreas-mystagogically")
+        wsgi_input = BytesIO(b"pancreas-mystagogically")
         cl = str(len(wsgi_input.getvalue()))
 
         req = swob.Request.blank("/v1/AUTH_test/c o n/o b j",
@@ -3026,7 +3065,7 @@ class TestObjectPut(BaseMiddlewareTest):
         for path in bad_container_paths:
             req = swob.Request.blank(path,
                                      environ={"REQUEST_METHOD": "PUT",
-                                              "wsgi.input": StringIO(""),
+                                              "wsgi.input": BytesIO(b""),
                                               "CONTENT_LENGTH": "0"})
             status, headers, body = self.call_pfs(req)
             self.assertEqual(status, '404 Not Found',
@@ -3057,7 +3096,7 @@ class TestObjectPut(BaseMiddlewareTest):
         for path in bad_paths:
             req = swob.Request.blank(path,
                                      environ={"REQUEST_METHOD": "PUT",
-                                              "wsgi.input": StringIO(""),
+                                              "wsgi.input": BytesIO(b""),
                                               "CONTENT_LENGTH": "0"})
             status, headers, body = self.call_pfs(req)
             self.assertEqual(status, '400 Bad Request',
@@ -3074,7 +3113,7 @@ class TestObjectPut(BaseMiddlewareTest):
                              'Got %s for %s' % (status, path))
 
     def test_big(self):
-        wsgi_input = StringIO('A' * 100 + 'B' * 100 + 'C' * 75)
+        wsgi_input = BytesIO(b'A' * 100 + b'B' * 100 + b'C' * 75)
         self.pfs.max_log_segment_size = 100
 
         req = swob.Request.blank("/v1/AUTH_test/con/obj",
@@ -3143,7 +3182,7 @@ class TestObjectPut(BaseMiddlewareTest):
         self.assertNotIn("Content-Length", put_calls[2][2])  # 3rd PUT
 
     def test_big_exact_multiple(self):
-        wsgi_input = StringIO('A' * 100 + 'B' * 100)
+        wsgi_input = BytesIO(b'A' * 100 + b'B' * 100)
         cl = str(len(wsgi_input.getvalue()))
         self.pfs.max_log_segment_size = 100
 
@@ -3201,7 +3240,7 @@ class TestObjectPut(BaseMiddlewareTest):
         self.fake_rpc.register_handler(
             "Server.RpcHead", mock_RpcHead_not_found)
 
-        wsgi_input = StringIO("toxicum-brickcroft")
+        wsgi_input = BytesIO(b"toxicum-brickcroft")
 
         req = swob.Request.blank("/v1/AUTH_test/a-container/an-object",
                                  environ={"REQUEST_METHOD": "PUT",
@@ -3210,7 +3249,7 @@ class TestObjectPut(BaseMiddlewareTest):
         self.assertEqual(status, "404 Not Found")
 
     def test_metadata(self):
-        wsgi_input = StringIO("extranean-paleophysiology")
+        wsgi_input = BytesIO(b"extranean-paleophysiology")
         cl = str(len(wsgi_input.getvalue()))
 
         headers_in = {
@@ -3253,7 +3292,7 @@ class TestObjectPut(BaseMiddlewareTest):
     def test_directory_in_the_way(self):
         # If "thing.txt" is a nonempty directory, we get an error that the
         # middleware turns into a 409 Conflict response.
-        wsgi_input = StringIO("Celestine-malleal")
+        wsgi_input = BytesIO(b"Celestine-malleal")
         cl = str(len(wsgi_input.getvalue()))
 
         def mock_RpcPutComplete_isdir(head_container_req):
@@ -3276,7 +3315,7 @@ class TestObjectPut(BaseMiddlewareTest):
     def test_file_in_the_way(self):
         # If "thing.txt" is a nonempty directory, we get an error that the
         # middleware turns into a 409 Conflict response.
-        wsgi_input = StringIO("Celestine-malleal")
+        wsgi_input = BytesIO(b"Celestine-malleal")
         cl = str(len(wsgi_input.getvalue()))
 
         def mock_RpcPutComplete_notdir(head_container_req):
@@ -3307,7 +3346,7 @@ class TestObjectPut(BaseMiddlewareTest):
         # then any user-supplied ETag will be wrong. Also, this makes
         # POST-as-COPY work despite ProxyFS's ETag values not being MD5
         # checksums.
-        wsgi_input = StringIO("extranean-paleophysiology")
+        wsgi_input = BytesIO(b"extranean-paleophysiology")
         cl = str(len(wsgi_input.getvalue()))
 
         headers_in = {"X-Delete-After": 86400,
@@ -3336,9 +3375,9 @@ class TestObjectPut(BaseMiddlewareTest):
         self.assertNotIn("ETag", put_headers)
 
     def test_etag_checking(self):
-        wsgi_input = StringIO("unsplashed-comprest")
+        wsgi_input = BytesIO(b"unsplashed-comprest")
         right_etag = hashlib.md5(wsgi_input.getvalue()).hexdigest()
-        wrong_etag = hashlib.md5(wsgi_input.getvalue() + "abc").hexdigest()
+        wrong_etag = hashlib.md5(wsgi_input.getvalue() + b"abc").hexdigest()
         non_checksum_etag = "pfsv2/AUTH_test/2226116/4341333-32"
         cl = str(len(wsgi_input.getvalue()))
 
@@ -3373,7 +3412,7 @@ class TestObjectPut(BaseMiddlewareTest):
         req = swob.Request.blank(
             "/v1/AUTH_test/a-container/a-dir-object",
             environ={"REQUEST_METHOD": "PUT"},
-            headers={"ETag": hashlib.md5("x").hexdigest(),
+            headers={"ETag": hashlib.md5(b"x").hexdigest(),
                      "Content-Length": 0,
                      "Content-Type": "application/directory"})
         status, headers, body = self.call_pfs(req)
@@ -3382,7 +3421,7 @@ class TestObjectPut(BaseMiddlewareTest):
         req = swob.Request.blank(
             "/v1/AUTH_test/a-container/a-dir-object",
             environ={"REQUEST_METHOD": "PUT"},
-            headers={"ETag": hashlib.md5("").hexdigest(),
+            headers={"ETag": hashlib.md5(b"").hexdigest(),
                      "Content-Length": 0,
                      "Content-Type": "application/directory"})
         status, headers, body = self.call_pfs(req)
@@ -3451,7 +3490,8 @@ class TestObjectPost(BaseMiddlewareTest):
             return {
                 "error": None,
                 "result": {
-                    "Metadata": base64.b64encode(old_meta),
+                    "Metadata": base64.b64encode(
+                        old_meta.encode('ascii')).decode('ascii'),
                     "ModificationTime": 1482345542483719281,
                     "FileSize": 551155,
                     "IsDir": False,
@@ -3501,7 +3541,8 @@ class TestObjectPost(BaseMiddlewareTest):
         method, args = rpc_calls[2]
         self.assertEqual(method, "Server.RpcPost")
         self.assertEqual(args[0]["VirtPath"], "/v1/AUTH_test/con/obj")
-        self.assertEqual(base64.b64decode(args[0]["OldMetaData"]), old_meta)
+        self.assertEqual(
+            base64.b64decode(args[0]["OldMetaData"]).decode('ascii'), old_meta)
         new_meta = json.loads(base64.b64decode(args[0]["NewMetaData"]))
         self.assertEqual(new_meta["X-Object-Meta-Red-Fish"], "blue fish")
         self.assertEqual(new_meta["Content-Type"], "application/fishy")
@@ -3520,7 +3561,8 @@ class TestObjectPost(BaseMiddlewareTest):
             return {
                 "error": None,
                 "result": {
-                    "Metadata": base64.b64encode(old_meta),
+                    "Metadata": base64.b64encode(
+                        old_meta.encode('ascii')).decode('ascii'),
                     "ModificationTime": 1510873171878460000,
                     "FileSize": 7748115,
                     "IsDir": False,
@@ -3556,7 +3598,8 @@ class TestObjectPost(BaseMiddlewareTest):
             return {
                 "error": None,
                 "result": {
-                    "Metadata": base64.b64encode(old_meta),
+                    "Metadata": base64.b64encode(
+                        old_meta.encode('ascii')).decode('ascii'),
                     "ModificationTime": 1482345542483719281,
                     "FileSize": 551155,
                     "IsDir": False,
@@ -3581,7 +3624,8 @@ class TestObjectPost(BaseMiddlewareTest):
         method, args = rpc_calls[2]
         self.assertEqual(method, "Server.RpcPost")
         self.assertEqual(args[0]["VirtPath"], "/v1/AUTH_test/con/obj")
-        self.assertEqual(base64.b64decode(args[0]["OldMetaData"]), old_meta)
+        self.assertEqual(
+            base64.b64decode(args[0]["OldMetaData"]).decode('ascii'), old_meta)
         new_meta = json.loads(base64.b64decode(args[0]["NewMetaData"]))
         self.assertEqual(new_meta["Content-Type"], "new/type")
 
@@ -3592,7 +3636,8 @@ class TestObjectPost(BaseMiddlewareTest):
             return {
                 "error": None,
                 "result": {
-                    "Metadata": base64.b64encode(old_meta),
+                    "Metadata": base64.b64encode(
+                        old_meta.encode('ascii')).decode('ascii'),
                     "ModificationTime": 1482345542483719281,
                     "FileSize": 551155,
                     "IsDir": False,
@@ -3617,7 +3662,8 @@ class TestObjectPost(BaseMiddlewareTest):
         method, args = rpc_calls[2]
         self.assertEqual(method, "Server.RpcPost")
         self.assertEqual(args[0]["VirtPath"], "/v1/AUTH_test/con/obj")
-        self.assertEqual(base64.b64decode(args[0]["OldMetaData"]), old_meta)
+        self.assertEqual(
+            base64.b64decode(args[0]["OldMetaData"]).decode('ascii'), old_meta)
         new_meta = json.loads(base64.b64decode(args[0]["NewMetaData"]))
         self.assertNotIn("X-Object-Meta-Color", new_meta)
 
@@ -3705,7 +3751,9 @@ class TestObjectHead(BaseMiddlewareTest):
                              '/v1/AUTH_test/c/an-object.png')
 
             if self.serialized_object_metadata:
-                md = base64.b64encode(self.serialized_object_metadata)
+                md = base64.b64encode(
+                    self.serialized_object_metadata.encode('ascii')
+                ).decode('ascii')
             else:
                 md = ""
 
@@ -3863,7 +3911,9 @@ class TestObjectHead(BaseMiddlewareTest):
         })
 
         def mock_RpcHead(head_object_req):
-            md = base64.b64encode(self.serialized_object_metadata)
+            md = base64.b64encode(
+                self.serialized_object_metadata.encode('ascii')
+            ).decode('ascii')
             return {
                 "error": None,
                 "result": {
@@ -3892,7 +3942,9 @@ class TestObjectHead(BaseMiddlewareTest):
         })
 
         def mock_RpcHead(head_object_req):
-            md = base64.b64encode(self.serialized_object_metadata)
+            md = base64.b64encode(
+                self.serialized_object_metadata.encode('ascii')
+            ).decode('ascii')
             return {
                 "error": None,
                 "result": {
@@ -3991,11 +4043,11 @@ class TestObjectCoalesce(BaseMiddlewareTest):
                 "c2/seg space 2a",
                 "c2/seg space 2b",
                 "c3/seg3",
-            ]})
+            ]}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '201 Created')
         self.assertEqual(headers["Etag"],
@@ -4028,7 +4080,8 @@ class TestObjectCoalesce(BaseMiddlewareTest):
                 "result": {
                     "Metadata": base64.b64encode(json.dumps({
                         "X-Container-Read": path + '\x00read-acl',
-                        "X-Container-Write": path + '\x00write-acl'})),
+                        "X-Container-Write": path + '\x00write-acl',
+                    }).encode('ascii')).decode('ascii'),
                     "ModificationTime": 1479240451156825194,
                     "FileSize": 0,
                     "IsDir": True,
@@ -4055,11 +4108,11 @@ class TestObjectCoalesce(BaseMiddlewareTest):
                 "c2/seg space 2a",
                 "c2/seg space 2b",
                 "c3/seg3",
-            ]})
+            ]}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body),
+                     "wsgi.input": BytesIO(request_body),
                      "swift.authorize": auth_cb})
         status, headers, body = self.call_pfs(req)
         # The first call is a call to RpcIsAccountBimodal, then a bunch of
@@ -4092,75 +4145,76 @@ class TestObjectCoalesce(BaseMiddlewareTest):
         ])
 
     def test_malformed_json(self):
-        request_body = "{{{[[[((("
+        request_body = b"{{{[[[((("
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '400 Bad Request')
 
     def test_incorrect_json(self):
-        request_body = "{}"
+        request_body = b"{}"
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '400 Bad Request')
 
     def test_incorrect_json_wrong_type(self):
-        request_body = "[]"
+        request_body = b"[]"
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '400 Bad Request')
 
     def test_incorrect_json_wrong_elements_type(self):
-        request_body = json.dumps({"elements": {1: 2}})
+        request_body = json.dumps({"elements": {1: 2}}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '400 Bad Request')
 
     def test_incorrect_json_wrong_element_type(self):
-        request_body = json.dumps({"elements": [1, "two", {}]})
+        request_body = json.dumps({"elements": [1, "two", {}]}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '400 Bad Request')
 
     def test_incorrect_json_subtle(self):
-        request_body = '["elements"]'
+        request_body = b'["elements"]'
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '400 Bad Request')
 
     def test_too_big(self):
-        request_body = '{' * (self.pfs.max_coalesce_request_size + 1)
+        request_body = b'{' * (self.pfs.max_coalesce_request_size + 1)
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '413 Request Entity Too Large')
 
     def test_too_many_elements(self):
         request_body = json.dumps({
-            "elements": ["/c/o"] * (self.pfs.max_coalesce + 1)})
+            "elements": ["/c/o"] * (self.pfs.max_coalesce + 1),
+        }).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '413 Request Entity Too Large')
 
@@ -4182,11 +4236,11 @@ class TestObjectCoalesce(BaseMiddlewareTest):
         request_body = json.dumps({
             "elements": [
                 "some/stuff",
-            ]})
+            ]}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '404 Not Found')
 
@@ -4204,11 +4258,11 @@ class TestObjectCoalesce(BaseMiddlewareTest):
         request_body = json.dumps({
             "elements": [
                 "some/stuff",
-            ]})
+            ]}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '409 Conflict')
 
@@ -4227,11 +4281,11 @@ class TestObjectCoalesce(BaseMiddlewareTest):
         request_body = json.dumps({
             "elements": [
                 "some/stuff",
-            ]})
+            ]}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '409 Conflict')
 
@@ -4250,11 +4304,11 @@ class TestObjectCoalesce(BaseMiddlewareTest):
         request_body = json.dumps({
             "elements": [
                 "some/stuff",
-            ]})
+            ]}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '409 Conflict')
 
@@ -4274,11 +4328,11 @@ class TestObjectCoalesce(BaseMiddlewareTest):
             "elements": [
                 "thing/one",
                 "thing/two",
-            ]})
+            ]}).encode('ascii')
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj",
             environ={"REQUEST_METHOD": "COALESCE",
-                     "wsgi.input": StringIO(request_body)})
+                     "wsgi.input": BytesIO(request_body)})
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '500 Internal Error')
 
@@ -4293,7 +4347,8 @@ class TestAuth(BaseMiddlewareTest):
                 "result": {
                     "Metadata": base64.b64encode(json.dumps({
                         "X-Container-Read": "the-x-con-read",
-                        "X-Container-Write": "the-x-con-write"})),
+                        "X-Container-Write": "the-x-con-write",
+                    }).encode('ascii')).decode('ascii'),
                     "ModificationTime": 1479240451156825194,
                     "FileSize": 0,
                     "IsDir": True,

--- a/pfs_middleware/tests/test_s3_compat.py
+++ b/pfs_middleware/tests/test_s3_compat.py
@@ -37,7 +37,7 @@ class TestS3Compat(unittest.TestCase):
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj?multipart-manifest=put",
             environ={'REQUEST_METHOD': 'PUT',
-                     'wsgi.input': swob.WsgiBytesIO("")},
+                     'wsgi.input': swob.WsgiBytesIO(b"")},
             headers={'Content-Length': '0'})
 
         resp = req.get_response(self.s3_compat)
@@ -47,7 +47,7 @@ class TestS3Compat(unittest.TestCase):
         req = swob.Request.blank(
             "/v1/AUTH_test/con/obj?multipart-manifest=put",
             environ={'REQUEST_METHOD': 'PUT',
-                     'wsgi.input': swob.WsgiBytesIO(""),
+                     'wsgi.input': swob.WsgiBytesIO(b""),
                      utils.ENV_IS_BIMODAL: True},
             headers={'Content-Length': '0'})
 

--- a/pfs_middleware/tox.ini
+++ b/pfs_middleware/tox.ini
@@ -1,32 +1,20 @@
 [tox]
-envlist = py27,py27-old-swift,py27-swift-master,lint
+envlist = {py27,py36,py37}-{release,master},py27-minver,lint
 
 [testenv]
-deps = -r{toxinidir}/test-requirements.txt
+usedevelop = True
+# minver tests with the earliest version of Swift we support.
+deps =
+    lint: flake8
+    !lint: -r{toxinidir}/test-requirements.txt
+    release: git+git://github.com/openstack/swift.git@64e5fd364ae044ebfda541fd90bb3551bab36dcb
+    minver: http://tarballs.openstack.org/swift/swift-2.9.0.tar.gz
+    master: http://tarballs.openstack.org/swift/swift-master.tar.gz
 commands = python -m unittest discover
 
 [testenv:lint]
-basepython = python2.7
+usedevelop = False
 commands = flake8 {posargs:pfs_middleware tests setup.py}
-
-[testenv:py27]
-usedevelop = True
-deps =
-  -r{toxinidir}/test-requirements.txt
-  git+git://github.com/openstack/swift.git@64e5fd364ae044ebfda541fd90bb3551bab36dcb
-
-[testenv:py27-old-swift]
-# This tests with the earliest version of Swift we support.
-usedevelop = True
-deps =
-  -r{toxinidir}/test-requirements.txt
-  http://tarballs.openstack.org/swift/swift-2.9.0.tar.gz
-
-[testenv:py27-swift-master]
-usedevelop = True
-deps =
-  -r{toxinidir}/test-requirements.txt
-  http://tarballs.openstack.org/swift/swift-master.tar.gz
 
 [flake8]
 # flake8 has opinions with which we agree, for the most part. However,

--- a/run_docker_tests.sh
+++ b/run_docker_tests.sh
@@ -14,11 +14,11 @@ if [ "$IMAGE" == "build" ]; then
     set -x
     # That's how you run it from scratch
     docker build -t proxyfs_unit_tests test/container
-    docker run -it -v `pwd`:/gopathroot/src/github.com/swiftstack/ProxyFS proxyfs_unit_tests
+    docker run --cap-add SYS_ADMIN --device /dev/fuse -it -v `pwd`:/gopathroot/src/github.com/swiftstack/ProxyFS proxyfs_unit_tests
 elif [ "$IMAGE" == "pull" ]; then
     set -x
     # That's how you run it using the image on Docker Hub
-    docker run -it -v `pwd`:/gopathroot/src/github.com/swiftstack/ProxyFS swiftstack/proxyfs_unit_tests
+    docker run --cap-add SYS_ADMIN --device /dev/fuse -it -v `pwd`:/gopathroot/src/github.com/swiftstack/ProxyFS swiftstack/proxyfs_unit_tests
 else
     echo "Bad argument: $IMAGE"
     exit 1

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -86,6 +86,12 @@ RUN yum -y install \
     libtool-2.4.2-22.el7_3
 RUN yum -y install python-pip
 
+# Get a py3 runtime
+RUN yum -y install centos-release-scl
+RUN yum -y install rh-python36 && \
+    ln -s /opt/rh/rh-python36/root/bin/python3.6 /bin/python3.6 && \
+    ln -s /opt/rh/rh-python36/root/usr/include /opt/rh/rh-python36/root/include
+
 # Pip install. Trying to do as much as possible at once.
 # Here's an explanation of why we need to install each package:
 ## Setup ProxyFS build environment


### PR DESCRIPTION
There's also some reorganization of tox environments, just to help cut down on definitions. Add tox envs for py36 and py37, testing against both the "current release" and Swift master. Note: our minimum-supported Swift version (2.9.0) can't even be imported on py3.