### PR TITLE
Ensure we checkpoint on explicit flushes only

### DIFF
--- a/fs/api_internal.go
+++ b/fs/api_internal.go
@@ -521,6 +521,15 @@ func (mS *mountStruct) FetchExtentMapChunk(userID inode.InodeUserID, groupID ino
 	return
 }
 
+// doInlineCheckpointIfEnabled is called whenever we must guarantee that reported state changes
+// are, indeed, persisted. Absent any sort of persistent transaction log, this means performing
+// a checkpoint unfortunately.
+//
+// Currently, only explicitly invoked Flushes trigger this. But, actually, any Swift/S3 API call
+// that modifies Objects or (what the client thinks are) Containers should also.
+//
+// TODO is to determine where else a call to this func should also be made.
+//
 func (mS *mountStruct) doInlineCheckpointIfEnabled() {
 	var (
 		err error
@@ -4187,7 +4196,6 @@ func (mS *mountStruct) Wrote(userID inode.InodeUserID, groupID inode.InodeGroupI
 
 	err = mS.volStruct.inodeVolumeHandle.Flush(inodeNumber, false)
 	mS.volStruct.untrackInFlightFileInodeData(inodeNumber, false)
-	mS.doInlineCheckpointIfEnabled()
 
 	err = mS.volStruct.inodeVolumeHandle.Wrote(inodeNumber, objectPath, fileOffset, objectOffset, length, true)
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,17 @@
 # ProxyFS Release Notes
 
+## 1.12.2 (September 19, 2019)
+
+### Bug Fixes:
+
+Removed an unnecessary checkpoint performed before each PFSAgent
+RpcWrote operation that is generated as each LogSegment is PUT
+to Swift. The prior behavior put a strain on the checkpointing
+system when a large set of small files are uploaded via PFSAgent
+exposed FUSE mount points. Note that explicit flushes (fsync()
+or fdatasync() calls) will still trigger a checkpoint so that
+ProxyFS/PFSAgent can honor the request faithfully.
+
 ## 1.12.1 (September 12, 2019)
 
 ### Bug Fixes:


### PR DESCRIPTION
Previously, we were also calling doInlineCheckpointIfEnabled()
during fs.Wrote calls presumably thinking that this was often
in response to a Swift or S3 PUT request. However, that path
uses fs.MiddlewarePutComplete()... which did not call the
doInlineCheckpointIfEnabled() func btw.

Indeed, if that were the intent, then fully any Swift or S3
request that modifies contents of a BiModal Account should be
calling doInlineCheckpointIfEnabled() as well.

The decision on when/where else to call this func is left for
a more careful review. But the removal of the call from fs.Wrote()
is certainly fine as that API is used by those without RESTful
assumptions (e.g. PFSAgent).