### PR TITLE
SAIO uses old liberasure not supporting ec_duplication_factor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ build/
 dist/
 
 # Local FUSE Mount Point directories
+AgentMountPoint
 CommonMountPoint
-MountPoint0
 
 # Default etcd database
 default.etcd/

--- a/saio/etc/swift/swift.conf
+++ b/saio/etc/swift/swift.conf
@@ -24,6 +24,6 @@ ec_type = liberasurecode_rs_vand
 ec_num_data_fragments = 8
 ec_num_parity_fragments = 4
 ec_object_segment_size = 1048576
-ec_duplication_factor = 1
+# ec_duplication_factor = 1
 default = no
 deprecated = no


### PR DESCRIPTION
TOX tests fail with that key specified in swift.conf's storage
policy. A prior change switched from isa_l_rs_cauchy to
liberasurecode_rs_vand...which doesn't support ec_duplication_factor.