### PR TITLE
Add logging of all metrics/stats available via HTTP

### DIFF
--- a/pfsagentd/setup_teardown_test.go
+++ b/pfsagentd/setup_teardown_test.go
@@ -101,7 +101,8 @@ func testSetup(t *testing.T) {
 		"Stats.BufferLength=100",
 		"Stats.MaxLatency=1s",
 
-		"StatsLogger.Period=10m",
+		"StatsLogger.Period=0m",
+		"StatsLogger.Verbose=false",
 
 		"Logging.LogFilePath=/dev/null",
 		"Logging.LogToConsole=false",

--- a/proxyfsd/daemon_test.go
+++ b/proxyfsd/daemon_test.go
@@ -51,7 +51,8 @@ func TestDaemon(t *testing.T) {
 		"Stats.BufferLength=100",
 		"Stats.MaxLatency=1s",
 
-		"StatsLogger.Period=10m",
+		"StatsLogger.Period=0m",
+		"StatsLogger.Verbose=false",
 
 		"Logging.LogFilePath=/dev/null",
 		"Logging.LogToConsole=false",

--- a/proxyfsd/default.conf
+++ b/proxyfsd/default.conf
@@ -207,13 +207,14 @@ MaxLatency:   1s
 TCPPort:           15346
 JobHistoryMaxSize:     5
 
-[StatsLogger]
-
 # Write selected memory, connection, and Swift operation statistics
 # to the log once each Period. The minimum Period is 10 min.  Use
 # 0 to disable statistic logging.
 #
-Period: 10m
+# Verbose setting will dump all available stats each Period.
+[StatsLogger]
+Period:  10m
+Verbose: true
 
 # Debug-related parameters for proxyfs
 #

--- a/proxyfsd/statslogger.conf
+++ b/proxyfsd/statslogger.conf
@@ -1,7 +1,8 @@
-[StatsLogger]
-
 # Write selected memory, connection, and Swift operation statistics
 # to the log once each Period. The minimum Period is 10 min.  Use
 # 0 to disable statistic logging.
 #
-Period: 10m
+# Verbose setting will dump all available stats each Period.
+[StatsLogger]
+Period:  10m
+Verbose: true

--- a/statslogger/config_test.go
+++ b/statslogger/config_test.go
@@ -54,7 +54,8 @@ func TestAPI(t *testing.T) {
 		"Stats.BufferLength=100",
 		"Stats.MaxLatency=1s",
 
-		"StatsLogger.Period=0s",
+		"StatsLogger.Period=0m",
+		"StatsLogger.Verbose=false",
 
 		"SwiftClient.NoAuthIPAddr=127.0.0.1",
 		"SwiftClient.NoAuthTCPPort=9999",


### PR DESCRIPTION
"metrics" refers to those statistics tracked in package stats
"stats"   refers to those statistics tracked in package bucketstats

With the default interval for statslogger being 10 minutes,
this change also defaults that logging to "verbosely" include
the above metrics/stats. Of note, an idle system just booted
already has 307 lines added to the log each 10 minutes as a result.