### PR TITLE
Bugfix pfs coalesce

### DIFF
--- a/bin/aws-multipart-test.py
+++ b/bin/aws-multipart-test.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2019 SwiftStack, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Exercise the multipart-upload functionality of S3API using the aws
+# command from the awscli package and perform some validation of the
+# results.
+#
+# The aws command needs a file ~/.aws/config that contains the
+# authentication information for the account(s) being used.
+# For the proxyfs runway environment, the file can look like this:
+#
+# % cat ~/.aws/config
+'''
+[plugins]
+endpoint = awscli_plugin_endpoint
+
+[profile default]
+aws_access_key_id = test:tester
+aws_secret_access_key = testing
+s3 =
+     endpoint_url = http://127.0.0.1:8080
+     multipart_threshold = 64MB
+     multipart_chunksize = 16MB
+s3api =
+     endpoint_url = http://127.0.0.1:8080
+     multipart_threshold = 5MB
+     multipart_chunksize = 5MB
+
+[profile swift]
+aws_access_key_id = admin:admin
+aws_secret_access_key = admin
+s3 =
+     endpoint_url = http://127.0.0.1:8080
+     multipart_threshold = 64MB
+     multipart_chunksize = 16MB
+s3api =
+     endpoint_url = http://127.0.0.1:8080
+     multipart_threshold = 5MB
+     multipart_chunksize = 5MB
+'''
+# The above config file defines two profiles, "default" and "swift".
+# this, where the admin account is a separate, non-swift, account
+# that can be accessed via curl at AUTH_admin.
+#
+# This command also assumes three files are in /tmp, available for
+# uploading, named /tmp/{part01,part02,part03} which contain 5 Mbyte
+# of zeros, 5 Mbyte of zeros, and 1 Mbyte of zeros, respectively.
+#
+# dd if=/dev/zero of=/tmp/part01 bs=1M count=10
+# dd if=/dev/zero of=/tmp/part02 bs=1M count=10
+# dd if=/dev/zero of=/tmp/part03 bs=1M count=1
+#
+from __future__ import print_function
+
+import argparse
+import os
+import Queue
+import sys
+import subprocess32
+import json
+
+def run_s3api_cmd(sub_cmd, profile_name, bucket_name, obj_name, extra_args):
+    '''Create and execute an "aws s3api" sub-command using the passed
+    arguments (any of which can be None).
+
+    Return the return code, stdout, and stderr as a tuple.
+    '''
+
+    cmd = ['aws', 's3api', sub_cmd]
+    if profile_name is not None:
+        cmd += ['--profile', profile_name]
+    if bucket_name is not None:
+        cmd += ['--bucket', bucket_name]
+    if obj_name is not None:
+        cmd += ['--key', obj_name]
+    if extra_args is not None:
+        cmd += extra_args
+
+    aws_proc = subprocess32.Popen(cmd, bufsize=-1, stdout=subprocess32.PIPE, stderr=subprocess32.PIPE)
+    (aws_stdout, aws_stderr) = aws_proc.communicate()
+    rc = aws_proc.wait()
+    if rc != 0:
+        err = ("run_s3api_cmd(): command '%s' returned %d"
+               % (' '.join(cmd), rc))
+        print("%s\nstderr: %s\n" % (err, aws_stderr), file=sys.stderr)
+        return (err, aws_stdout, aws_stderr)
+
+    print("%s\n%s\n" % (' '.join(cmd), aws_stdout))
+    return (None, aws_stdout, aws_stderr)
+
+
+def multipart_upload(profile, bucket, objname, file_parts):
+    '''
+    Create a new multipart-upload context (uploadId) for the object
+    and then upload the files specified in file_parts.
+
+    Return the JSON decoded string from the "complete-multipart-upload"
+    and "head-object" subcommands.
+    '''
+
+    if bucket is None or objname is None:
+        err ="multipart_upload(): bucket '%s' objname '%s' must be specified" % (bucket, objname)
+        print("%s\n" % (err), file=sys.stderr)
+        return err
+
+    if len(file_parts) < 2:
+        err = "multipart_upload(): must specify at least two files to upload, got %d" % (len(file_parts))
+        print("%s\n" % (err), file=sys.stderr)
+        return err
+
+    for file in file_parts:
+        try:
+            fp = open(file, 'r')
+            fp.close()
+        except:
+            err = "multipart_upload(): could not open file '%s' for reading" % (file)
+            print("%s\n" % (err), file=sys.stderr)
+            return err
+
+    # create the upload bucket (ignore failures if already present)
+    (err, aws_stdout, aws_stderr) = run_s3api_cmd(
+        'create-bucket', profile, bucket, None, None)
+    # if err is not None:
+    #     err = "'create-bucket' failed: %s" % (err)
+    #     print("%s\n" % (err), file=sys.stderr)
+    #     return err
+
+    # create the upload context
+    (err, aws_stdout, aws_stderr) = run_s3api_cmd(
+        'create-multipart-upload', profile, bucket, objname, None)
+    if err is not None:
+        err = "'create-multipart-upload' failed: %s" % (err)
+        print("%s\n" % (err), file=sys.stderr)
+        return err
+    create_resp = json.loads(aws_stdout)
+    upload_id = create_resp['UploadId']
+
+    # upload the parts
+    part_num = 0
+    etag_set = []
+    for file in file_parts:
+        part_num += 1
+
+        extra_args = ['--upload-id', upload_id, '--part-number', str(part_num), '--body', file]
+        (err, aws_stdout, aws_stderr) = run_s3api_cmd(
+            'upload-part', profile, bucket, objname, extra_args)
+        if err is not None:
+            err = "'upload-part' failed: %s" % (err)
+            print("%s\n" % (err), file=sys.stderr)
+            return err
+
+        upload_resp = json.loads(aws_stdout)
+        etag = { "ETag": upload_resp['ETag'], "PartNumber": part_num }
+        etag_set.append(etag)
+
+    mpu_info = { "Parts": etag_set}
+    print("%s\n" % json.dumps(mpu_info))
+
+    # complete the multipart-upload (if there are too many parts we won't
+    # be able to pass them on the command line and this will break)
+    extra_args = ['--upload-id', upload_id, '--multipart-upload', json.dumps(mpu_info)]
+    (err, aws_stdout, aws_stderr) = run_s3api_cmd(
+        'complete-multipart-upload', profile, bucket, objname, extra_args)
+    if err is not None:
+        err = "'complete-multipart-upload' failed: %s" % (err)
+        print("%s\n" % (err), file=sys.stderr)
+        return err
+
+    complete_resp = json.loads(aws_stdout)
+    # we should validate ""Last-Modified"" time in the response
+    # headers, except they aren't visible via aws s3api!  but there
+    # was a bug where the time was incorrect.
+
+    # get the object attributes
+    (err, aws_stdout, aws_stderr) = run_s3api_cmd(
+        'head-object', profile, bucket, objname, None)
+    if err is not None:
+        err = "'head-object' failed: %s" % (err)
+        print("%s\n" % (err), file=sys.stderr)
+        return err
+
+    head_resp = json.loads(aws_stdout)
+
+    # TODO: should validate ""LastModified"" time in the HEAD response
+    # TODO: should validate the ACL (use 'get-object-acl')
+
+
+    # get the object attributes from a list-object commands;
+    # they should match
+    (err, aws_stdout, aws_stderr) = run_s3api_cmd(
+        'list-objects', profile, bucket, None, None)
+    if err is not None:
+        err = "'list-objects' failed: %s" % (err)
+        print("%s\n" % (err), file=sys.stderr)
+        return err
+
+    list_resp = json.loads(aws_stdout)
+
+    s3_etag = complete_resp['ETag']
+    if s3_etag != head_resp['ETag']:
+        print("ERROR: ETag from complete-multipart-upload '%s' does not match ETag from head-object '%s'\n" %
+              (s3_etag, head_resp['ETag']))
+
+    for obj_info in list_resp['Contents']:
+        if obj_info['Key'] == 'testobj':
+            if s3_etag != obj_info['ETag']:
+                print("ERROR: ETag from complete-multipart-upload '%s' does not match ETag from list-objects '%s'\n" %
+                      (s3_etag, obj_info['ETag']))
+            break
+
+    return (None, complete_resp, head_resp)
+
+(err, proxyfs_complete_resp, proxyfs_head_resp) = multipart_upload(
+    "default", "multipart-upload", "testobj", ['/tmp/part01', '/tmp/part02', '/tmp/part03'])
+
+(err, swift_complete_resp, swift_head_resp) = multipart_upload(
+    "swift", "multipart-upload", "testobj", ['/tmp/part01', '/tmp/part02', '/tmp/part03'])
+
+if proxyfs_complete_resp['ETag'] != swift_complete_resp['ETag']:
+    print("ERROR: ETag from proxyfs complete-multipart-upload '%s' does not match ETag from swift '%s'\n" %
+          (proxyfs_complete_resp['ETag'], swift_complete_resp['ETag']))
+
+sys.exit(0)

--- a/fs/api.go
+++ b/fs/api.go
@@ -182,7 +182,7 @@ type MountHandle interface {
 	ListXAttr(userID inode.InodeUserID, groupID inode.InodeGroupID, otherGroupIDs []inode.InodeGroupID, inodeNumber inode.InodeNumber) (streamNames []string, err error)
 	Lookup(userID inode.InodeUserID, groupID inode.InodeGroupID, otherGroupIDs []inode.InodeGroupID, dirInodeNumber inode.InodeNumber, basename string) (inodeNumber inode.InodeNumber, err error)
 	LookupPath(userID inode.InodeUserID, groupID inode.InodeGroupID, otherGroupIDs []inode.InodeGroupID, fullpath string) (inodeNumber inode.InodeNumber, err error)
-	MiddlewareCoalesce(destPath string, metaData []byte, elementPaths []string) (ino uint64, numWrites uint64, modificationTime uint64, err error)
+	MiddlewareCoalesce(destPath string, metaData []byte, elementPaths []string) (ino uint64, numWrites uint64, attrChangeTime uint64, modificationTime uint64, err error)
 	MiddlewareDelete(parentDir string, baseName string) (err error)
 	MiddlewareGetAccount(maxEntries uint64, marker string, endmarker string) (accountEnts []AccountEntry, mtime uint64, ctime uint64, err error)
 	MiddlewareGetContainer(vContainerName string, maxEntries uint64, marker string, endmarker string, prefix string, delimiter string) (containerEnts []ContainerEntry, err error)

--- a/fs/api.go
+++ b/fs/api.go
@@ -182,7 +182,7 @@ type MountHandle interface {
 	ListXAttr(userID inode.InodeUserID, groupID inode.InodeGroupID, otherGroupIDs []inode.InodeGroupID, inodeNumber inode.InodeNumber) (streamNames []string, err error)
 	Lookup(userID inode.InodeUserID, groupID inode.InodeGroupID, otherGroupIDs []inode.InodeGroupID, dirInodeNumber inode.InodeNumber, basename string) (inodeNumber inode.InodeNumber, err error)
 	LookupPath(userID inode.InodeUserID, groupID inode.InodeGroupID, otherGroupIDs []inode.InodeGroupID, fullpath string) (inodeNumber inode.InodeNumber, err error)
-	MiddlewareCoalesce(destPath string, elementPaths []string) (ino uint64, numWrites uint64, modificationTime uint64, err error)
+	MiddlewareCoalesce(destPath string, metaData []byte, elementPaths []string) (ino uint64, numWrites uint64, modificationTime uint64, err error)
 	MiddlewareDelete(parentDir string, baseName string) (err error)
 	MiddlewareGetAccount(maxEntries uint64, marker string, endmarker string) (accountEnts []AccountEntry, mtime uint64, ctime uint64, err error)
 	MiddlewareGetContainer(vContainerName string, maxEntries uint64, marker string, endmarker string, prefix string, delimiter string) (containerEnts []ContainerEntry, err error)

--- a/fs/api_internal.go
+++ b/fs/api_internal.go
@@ -1313,7 +1313,9 @@ func (mS *mountStruct) LookupPath(userID inode.InodeUserID, groupID inode.InodeG
 	return cursorInodeNumber, nil
 }
 
-func (mS *mountStruct) MiddlewareCoalesce(destPath string, elementPaths []string) (ino uint64, numWrites uint64, modificationTime uint64, err error) {
+func (mS *mountStruct) MiddlewareCoalesce(destPath string, metaData []byte, elementPaths []string) (
+	ino uint64, numWrites uint64, modificationTime uint64, err error) {
+
 	var (
 		coalesceElementList      []*inode.CoalesceElement
 		coalesceElementListIndex int
@@ -1411,7 +1413,8 @@ Restart:
 	// Invoke package inode to actually perform the Coalesce operation
 
 	destFileInodeNumber = dirEntryInodeNumber
-	coalesceTime, numWrites, _, err = mS.volStruct.inodeVolumeHandle.Coalesce(destFileInodeNumber, coalesceElementList)
+	coalesceTime, numWrites, _, err = mS.volStruct.inodeVolumeHandle.Coalesce(
+		destFileInodeNumber, MiddlewareStream, metaData, coalesceElementList)
 
 	// We can now release all the WriteLocks we are currently holding
 

--- a/fs/api_internal.go
+++ b/fs/api_internal.go
@@ -1314,13 +1314,14 @@ func (mS *mountStruct) LookupPath(userID inode.InodeUserID, groupID inode.InodeG
 }
 
 func (mS *mountStruct) MiddlewareCoalesce(destPath string, metaData []byte, elementPaths []string) (
-	ino uint64, numWrites uint64, modificationTime uint64, err error) {
+	ino uint64, numWrites uint64, attrChangeTime uint64, modificationTime uint64, err error) {
 
 	var (
 		coalesceElementList      []*inode.CoalesceElement
 		coalesceElementListIndex int
 		coalesceSize             uint64
-		coalesceTime             time.Time
+		ctime                    time.Time
+		mtime                    time.Time
 		destFileInodeNumber      inode.InodeNumber
 		dirEntryBasename         string
 		dirEntryInodeNumber      inode.InodeNumber
@@ -1413,7 +1414,7 @@ Restart:
 	// Invoke package inode to actually perform the Coalesce operation
 
 	destFileInodeNumber = dirEntryInodeNumber
-	coalesceTime, numWrites, _, err = mS.volStruct.inodeVolumeHandle.Coalesce(
+	ctime, mtime, numWrites, _, err = mS.volStruct.inodeVolumeHandle.Coalesce(
 		destFileInodeNumber, MiddlewareStream, metaData, coalesceElementList)
 
 	// We can now release all the WriteLocks we are currently holding
@@ -1423,7 +1424,8 @@ Restart:
 	// Regardless of err return, fill in other return values
 
 	ino = uint64(destFileInodeNumber)
-	modificationTime = uint64(coalesceTime.UnixNano())
+	attrChangeTime = uint64(ctime.UnixNano())
+	modificationTime = uint64(mtime.UnixNano())
 
 	return
 }

--- a/inode/api.go
+++ b/inode/api.go
@@ -227,7 +227,7 @@ type VolumeHandle interface {
 	Wrote(fileInodeNumber InodeNumber, objectPath string, fileOffset []uint64, objectOffset []uint64, length []uint64, patchOnly bool) (err error)
 	SetSize(fileInodeNumber InodeNumber, Size uint64) (err error)
 	Flush(fileInodeNumber InodeNumber, andPurge bool) (err error)
-	Coalesce(destInodeNumber InodeNumber, elements []*CoalesceElement) (modificationTime time.Time, numWrites uint64, fileSize uint64, err error)
+	Coalesce(destInodeNumber InodeNumber, metaDataName string, metaData []byte, elements []*CoalesceElement) (modificationTime time.Time, numWrites uint64, fileSize uint64, err error)
 
 	// Symlink Inode specific methods, implemented in symlink.go
 

--- a/inode/api.go
+++ b/inode/api.go
@@ -227,7 +227,7 @@ type VolumeHandle interface {
 	Wrote(fileInodeNumber InodeNumber, objectPath string, fileOffset []uint64, objectOffset []uint64, length []uint64, patchOnly bool) (err error)
 	SetSize(fileInodeNumber InodeNumber, Size uint64) (err error)
 	Flush(fileInodeNumber InodeNumber, andPurge bool) (err error)
-	Coalesce(destInodeNumber InodeNumber, metaDataName string, metaData []byte, elements []*CoalesceElement) (modificationTime time.Time, numWrites uint64, fileSize uint64, err error)
+	Coalesce(destInodeNumber InodeNumber, metaDataName string, metaData []byte, elements []*CoalesceElement) (attrChangeTime time.Time, modificationTime time.Time, numWrites uint64, fileSize uint64, err error)
 
 	// Symlink Inode specific methods, implemented in symlink.go
 

--- a/inode/coalesce_test.go
+++ b/inode/coalesce_test.go
@@ -153,8 +153,10 @@ func TestCoalesce(t *testing.T) {
 		ElementInodeNumber:             file2cInodeNumber,
 		ElementName:                    "file2c"})
 
-	// Coalesce the above 5 files into d1/combined
-	_, _, fileSize, err := vh.Coalesce(combinedInodeNumber, elements)
+	newMetaData := []byte("The quick brown fox jumped over the lazy dog.")
+
+	// Coalesce the above 5 files and metadata into d1/combined
+	_, _, fileSize, err := vh.Coalesce(combinedInodeNumber, "MetaDataStream", newMetaData, elements)
 	if !assert.Nil(err) {
 		return
 	}
@@ -185,6 +187,12 @@ func TestCoalesce(t *testing.T) {
 		return
 	}
 	assert.Equal(combinedInodeNumber, foundInodeNumber)
+
+	// Verify the new file has the new metadata
+	buf, err := vh.GetStream(combinedInodeNumber, "MetaDataStream")
+	if assert.Nil(err) {
+		assert.Equal(buf, newMetaData)
+	}
 
 	testTeardown(t)
 }
@@ -254,7 +262,7 @@ func TestCoalesceDir(t *testing.T) {
 		ElementName:                    "file1b"})
 
 	// Coalesce the above 2 files into d1
-	_, _, _, err = vh.Coalesce(d1InodeNumber, elements)
+	_, _, _, err = vh.Coalesce(d1InodeNumber, "MetaDataStream", nil, elements)
 	assert.NotNil(err)
 	assert.True(blunder.Is(err, blunder.PermDeniedError))
 
@@ -329,7 +337,7 @@ func TestCoalesceMultipleLinks(t *testing.T) {
 		ElementName:                    "file1b"})
 
 	// Coalesce the above 2 files into d1/combined
-	_, _, _, err = vh.Coalesce(combinedInodeNumber, elements)
+	_, _, _, err = vh.Coalesce(combinedInodeNumber, "MetaDataStream", nil, elements)
 	assert.NotNil(err)
 	assert.True(blunder.Is(err, blunder.TooManyLinksError))
 
@@ -416,7 +424,7 @@ func TestCoalesceDuplicates(t *testing.T) {
 		ElementName:                    "file1a"})
 
 	// Coalesce the above 3 files into d1/combined
-	_, _, _, err = vh.Coalesce(combinedInodeNumber, elements)
+	_, _, _, err = vh.Coalesce(combinedInodeNumber, "MetaDataStream", nil, elements)
 	assert.NotNil(err)
 	assert.True(blunder.Is(err, blunder.InvalidArgError))
 

--- a/inode/file.go
+++ b/inode/file.go
@@ -915,6 +915,9 @@ func (vS *volumeStruct) SetSize(fileInodeNumber InodeNumber, size uint64) (err e
 		return
 	}
 
+	// changing the file's size is just like a write
+	fileInode.NumWrites++
+
 	err = fileInode.volume.flushInode(fileInode)
 	if nil != err {
 		logger.ErrorWithError(err)
@@ -1010,7 +1013,9 @@ func (vS *volumeStruct) resetFileInodeInMemory(fileInode *inMemoryInodeStruct) (
 	return
 }
 
-func (vS *volumeStruct) Coalesce(destInodeNumber InodeNumber, elements []*CoalesceElement) (coalesceTime time.Time, numWrites uint64, fileSize uint64, err error) {
+func (vS *volumeStruct) Coalesce(destInodeNumber InodeNumber, metaDataName string, metaData []byte, elements []*CoalesceElement) (
+	coalesceTime time.Time, numWrites uint64, fileSize uint64, err error) {
+
 	var (
 		alreadyInInodeMap                  bool
 		destInode                          *inMemoryInodeStruct
@@ -1131,7 +1136,7 @@ func (vS *volumeStruct) Coalesce(destInodeNumber InodeNumber, elements []*Coales
 
 	for _, element = range elements {
 		elementInode = inodeMap[element.ElementInodeNumber]
-		destInode.NumWrites += elementInode.NumWrites
+		destInode.NumWrites += 1
 		elementInodeExtentMap = elementInode.payload.(sortedmap.BPlusTree)
 		elementInodeExtentMapLen, err = elementInodeExtentMap.Len()
 		for elementInodeExtentMapIndex = 0; elementInodeExtentMapIndex < elementInodeExtentMapLen; elementInodeExtentMapIndex++ {
@@ -1187,15 +1192,18 @@ func (vS *volumeStruct) Coalesce(destInodeNumber InodeNumber, elements []*Coales
 	}
 
 	// Now, destInode is fully assembled... update its metadata & assemble remaining results
-
 	coalesceTime = time.Now()
-
 	destInode.CreationTime = coalesceTime
 	destInode.AttrChangeTime = coalesceTime
 	destInode.ModificationTime = coalesceTime
 
-	numWrites = destInode.NumWrites
+	// attach new middleware headers (why are we making a copy?)
+	inodeStreamBuf := make([]byte, len(metaData))
+	copy(inodeStreamBuf, metaData)
+	destInode.StreamMap[metaDataName] = inodeStreamBuf
 
+	// collect the NumberOfWrites value while locked (important for Etag)
+	numWrites = destInode.NumWrites
 	fileSize = destInode.Size
 
 	// Now, destInode is fully assembled... need to remove all elements references to currently shared LogSegments

--- a/inode/file.go
+++ b/inode/file.go
@@ -993,7 +993,6 @@ func (vS *volumeStruct) resetFileInodeInMemory(fileInode *inMemoryInodeStruct) (
 	)
 
 	fileInode.dirty = true
-
 	fileInodeExtentMap = fileInode.payload.(sortedmap.BPlusTree)
 
 	ok = true
@@ -1013,11 +1012,13 @@ func (vS *volumeStruct) resetFileInodeInMemory(fileInode *inMemoryInodeStruct) (
 	return
 }
 
-func (vS *volumeStruct) Coalesce(destInodeNumber InodeNumber, metaDataName string, metaData []byte, elements []*CoalesceElement) (
-	coalesceTime time.Time, numWrites uint64, fileSize uint64, err error) {
+func (vS *volumeStruct) Coalesce(destInodeNumber InodeNumber, metaDataName string,
+	metaData []byte, elements []*CoalesceElement) (
+	attrChangeTime time.Time, modificationTime time.Time, numWrites uint64, fileSize uint64, err error) {
 
 	var (
 		alreadyInInodeMap                  bool
+		coalesceTime                       time.Time
 		destInode                          *inMemoryInodeStruct
 		destInodeExtentMap                 sortedmap.BPlusTree
 		destInodeOffsetBeforeElementAppend uint64
@@ -1205,6 +1206,8 @@ func (vS *volumeStruct) Coalesce(destInodeNumber InodeNumber, metaDataName strin
 	// collect the NumberOfWrites value while locked (important for Etag)
 	numWrites = destInode.NumWrites
 	fileSize = destInode.Size
+	attrChangeTime = destInode.AttrChangeTime
+	modificationTime = destInode.ModificationTime
 
 	// Now, destInode is fully assembled... need to remove all elements references to currently shared LogSegments
 

--- a/jrpcfs/api.go
+++ b/jrpcfs/api.go
@@ -784,6 +784,8 @@ type PutContainerReply struct {
 type CoalesceReq struct {
 	VirtPath                    string
 	ElementAccountRelativePaths []string
+	// New or updated HTTP metadata to be stored
+	NewMetaData []byte
 }
 
 type CoalesceReply struct {

--- a/jrpcfs/middleware.go
+++ b/jrpcfs/middleware.go
@@ -362,8 +362,9 @@ func (s *Server) RpcCoalesce(in *CoalesceReq, reply *CoalesceReply) (err error) 
 	_, destContainer, destObject, _, mountHandle, err := mountIfNotMounted(in.VirtPath)
 
 	var ino uint64
-	ino, reply.NumWrites, reply.ModificationTime, err =
-		mountHandle.MiddlewareCoalesce(destContainer+"/"+destObject, in.NewMetaData, in.ElementAccountRelativePaths)
+	ino, reply.NumWrites, reply.AttrChangeTime, reply.ModificationTime, err =
+		mountHandle.MiddlewareCoalesce(
+			destContainer+"/"+destObject, in.NewMetaData, in.ElementAccountRelativePaths)
 	reply.InodeNumber = int64(ino)
 	return
 }

--- a/jrpcfs/middleware.go
+++ b/jrpcfs/middleware.go
@@ -362,7 +362,8 @@ func (s *Server) RpcCoalesce(in *CoalesceReq, reply *CoalesceReply) (err error) 
 	_, destContainer, destObject, _, mountHandle, err := mountIfNotMounted(in.VirtPath)
 
 	var ino uint64
-	ino, reply.NumWrites, reply.ModificationTime, err = mountHandle.MiddlewareCoalesce(destContainer+"/"+destObject, in.ElementAccountRelativePaths)
+	ino, reply.NumWrites, reply.ModificationTime, err =
+		mountHandle.MiddlewareCoalesce(destContainer+"/"+destObject, in.NewMetaData, in.ElementAccountRelativePaths)
 	reply.InodeNumber = int64(ino)
 	return
 }

--- a/jrpcfs/middleware_test.go
+++ b/jrpcfs/middleware_test.go
@@ -2113,6 +2113,7 @@ func TestRpcCoalesce(t *testing.T) {
 	assert.True(coalesceReply.NumWrites > 0)
 	assert.True(coalesceReply.ModificationTime > 0)
 	assert.True(coalesceReply.ModificationTime > timeBeforeRequest)
+	assert.True(coalesceReply.ModificationTime == coalesceReply.AttrChangeTime)
 
 	combinedContents, err := mountHandle.Read(inode.InodeRootUserID, inode.InodeGroupID(0), nil, combinedInode, 0, 99999, nil)
 	assert.Nil(err)

--- a/pfs_middleware/pfs_middleware/rpc.py
+++ b/pfs_middleware/pfs_middleware/rpc.py
@@ -228,7 +228,7 @@ def parse_get_object_response(read_plan_response):
             read_plan_response["LeaseId"])
 
 
-def coalesce_object_request(destination, elements):
+def coalesce_object_request(destination, elements, new_metadata):
     """
     Return a JSON-RPC request to get a read plan and other info for a
     particular object.
@@ -240,7 +240,8 @@ def coalesce_object_request(destination, elements):
     """
     return jsonrpc_request("Server.RpcCoalesce",
                            [{"VirtPath": destination,
-                             "ElementAccountRelativePaths": elements}])
+                             "ElementAccountRelativePaths": elements,
+                             "NewMetaData": _encode_binary(new_metadata)}])
 
 
 def parse_coalesce_object_response(coalesce_object_response):

--- a/pfs_middleware/tests/test_pfs_middleware.py
+++ b/pfs_middleware/tests/test_pfs_middleware.py
@@ -4114,8 +4114,7 @@ class TestObjectCoalesce(BaseMiddlewareTest):
 
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '201 Created')
-        self.assertEqual(headers["Etag"],
-                         '"pfsv2/AUTH_test/00045275/00000005-32"')
+        self.assertEqual(headers["Etag"], '10340ab593ac8c32290a278e36d1f8df')
 
         # The first call is a call to RpcIsAccountBimodal, the last is the one
         # we care about: RpcCoalesce. There *could* be some intervening calls

--- a/pfs_middleware/tests/test_pfs_middleware.py
+++ b/pfs_middleware/tests/test_pfs_middleware.py
@@ -2984,10 +2984,10 @@ class TestObjectPut(BaseMiddlewareTest):
                      "X-Object-Sysmeta-Abc": "DEF"},
             body="")
 
+        # directories always return the hard coded value for EMPTY_OBJECT_ETAG
         status, headers, body = self.call_pfs(req)
         self.assertEqual(status, '201 Created')
-        self.assertEqual(headers["ETag"],
-                         mware.construct_etag("AUTH_test", 9268022, 0))
+        self.assertEqual(headers["ETag"], "d41d8cd98f00b204e9800998ecf8427e")
 
         rpc_calls = self.fake_rpc.calls
         self.assertEqual(len(rpc_calls), 3)
@@ -4154,8 +4154,6 @@ class TestObjectCoalesce(BaseMiddlewareTest):
         self.assertNotIn('X-Object-Sysmeta-Slo-Etag', headers)
         self.assertNotIn('X-Object-Sysmeta-Slo-Size', headers)
 
-        print("test_success(): headers: '%s'\n" % (headers))
-
     def test_not_authed(self):
         def mock_RpcHead(get_container_req):
             path = get_container_req['VirtPath']
@@ -4515,43 +4513,179 @@ class TestAuth(BaseMiddlewareTest):
         self.assertEqual(status, '204 No Content')
 
 
-class TestBestPossibleEtag(unittest.TestCase):
-    # Duplicated here so we can't accidentally change it. If we change this
-    # header or its value, we have to consider handling old data.
+class TestEtagHandling(unittest.TestCase):
+    '''Test that mung_etags()/unmung_etags() are inverse functions (more
+    or less), that the unmung_etags() correctly unmungs the current
+    disk layout for the header, and that best_possible_etag() returns
+    the correct etag value.
+    '''
+
+    # Both the header names and the way the values are calculated and
+    # the way they are formatted are part of the "disk layout".  If we
+    # change them, we have to consider handling old data.
+    #
+    # Names and values duplicated here so this test will break if they
+    # are changed.
     HEADER = "X-Object-Sysmeta-ProxyFS-Initial-MD5"
 
-    def test_md5_good(self):
-        self.assertEqual(
-            mware.unmung_etags_and_return_best(
-                {self.HEADER: "1:5484c2634aa61c69fc02ef5400a61c94"},
-                "AUTH_test", 6676743, 1),
-            '5484c2634aa61c69fc02ef5400a61c94')
+    ETAG_HEADERS = {
+        "ORIGINAL_MD5": {
+            "name": "X-Object-Sysmeta-ProxyFS-Initial-MD5",
+            "value": "5484c2634aa61c69fc02ef5400a61c94",
+            "num_writes": 7,
+            "munged_value": "7:5484c2634aa61c69fc02ef5400a61c94"
+        },
+        "S3API_ETAG": {
+            "name": "X-Object-Sysmeta-S3Api-Etag",
+            "value": "cb0dc66d591395cdf93555dafd4145ad",
+            "num_writes": 3,
+            "munged_value": "3:cb0dc66d591395cdf93555dafd4145ad"
+        },
+        "LISTING_ETAG_OVERRIDE": {
+            "name": "X-Object-Sysmeta-Container-Update-Override-Etag",
+            "value": "dbca19e0c46aa9b10e8de2f5856abc86",
+            "num_writes": 9,
+            "munged_value": "9:dbca19e0c46aa9b10e8de2f5856abc86"
+        },
+    }
 
-    def test_modified(self):
-        self.assertEqual(
-            mware.unmung_etags_and_return_best(
-                {self.HEADER: "1:5484c2634aa61c69fc02ef5400a61c94"},
-                "AUTH_test", 0x16497360, 2),
-            '"pfsv2/AUTH_test/16497360/00000002-32"')
+    EMPTY_OBJECT_ETAG = "d41d8cd98f00b204e9800998ecf8427e"
 
-    def test_missing(self):
-        self.assertEqual(
-            mware.unmung_etags_and_return_best(
-                {}, "AUTH_test", 0x01740209, 1),
-            '"pfsv2/AUTH_test/01740209/00000001-32"')
+    def test_mung_etags(self):
+        '''Verify that mung_etags() mungs each of the etag header values to
+        the correct on-disk version with num_writes and unmung_etags()
+        recovers the original value.
+        '''
+        for header in self.ETAG_HEADERS.keys():
 
-    def test_bogus(self):
-        self.assertEqual(
-            mware.unmung_etags_and_return_best(
-                {self.HEADER: "counterfact-preformative"},
-                "AUTH_test", 0x707301, 2),
-            '"pfsv2/AUTH_test/00707301/00000002-32"')
+            name = self.ETAG_HEADERS[header]["name"]
+            value = self.ETAG_HEADERS[header]["value"]
+            num_writes = self.ETAG_HEADERS[header]["num_writes"]
+            munged_value = self.ETAG_HEADERS[header]["munged_value"]
 
-        self.assertEqual(
-            mware.unmung_etags_and_return_best(
-                {self.HEADER: "magpie:interfollicular"},
-                "AUTH_test", 0x707301, 2),
-            '"pfsv2/AUTH_test/00707301/00000002-32"')
+            obj_metadata = {name: value}
+            mware.mung_etags(obj_metadata, None, num_writes)
+
+            # The handling of ORIGINAL_MD5_HEADER is a bit strange.
+            # If an etag value is passed to mung_etags() as the 2nd
+            # argument then the header is created and assigned the
+            # munged version of that etag value.  But if its None than
+            # an ORIGINAL_MD5_HEADER, if present, is passed through
+            # unmolested (but will be dropped by the unmung code if
+            # the format is wrong or num_writes does not match, which
+            # is likely).
+            if header == "ORIGINAL_MD5":
+                self.assertEqual(obj_metadata[name], value)
+            else:
+                self.assertEqual(obj_metadata[name], munged_value)
+
+            # same test but with an etag value passed to mung_etags()
+            # instead of None
+            md5_etag_value = self.ETAG_HEADERS["ORIGINAL_MD5"]["value"]
+
+            obj_metadata = {name: value}
+            mware.mung_etags(obj_metadata, md5_etag_value, num_writes)
+            self.assertEqual(obj_metadata[name], munged_value)
+
+            # and verify that it gets unmunged to the original value
+            mware.unmung_etags(obj_metadata, num_writes)
+            self.assertEqual(obj_metadata[name], value)
+
+    def test_unmung_etags(self):
+        '''Verify that unmung_etags() recovers the correct value for
+        each ETag header and discards header values where num_writes
+        is incorrect or the value is corrupt.
+        '''
+        # build metadata with all of the etag headers
+        orig_obj_metadata = {}
+        for header in self.ETAG_HEADERS.keys():
+
+            name = self.ETAG_HEADERS[header]["name"]
+            munged_value = self.ETAG_HEADERS[header]["munged_value"]
+            orig_obj_metadata[name] = munged_value
+
+        # unmung_etags() should strip out headers with stale
+        # num_writes so only the one for header remains
+        for header in self.ETAG_HEADERS.keys():
+
+            name = self.ETAG_HEADERS[header]["name"]
+            value = self.ETAG_HEADERS[header]["value"]
+            num_writes = self.ETAG_HEADERS[header]["num_writes"]
+            munged_value = self.ETAG_HEADERS[header]["munged_value"]
+
+            obj_metadata = orig_obj_metadata.copy()
+            mware.unmung_etags(obj_metadata, num_writes)
+
+            # header should be the only one left
+            for hdr2 in self.ETAG_HEADERS.keys():
+
+                if hdr2 == header:
+                    self.assertEqual(obj_metadata[name], value)
+                else:
+                    self.assertTrue(
+                        self.ETAG_HEADERS[hdr2]["name"] not in obj_metadata)
+
+            # verify mung_etags() takes it back to the munged value
+            if header != "ORIGINAL_MD5":
+                mware.mung_etags(obj_metadata, None, num_writes)
+                self.assertEqual(obj_metadata[name], munged_value)
+
+        # Try to unmung on-disk headers with corrupt values. Instead
+        # of a panic it should simply elide the headers (and possibly
+        # log the corrupt value, which it doesn't currently do).
+        for bad_value in ("counterfact-preformative",
+                          "magpie:interfollicular"):
+
+            obj_metadata = {}
+            for header in self.ETAG_HEADERS.keys():
+
+                name = self.ETAG_HEADERS[header]["name"]
+                obj_metadata[name] = bad_value
+
+            mware.unmung_etags(obj_metadata, 0)
+            self.assertEqual(obj_metadata, {})
+
+    def test_best_possible_etag(self):
+        '''Test that best_possible_etag() returns the best ETag.
+        '''
+
+        # Start with metadata that consists of all possible ETag
+        # headers and verify that best_possible_headers() chooses the
+        # right ETag based on the circumstance.
+        obj_metadata = {}
+        for header in self.ETAG_HEADERS.keys():
+
+            name = self.ETAG_HEADERS[header]["name"]
+            value = self.ETAG_HEADERS[header]["value"]
+            obj_metadata[name] = value
+
+        # directories always return the same etag
+        etag = mware.best_possible_etag(obj_metadata, "AUTH_test", 42, 7,
+                                        is_dir=True)
+        self.assertEqual(etag, self.EMPTY_OBJECT_ETAG)
+
+        # a container listing should return the Container Listing Override ETag
+        etag = mware.best_possible_etag(obj_metadata, "AUTH_test", 42, 7,
+                                        container_listing=True)
+        self.assertEqual(etag,
+                         self.ETAG_HEADERS["LISTING_ETAG_OVERRIDE"]["value"])
+
+        # if its not a directory and its not a container list, then
+        # the function should return the original MD5 ETag (the
+        # S3API_ETAG is returned as a header, but not as an ETag).
+        etag = mware.best_possible_etag(obj_metadata, "AUTH_test", 42, 7)
+        self.assertEqual(etag,
+                         self.ETAG_HEADERS["ORIGINAL_MD5"]["value"])
+
+        # if none of the headers provide the correct ETag then
+        # best_possible_etag() will construct a unique one (which also
+        # should not be changed without handling "old data", i.e.
+        # its part of the "disk layout").
+        del obj_metadata[self.ETAG_HEADERS["ORIGINAL_MD5"]["name"]]
+
+        etag = mware.best_possible_etag(obj_metadata, "AUTH_test", 42, 7)
+        self.assertEqual(etag,
+                         '"pfsv2/AUTH_test/0000002A/00000007-32"')
 
 
 class TestProxyfsMethod(BaseMiddlewareTest):

--- a/pfsagentd/functional_test.go
+++ b/pfsagentd/functional_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestFunctional(t *testing.T) {
 	testSetup(t)
+	defer testTeardown(t)
+
 	time.Sleep(2 * time.Second) // TODO
-	testTeardown(t)
 }


### PR DESCRIPTION
Fix bugs with the COALESCE operation for static-large objects where it dropped the metadata (headers) associated with the operation on the floor and failed to return the correct modification time.

Lack of headers broke multipart-upload in the S3API because the new object lacked the ACL headers so it could not be accessed via S3API.  It also dropped the S3API and SLO ETag values on the floor, which meant the object did not return the correct ETag later.

First commit: store selected metadata associated with the operation.  Mung the ETag headers os the request values are returned until the object is modified via SMB or NFS, at which point the ProxyFS generated ETag is returned.

Second commit: return the correct modification time for the COALESCE operaiton.
