### PR TITLE
Bugfix swiftclient timeout2

### DIFF
--- a/proxyfsd/swift_client.conf
+++ b/proxyfsd/swift_client.conf
@@ -1,13 +1,26 @@
-# Swift description
-
+# swiftclient settings
+#
+# RetryDelay, RetryExpBackoff, RetryLimit control the behavior of
+# swiftclient when operations (GET, PUT, etc.) fail for a container or
+# object and RetryDelayObject, RetryLimitObject, RetryExpBackoffObject
+# control the behavior when operations fail for an object.
+#
+# RetryDelay is the time before the first retry; RetryLimit is the
+# maximum number of retries, and RetryExpBackoff is an exponential
+# backoff which is multiplied with the previous RetryDelay to
+# determine how long to wait for the second, third, fourth,
+# etc. retry.
 [SwiftClient]
 NoAuthIPAddr:                 127.0.0.1
 NoAuthTCPPort:                8090
+
 RetryDelay:                   1s
-RetryExpBackoff:              1.4
-RetryLimit:                   12
+RetryExpBackoff:              1.5
+RetryLimit:                   11
+
 RetryDelayObject:             1s
+RetryExpBackoffObject:        1.95
 RetryLimitObject:             8
-RetryExpBackoffObject:        1.8
+
 ChunkedConnectionPoolSize:    512
 NonChunkedConnectionPoolSize: 128

--- a/swiftclient/config.go
+++ b/swiftclient/config.go
@@ -189,6 +189,58 @@ func init() {
 	transitions.Register("swiftclient", &globals)
 }
 
+// Update the configuration variables that can be changed by sending proxyfs a
+// SIGHUP.  Note that others, like "SwiftClient.ChunkedConnectionPoolSize"
+// cannot currently be changed.
+//
+func (dummy *globalsStruct) reloadConfig(confMap conf.ConfMap) (err error) {
+
+	globals.retryLimit, err = confMap.FetchOptionValueUint16("SwiftClient", "RetryLimit")
+	if nil != err {
+		return
+	}
+	globals.retryLimitObject, err = confMap.FetchOptionValueUint16("SwiftClient", "RetryLimitObject")
+	if nil != err {
+		return
+	}
+
+	globals.retryDelay, err = confMap.FetchOptionValueDuration("SwiftClient", "RetryDelay")
+	if nil != err {
+		return
+	}
+	globals.retryDelayObject, err = confMap.FetchOptionValueDuration("SwiftClient", "RetryDelayObject")
+	if nil != err {
+		return
+	}
+
+	globals.retryExpBackoff, err = confMap.FetchOptionValueFloat64("SwiftClient", "RetryExpBackoff")
+	if nil != err {
+		return
+	}
+	globals.retryExpBackoffObject, err = confMap.FetchOptionValueFloat64("SwiftClient", "RetryExpBackoffObject")
+	if nil != err {
+		return
+	}
+	logger.Infof("SwiftClient.RetryLimit %d, SwiftClient.RetryDelay %4.3f sec, SwiftClient.RetryExpBackoff %2.1f",
+		globals.retryLimit, float64(globals.retryDelay)/float64(time.Second), globals.retryExpBackoff)
+	logger.Infof("SwiftClient.RetryLimitObject %d, SwiftClient.RetryDelayObject %4.3f sec, SwiftClient.RetryExpBackoffObject %2.1f",
+		globals.retryLimitObject, float64(globals.retryDelayObject)/float64(time.Second),
+		globals.retryExpBackoffObject)
+
+	globals.checksumChunkedPutChunks, err = confMap.FetchOptionValueBool("SwiftClient", "ChecksumChunkedPutChunks")
+	if nil != err {
+		err = nil
+		globals.checksumChunkedPutChunks = false
+	}
+	checksums := "disabled"
+	if globals.checksumChunkedPutChunks {
+		checksums = "enabled"
+	}
+	logger.Infof("SwiftClient.ChecksumChunkedPutChunks %s\n", checksums)
+
+	return
+}
+
 func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	var (
 		chunkedConnectionPoolSize    uint16
@@ -221,49 +273,6 @@ func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	if nil != err {
 		return
 	}
-
-	globals.retryLimit, err = confMap.FetchOptionValueUint16("SwiftClient", "RetryLimit")
-	if nil != err {
-		return
-	}
-	globals.retryLimitObject, err = confMap.FetchOptionValueUint16("SwiftClient", "RetryLimitObject")
-	if nil != err {
-		return
-	}
-
-	globals.retryDelay, err = confMap.FetchOptionValueDuration("SwiftClient", "RetryDelay")
-	if nil != err {
-		return
-	}
-	globals.retryDelayObject, err = confMap.FetchOptionValueDuration("SwiftClient", "RetryDelayObject")
-	if nil != err {
-		return
-	}
-
-	globals.retryExpBackoff, err = confMap.FetchOptionValueFloat64("SwiftClient", "RetryExpBackoff")
-	if nil != err {
-		return
-	}
-	globals.retryExpBackoffObject, err = confMap.FetchOptionValueFloat64("SwiftClient", "RetryExpBackoffObject")
-	if nil != err {
-		return
-	}
-	globals.checksumChunkedPutChunks, err = confMap.FetchOptionValueBool("SwiftClient", "ChecksumChunkedPutChunks")
-	if nil != err {
-		globals.checksumChunkedPutChunks = false
-	}
-
-	logger.Infof("SwiftClient.RetryLimit %d, SwiftClient.RetryDelay %4.3f sec, SwiftClient.RetryExpBackoff %2.1f",
-		globals.retryLimit, float64(globals.retryDelay)/float64(time.Second), globals.retryExpBackoff)
-	logger.Infof("SwiftClient.RetryLimitObject %d, SwiftClient.RetryDelayObject %4.3f sec, SwiftClient.RetryExpBackoffObject %2.1f",
-		globals.retryLimitObject, float64(globals.retryDelayObject)/float64(time.Second),
-		globals.retryExpBackoffObject)
-
-	checksums := "disabled"
-	if globals.checksumChunkedPutChunks {
-		checksums = "enabled"
-	}
-	logger.Infof("SwiftClient.ChecksumChunkedPutChunks %s\n", checksums)
 
 	globals.connectionNonce = 0
 
@@ -313,6 +322,9 @@ func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 
 	globals.maxIntAsUint64 = uint64(^uint(0) >> 1)
 
+	// load the configuration tunables that can be changed after boot
+	err = dummy.reloadConfig(confMap)
+
 	return
 }
 
@@ -344,7 +356,10 @@ func (dummy *globalsStruct) UnserveVolume(confMap conf.ConfMap, volumeName strin
 func (dummy *globalsStruct) SignaledStart(confMap conf.ConfMap) (err error) {
 	drainConnections()
 	globals.connectionNonce++
-	err = nil
+
+	// load the configuration tunables that can be changed after boot
+	err = dummy.reloadConfig(confMap)
+
 	return
 }
 

--- a/trackedlock/config.go
+++ b/trackedlock/config.go
@@ -41,6 +41,9 @@ func parseConfMap(confMap conf.ConfMap) (err error) {
 		globals.lockCheckPeriod = 0
 	}
 
+	logger.Infof("trackedlock pkg: LockHoldTimeLimit %d sec  LockCheckPeriod %d sec",
+		globals.lockHoldTimeLimit/time.Second, globals.lockCheckPeriod/time.Second)
+
 	// log information upto 16 locks
 	globals.lockWatcherLocksLogged = 16
 
@@ -67,9 +70,6 @@ func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 		// parseConfMap() has logged an error
 		return
 	}
-	logger.Infof("trackedlock.Up(): LockHoldTimeLimit %d sec  LockCheckPeriod %d sec",
-		globals.lockHoldTimeLimit/time.Second, globals.lockCheckPeriod/time.Second)
-
 	globals.mutexMap = make(map[*MutexTrack]interface{}, 128)
 	globals.rwMutexMap = make(map[*RWMutexTrack]interface{}, 128)
 	globals.stopChan = make(chan struct{})
@@ -125,7 +125,7 @@ func (dummy *globalsStruct) updateStateFromConfMap(confMap conf.ConfMap) (err er
 		return
 	}
 
-	logger.Infof("trackedlock lock hold time limit/lock check period changing from %d/%d sec to %d/%d sec",
+	logger.Infof("trackedlock pkg: LockHoldTimeLimit / LockCheckPeriod changed from %d/%d sec to %d/%d sec",
 		oldTimeLimit/time.Second, oldCheckPeriod/time.Second,
 		globals.lockHoldTimeLimit/time.Second, globals.lockCheckPeriod/time.Second)
 


### PR DESCRIPTION
Revise the retry timeouts so that a retry occurs shortly before the SMB client timeout at 120 sec, which should mean that we make an attempt to avoid the SMB client with just a few seconds to spare.