### PR TITLE
Change swiftclient retry timeouts and drop Timeout config variable.

### DIFF
--- a/proxyfsd/swift_client.conf
+++ b/proxyfsd/swift_client.conf
@@ -3,12 +3,11 @@
 [SwiftClient]
 NoAuthIPAddr:                 127.0.0.1
 NoAuthTCPPort:                8090
-Timeout:                      10s
-RetryLimit:                   10
-RetryLimitObject:             6
 RetryDelay:                   1s
-RetryDelayObject:             1s
 RetryExpBackoff:              1.4
-RetryExpBackoffObject:        2.0
+RetryLimit:                   12
+RetryDelayObject:             1s
+RetryLimitObject:             8
+RetryExpBackoffObject:        1.8
 ChunkedConnectionPoolSize:    512
 NonChunkedConnectionPoolSize: 128

--- a/swiftclient/config.go
+++ b/swiftclient/config.go
@@ -64,7 +64,6 @@ type requestFailureStatistic struct {
 type globalsStruct struct {
 	noAuthStringAddr                string
 	noAuthTCPAddr                   *net.TCPAddr
-	timeout                         time.Duration // TODO: Currently not enforced
 	retryLimit                      uint16        // maximum retries
 	retryLimitObject                uint16        // maximum retries for object ops
 	retryDelay                      time.Duration // delay before first retry
@@ -219,11 +218,6 @@ func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	globals.noAuthStringAddr = noAuthIPAddr + ":" + strconv.Itoa(int(noAuthTCPPort))
 
 	globals.noAuthTCPAddr, err = net.ResolveTCPAddr("tcp4", globals.noAuthStringAddr)
-	if nil != err {
-		return
-	}
-
-	globals.timeout, err = confMap.FetchOptionValueDuration("SwiftClient", "Timeout")
 	if nil != err {
 		return
 	}


### PR DESCRIPTION
Change the swiftclient retry times to match the values that i just
recommended to the controller (basically, wait upto ~139 sec for
an operation to complete).

Get rid of the requirement for the `swiftclientTimeout` variable, which
doesn't do anything, and delete it from the runway environment.