### PR TITLE
Fixed issues with duplicate bucketstats/transitions registrations

### DIFF
--- a/bucketstats/api_test.go
+++ b/bucketstats/api_test.go
@@ -87,15 +87,15 @@ func TestRegister(t *testing.T) {
 	// its also OK to unregister stats that don't exist
 	UnRegister("main", "neverStats")
 
-	// but registering it twice should panic
-	testFunc = func() {
-		Register("main", "myStats", &myStats)
-	}
-	panicStr = catchAPanic(testFunc)
-	if panicStr == "" {
-		t.Errorf("Register() of \"main\", \"myStats\" twice should have paniced")
-	}
-	UnRegister("main", "myStats")
+	// but registering it twice should panic... but, for now, will not
+	// testFunc = func() {
+	// 	Register("main", "myStats", &myStats)
+	// }
+	// panicStr = catchAPanic(testFunc)
+	// if panicStr == "" {
+	// 	t.Errorf("Register() of \"main\", \"myStats\" twice should have paniced")
+	// }
+	// UnRegister("main", "myStats")
 
 	// a statistics group must have at least one of package and group name
 	UnRegister("main", "myStats")

--- a/bucketstats/impl.go
+++ b/bucketstats/impl.go
@@ -90,7 +90,7 @@ func register(pkgName string, statsGroupName string, statsStruct interface{}) {
 		}
 		names[statNameValue.String()] = struct{}{}
 
-		// initialize the statistic (all fields are already zero)
+		// initialize the statistic (all fields are already zero - unless relaunched in test sequence)
 		switch v := (fieldAsValue.Addr().Interface()).(type) {
 		case *Total:
 		case *Average:
@@ -124,10 +124,12 @@ func register(pkgName string, statsGroupName string, statsStruct interface{}) {
 		pkgNameToGroupName[pkgName] = make(map[string]interface{})
 	}
 
-	if pkgNameToGroupName[pkgName][statsGroupName] != nil {
-		panic(fmt.Sprintf("pkgName '%s' with statsGroupName '%s' is already registered",
-			pkgName, statsGroupName))
-	}
+	// as tests might cause reregistrations, we need not check for pre-existence
+	// if pkgNameToGroupName[pkgName][statsGroupName] != nil {
+	// 	panic(fmt.Sprintf("pkgName '%s' with statsGroupName '%s' is already registered",
+	// 		pkgName, statsGroupName))
+	// }
+
 	pkgNameToGroupName[pkgName][statsGroupName] = statsStruct
 
 	return

--- a/proxyfsd/daemon.go
+++ b/proxyfsd/daemon.go
@@ -90,6 +90,7 @@ func Daemon(confFile string, confStrings []string, errChan chan error, wg *sync.
 		wg.Done()
 	}()
 
+	// TODO: This should be configurable (i.e. enable/disable... and which port#)
 	go func() {
 		logger.Infof("proxyfsd.Daemon() starting debug HTTP server: %s",
 			http.ListenAndServe("localhost:6060", nil))

--- a/trackedlock/config.go
+++ b/trackedlock/config.go
@@ -52,7 +52,7 @@ func parseConfMap(confMap conf.ConfMap) (err error) {
 // at the appropriate times and config changes.
 //
 func init() {
-	transitions.Register("swiftclient", &globals)
+	transitions.Register("trackedlock", &globals)
 }
 
 // Up() initializes the package.  It must be called and successfully return


### PR DESCRIPTION
Currently, all transitions registrations happen in init() func's for
each interested client package. These init() func's will be called
precisely once at process launch... before the main() func for the
program is called.

One issue was that a cut&paste error had two transitions registrations
cite the same package name. This was actually innocuous, as it turns out,
but I'd prefer to nevertheless detect this (as was previously done in
bucketstats registrations interestingly). So one change enforces such
uniqueness.

Meanwhile, bucketstats registrations are all made in interested client
package Up() func's... and a corresponding deregistration is made in
those packages' Down() func's. This is actually fine as Up() and Down()
callbacks should be precisely paired. However, there is also an assumption
in the bucketstats registration code that all stats start out zeroed.
This turns out not to be the case. Such an assumption is only guaranteed
at process launch. As such, it was possible... depending on events that
bucketstats captures during a run... for such assumptions to be violated.
This would have the effect similar to a package forgetting to call
the bucketstats deregistration func.

My work-around is to allow re-registrations... and note that bucketstats
are not necessarily starting out at zero.

A better fix would be to eliminate the deregistration in bucketstats and,
instead, move calls to the registration func to each interested client
package's init() func.

Why this is important is because several Go test sequences actually
cause a ProxyFS package stack subset to come Up() and Down() multiple
times breaking the "everything must have started out zeroed" assumption.
This was causing intermittent panic() calls during Make's "go test"
phase... now avoided.

I consider this a TODO to reach a conclusion on how we want this to
ultimately work but, for now, we will avoid these intermittent failures.