### PR TITLE
Fixed premature timeout awaiting test daemon startup

### DIFF
--- a/bucketstats/api_test.go
+++ b/bucketstats/api_test.go
@@ -87,15 +87,15 @@ func TestRegister(t *testing.T) {
 	// its also OK to unregister stats that don't exist
 	UnRegister("main", "neverStats")
 
-	// but registering it twice should panic... but, for now, will not
-	// testFunc = func() {
-	// 	Register("main", "myStats", &myStats)
-	// }
-	// panicStr = catchAPanic(testFunc)
-	// if panicStr == "" {
-	// 	t.Errorf("Register() of \"main\", \"myStats\" twice should have paniced")
-	// }
-	// UnRegister("main", "myStats")
+	// but registering it twice should panic
+	testFunc = func() {
+		Register("main", "myStats", &myStats)
+	}
+	panicStr = catchAPanic(testFunc)
+	if panicStr == "" {
+		t.Errorf("Register() of \"main\", \"myStats\" twice should have paniced")
+	}
+	UnRegister("main", "myStats")
 
 	// a statistics group must have at least one of package and group name
 	UnRegister("main", "myStats")

--- a/bucketstats/impl.go
+++ b/bucketstats/impl.go
@@ -124,11 +124,11 @@ func register(pkgName string, statsGroupName string, statsStruct interface{}) {
 		pkgNameToGroupName[pkgName] = make(map[string]interface{})
 	}
 
-	// as tests might cause reregistrations, we need not check for pre-existence
-	// if pkgNameToGroupName[pkgName][statsGroupName] != nil {
-	// 	panic(fmt.Sprintf("pkgName '%s' with statsGroupName '%s' is already registered",
-	// 		pkgName, statsGroupName))
-	// }
+	// check for pre-existence
+	if pkgNameToGroupName[pkgName][statsGroupName] != nil {
+		panic(fmt.Sprintf("pkgName '%s' with statsGroupName '%s' is already registered",
+			pkgName, statsGroupName))
+	}
 
 	pkgNameToGroupName[pkgName][statsGroupName] = statsStruct
 

--- a/pfsagentd/setup_teardown_test.go
+++ b/pfsagentd/setup_teardown_test.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	testDaemonStartPollInterval = 1 * time.Second
-	testDaemonStartPollLimit    = 5
 	testProxyFSDaemonHTTPPort   = "53461"
 	testProxyFSDaemonIPAddr     = "127.0.0.1"
 	testSwiftNoAuthIPAddr       = "127.0.0.1"
@@ -36,7 +35,6 @@ var testDaemonGlobals testDaemonGlobalsStruct
 
 func testSetup(t *testing.T) {
 	var (
-		daemonPollAttempt              uint32
 		err                            error
 		infoResponse                   *http.Response
 		ramswiftSignalHandlerIsArmedWG sync.WaitGroup
@@ -204,17 +202,12 @@ func testSetup(t *testing.T) {
 
 	ramswiftSignalHandlerIsArmedWG.Wait()
 
-	daemonPollAttempt = 0
-
 	for {
 		infoResponse, err = http.Get("http://" + testSwiftNoAuthIPAddr + ":" + testSwiftNoAuthPort + "/info")
 		if nil == err {
 			break
 		}
-		daemonPollAttempt++
-		if daemonPollAttempt == testDaemonStartPollLimit {
-			t.Fatalf("GET /info from ramswift.Daemon() failed to connect")
-		}
+
 		time.Sleep(testDaemonStartPollInterval)
 	}
 
@@ -231,17 +224,12 @@ func testSetup(t *testing.T) {
 		t.Fatalf("proxyfsd.Daemon() startup failed: %v", err)
 	}
 
-	daemonPollAttempt = 0
-
 	for {
 		versionResponse, err = http.Get("http://" + testProxyFSDaemonIPAddr + ":" + testProxyFSDaemonHTTPPort + "/version")
 		if nil == err {
 			break
 		}
-		daemonPollAttempt++
-		if daemonPollAttempt == testDaemonStartPollLimit {
-			t.Fatalf("GET /version from proxyfsd.Daemon() failed to connect")
-		}
+
 		time.Sleep(testDaemonStartPollInterval)
 	}
 

--- a/pfsagentd/swift_proxy_emulator_test.go
+++ b/pfsagentd/swift_proxy_emulator_test.go
@@ -33,7 +33,6 @@ var testSwiftProxyEmulatorGlobals testSwiftProxyEmulatorGlobalsStruct
 
 func startSwiftProxyEmulator(t *testing.T, confMap conf.ConfMap) {
 	var (
-		daemonPollAttempt        uint32
 		err                      error
 		infoResponse             *http.Response
 		jrpcServerIPAddr         string
@@ -106,17 +105,12 @@ func startSwiftProxyEmulator(t *testing.T, confMap conf.ConfMap) {
 		testSwiftProxyEmulatorGlobals.Done()
 	}()
 
-	daemonPollAttempt = 0
-
 	for {
 		infoResponse, err = http.Get("http://" + testSwiftProxyAddr + "/info")
 		if nil == err {
 			break
 		}
-		daemonPollAttempt++
-		if daemonPollAttempt == testDaemonStartPollLimit {
-			t.Fatalf("GET /info from ServeHTTP() failed to connect")
-		}
+
 		time.Sleep(testDaemonStartPollInterval)
 	}
 


### PR DESCRIPTION
Previous disabling of bucketstats.Register() duplicate test is now
unnecessary. What was happening is a testSetup() in e.g. pfsagentd
failed due to slow start of either ramswift or proxyfsd Daemon()
goroutines... leading to somehow skipping calls to Down() in e.g.
package swiftclient where bucketstats.UnRegister() would be called.
As such, the next test case would call testSetup() and re-launch
proxyfsd.Daemon() that would end up calling swiftclient.Up(). This
resulted in a subsequent bucketstatus.Register() call hitting the
panic. This change avoids that case (letting go test timeout instead)
so that a duplicate call to bucketstats.Register() should definitely
panic().