### PR TITLE
Added /metrics support in PFSAgent

### DIFF
--- a/httpserver/request_handler.go
+++ b/httpserver/request_handler.go
@@ -1833,7 +1833,7 @@ func sortedTwoColumnResponseWriter(llrb sortedmap.LLRBTree, responseWriter http.
 
 	lenLLRB, err = llrb.Len()
 	if nil != err {
-		err = fmt.Errorf("llrb.Len()) failed: %v", err)
+		err = fmt.Errorf("llrb.Len() failed: %v", err)
 		logger.Fatalf("HTTP Server Logic Error: %v", err)
 	}
 

--- a/pfsagentd/fuse.go
+++ b/pfsagentd/fuse.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -242,12 +243,15 @@ func serveFuse() {
 			handleWriteRequest(request.(*fuse.WriteRequest)) // See io.go
 		default:
 			// Bazil FUSE punted the not-understood opCode... so just reject it
+			_ = atomic.AddUint64(&globals.metrics.FUSE_UnknownRequest_calls, 1)
 			request.RespondError(fuse.ENOTSUP)
 		}
 	}
 }
 
 func handleAccessRequest(request *fuse.AccessRequest) {
+	_ = atomic.AddUint64(&globals.metrics.FUSE_AccessRequest_calls, 1)
+
 	logFatalf("handleAccessRequest() should not have been called due to DefaultPermissions() passed to fuse.Mount()")
 }
 
@@ -260,6 +264,8 @@ func handleCreateRequest(request *fuse.CreateRequest) {
 		createRequest          *jrpcfs.CreateRequest
 		response               *fuse.CreateResponse
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_CreateRequest_calls, 1)
 
 	createRequest = &jrpcfs.CreateRequest{
 		InodeHandle: jrpcfs.InodeHandle{
@@ -300,10 +306,14 @@ func handleCreateRequest(request *fuse.CreateRequest) {
 // that no subsequent upcalls will be made, this is not necessary.
 //
 func handleDestroyRequest(request *fuse.DestroyRequest) {
+	_ = atomic.AddUint64(&globals.metrics.FUSE_DestroyRequest_calls, 1)
+
 	request.Respond()
 }
 
 func handleExchangeDataRequest(request *fuse.ExchangeDataRequest) {
+	_ = atomic.AddUint64(&globals.metrics.FUSE_ExchangeDataRequest_calls, 1)
+
 	request.RespondError(fuse.ENOTSUP)
 }
 
@@ -316,6 +326,8 @@ func handleFlushRequest(request *fuse.FlushRequest) {
 		fileInode *fileInodeStruct
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_FlushRequest_calls, 1)
+
 	fileInode = referenceFileInode(inode.InodeNumber(request.Header.Node))
 	fileInode.doFlushIfNecessary()
 	fileInode.dereference()
@@ -327,6 +339,8 @@ func handleFlushRequest(request *fuse.FlushRequest) {
 // As the InodeCache is managed with its own eviction logic, this becomes a no-op.
 //
 func handleForgetRequest(request *fuse.ForgetRequest) {
+	_ = atomic.AddUint64(&globals.metrics.FUSE_ForgetRequest_calls, 1)
+
 	request.Respond()
 }
 
@@ -338,6 +352,8 @@ func handleFsyncRequest(request *fuse.FsyncRequest) {
 	var (
 		fileInode *fileInodeStruct
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_FsyncRequest_calls, 1)
 
 	fileInode = referenceFileInode(inode.InodeNumber(request.Header.Node))
 	fileInode.doFlushIfNecessary()
@@ -423,6 +439,8 @@ func handleGetattrRequest(request *fuse.GetattrRequest) {
 		response *fuse.GetattrResponse
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_GetattrRequest_calls, 1)
+
 	attr, err = getattrRequestHelper(request.Header.Node)
 	if nil != err {
 		request.RespondError(fuse.ENOENT)
@@ -443,6 +461,8 @@ func handleGetxattrRequest(request *fuse.GetxattrRequest) {
 		getXAttrRequest *jrpcfs.GetXAttrRequest
 		response        *fuse.GetxattrResponse
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_GetxattrRequest_calls, 1)
 
 	if (0 == request.Size) && (0 != request.Position) {
 		request.RespondError(fuse.ERANGE)
@@ -489,10 +509,14 @@ func handleGetxattrRequest(request *fuse.GetxattrRequest) {
 }
 
 func handleInitRequest(request *fuse.InitRequest) {
+	_ = atomic.AddUint64(&globals.metrics.FUSE_InitRequest_calls, 1)
+
 	logFatalf("handleInitRequest() should not have been called... fuse.Mount() supposedly took care of it")
 }
 
 func handleInterruptRequest(request *fuse.InterruptRequest) {
+	_ = atomic.AddUint64(&globals.metrics.FUSE_InterruptRequest_calls, 1)
+
 	request.RespondError(fuse.ENOTSUP)
 }
 
@@ -503,6 +527,8 @@ func handleLinkRequest(request *fuse.LinkRequest) {
 		linkRequest *jrpcfs.LinkRequest
 		response    *fuse.LookupResponse
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_LinkRequest_calls, 1)
 
 	linkRequest = &jrpcfs.LinkRequest{
 		InodeHandle: jrpcfs.InodeHandle{
@@ -546,6 +572,8 @@ func handleListxattrRequest(request *fuse.ListxattrRequest) {
 		listXAttrRequest *jrpcfs.ListXAttrRequest
 		response         *fuse.ListxattrResponse
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_ListxattrRequest_calls, 1)
 
 	if (0 == request.Size) && (0 != request.Position) {
 		request.RespondError(fuse.ERANGE)
@@ -680,6 +708,8 @@ func handleLookupRequest(request *fuse.LookupRequest) {
 		response *fuse.LookupResponse
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_LookupRequest_calls, 1)
+
 	response, err = lookupRequestHelper(request.Node, request.Name)
 	if nil != err {
 		request.RespondError(fuse.ENOENT)
@@ -697,6 +727,8 @@ func handleMkdirRequest(request *fuse.MkdirRequest) {
 		mkdirRequest           *jrpcfs.MkdirRequest
 		response               *fuse.MkdirResponse
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_MkdirRequest_calls, 1)
 
 	mkdirRequest = &jrpcfs.MkdirRequest{
 		InodeHandle: jrpcfs.InodeHandle{
@@ -731,6 +763,8 @@ func handleMkdirRequest(request *fuse.MkdirRequest) {
 }
 
 func handleMknodRequest(request *fuse.MknodRequest) {
+	_ = atomic.AddUint64(&globals.metrics.FUSE_MknodRequest_calls, 1)
+
 	request.RespondError(fuse.ENOTSUP)
 }
 
@@ -771,6 +805,8 @@ func handleOpenRequest(request *fuse.OpenRequest) {
 		response *fuse.OpenResponse
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_OpenRequest_calls, 1)
+
 	response = openRequestHelper(request.Node, request.Dir)
 
 	request.Respond(response)
@@ -791,6 +827,8 @@ func handleReadRequest(request *fuse.ReadRequest) {
 	)
 
 	if request.Dir {
+		_ = atomic.AddUint64(&globals.metrics.FUSE_ReadRequestDirInodeCase_calls, 1)
+
 		handle, ok = globals.handleTable[request.Handle]
 		if !ok {
 			request.RespondError(fuse.ESTALE)
@@ -862,6 +900,8 @@ func handleReadlinkRequest(request *fuse.ReadlinkRequest) {
 		readSymlinkRequest *jrpcfs.ReadSymlinkRequest
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_ReadlinkRequest_calls, 1)
+
 	readSymlinkRequest = &jrpcfs.ReadSymlinkRequest{
 		InodeHandle: jrpcfs.InodeHandle{
 			MountID:     globals.mountID,
@@ -885,6 +925,8 @@ func handleReleaseRequest(request *fuse.ReleaseRequest) {
 		fileInode *fileInodeStruct
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_ReleaseRequest_calls, 1)
+
 	if !request.Dir && (0 != (request.ReleaseFlags & fuse.ReleaseFlush)) {
 		fileInode = referenceFileInode(inode.InodeNumber(request.Header.Node))
 		fileInode.doFlushIfNecessary()
@@ -906,6 +948,8 @@ func handleRemoveRequest(request *fuse.RemoveRequest) {
 		unlinkReply   *jrpcfs.Reply
 		unlinkRequest *jrpcfs.UnlinkRequest
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_RemoveRequest_calls, 1)
 
 	unlinkRequest = &jrpcfs.UnlinkRequest{
 		InodeHandle: jrpcfs.InodeHandle{
@@ -938,6 +982,8 @@ func handleRemovexattrRequest(request *fuse.RemovexattrRequest) {
 		removeXAttrRequest *jrpcfs.RemoveXAttrRequest
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_RemovexattrRequest_calls, 1)
+
 	removeXAttrRequest = &jrpcfs.RemoveXAttrRequest{
 		InodeHandle: jrpcfs.InodeHandle{
 			MountID:     globals.mountID,
@@ -963,6 +1009,8 @@ func handleRenameRequest(request *fuse.RenameRequest) {
 		renameReply   *jrpcfs.Reply
 		renameRequest *jrpcfs.RenameRequest
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_RenameRequest_calls, 1)
 
 	renameRequest = &jrpcfs.RenameRequest{
 		MountID:           globals.mountID,
@@ -1007,6 +1055,8 @@ func handleSetattrRequest(request *fuse.SetattrRequest) {
 		settingUid             bool
 		timeNow                time.Time
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_SetattrRequest_calls, 1)
 
 	// TODO: Verify it is ok to accept but ignore fuse.SetattrHandle    in request.Valid
 	// TODO: Verify it is ok to accept but ignore fuse.SetattrLockOwner in request.Valid
@@ -1175,6 +1225,8 @@ func handleSetxattrRequest(request *fuse.SetxattrRequest) {
 		xattrReplacementIndex int
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_SetxattrRequest_calls, 1)
+
 	if 0 == request.Position {
 		attrValue = request.Xattr
 	} else {
@@ -1232,6 +1284,8 @@ func handleStatfsRequest(request *fuse.StatfsRequest) {
 		statVFSRequest *jrpcfs.StatVFSRequest
 	)
 
+	_ = atomic.AddUint64(&globals.metrics.FUSE_StatfsRequest_calls, 1)
+
 	statVFSRequest = &jrpcfs.StatVFSRequest{
 		MountID: globals.mountID,
 	}
@@ -1266,6 +1320,8 @@ func handleSymlinkRequest(request *fuse.SymlinkRequest) {
 		symlinkRequest         *jrpcfs.SymlinkRequest
 		response               *fuse.SymlinkResponse
 	)
+
+	_ = atomic.AddUint64(&globals.metrics.FUSE_SymlinkRequest_calls, 1)
 
 	symlinkRequest = &jrpcfs.SymlinkRequest{
 		InodeHandle: jrpcfs.InodeHandle{

--- a/pfsagentd/globals.go
+++ b/pfsagentd/globals.go
@@ -215,6 +215,54 @@ type logSegmentCacheElementStruct struct {
 	buf             []byte
 }
 
+// metricsStruct contains Prometheus-styled field names to be output by serveGetOfMetrics().
+//
+// In order to utilize Go Reflection, these field names must be capitalized (i.e. Global).
+
+type metricsStruct struct {
+	FUSE_AccessRequest_calls       uint64
+	FUSE_CreateRequest_calls       uint64
+	FUSE_DestroyRequest_calls      uint64
+	FUSE_ExchangeDataRequest_calls uint64
+	FUSE_FlushRequest_calls        uint64
+	FUSE_ForgetRequest_calls       uint64
+	FUSE_FsyncRequest_calls        uint64
+	FUSE_GetattrRequest_calls      uint64
+	FUSE_GetxattrRequest_calls     uint64
+	FUSE_InitRequest_calls         uint64
+	FUSE_InterruptRequest_calls    uint64
+	FUSE_LinkRequest_calls         uint64
+	FUSE_ListxattrRequest_calls    uint64
+	FUSE_LookupRequest_calls       uint64
+	FUSE_MkdirRequest_calls        uint64
+	FUSE_MknodRequest_calls        uint64
+	FUSE_OpenRequest_calls         uint64
+	FUSE_ReadlinkRequest_calls     uint64
+	FUSE_ReleaseRequest_calls      uint64
+	FUSE_RemoveRequest_calls       uint64
+	FUSE_RemovexattrRequest_calls  uint64
+	FUSE_RenameRequest_calls       uint64
+	FUSE_SetattrRequest_calls      uint64
+	FUSE_SetxattrRequest_calls     uint64
+	FUSE_StatfsRequest_calls       uint64
+	FUSE_SymlinkRequest_calls      uint64
+
+	FUSE_UnknownRequest_calls uint64
+
+	FUSE_ReadRequestDirInodeCase_calls  uint64
+	FUSE_ReadRequestFileInodeCase_calls uint64
+	FUSE_WriteRequest_calls             uint64
+
+	FUSE_ReadRequestFileInodeCase_bytes uint64
+	FUSE_WriteRequest_bytes             uint64
+
+	ReadCacheHits   uint64
+	ReadCacheMisses uint64
+
+	LogSegmentPUTs        uint64
+	LogSegmentPUTReadHits uint64
+}
+
 type globalsStruct struct {
 	sync.Mutex
 	config                          configStruct
@@ -240,6 +288,7 @@ type globalsStruct struct {
 	handleTable                     map[fuse.HandleID]*handleStruct
 	logSegmentCacheMap              map[logSegmentCacheElementKeyStruct]*logSegmentCacheElementStruct
 	logSegmentCacheLRU              *list.List // Front() is oldest logSegmentCacheElementStruct.cacheLRUElement
+	metrics                         *metricsStruct
 }
 
 var globals globalsStruct
@@ -507,6 +556,8 @@ func initializeGlobals(confMap conf.ConfMap) {
 
 	globals.logSegmentCacheMap = make(map[logSegmentCacheElementKeyStruct]*logSegmentCacheElementStruct)
 	globals.logSegmentCacheLRU = list.New()
+
+	globals.metrics = &metricsStruct{}
 }
 
 func uninitializeGlobals() {
@@ -542,4 +593,5 @@ func uninitializeGlobals() {
 	globals.handleTable = nil
 	globals.logSegmentCacheMap = nil
 	globals.logSegmentCacheLRU = nil
+	globals.metrics = nil
 }

--- a/pfsagentd/http_server.go
+++ b/pfsagentd/http_server.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
+	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
+
+	"github.com/swiftstack/sortedmap"
 
 	"github.com/swiftstack/ProxyFS/version"
 )
@@ -69,10 +75,169 @@ func serveGet(responseWriter http.ResponseWriter, request *http.Request) {
 	path = strings.TrimRight(request.URL.Path, "/")
 
 	switch path {
+	case "/metrics":
+		serveGetOfMetrics(responseWriter, request)
 	case "/version":
 		serveGetOfVersion(responseWriter, request)
 	default:
 		responseWriter.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func serveGetOfMetrics(responseWriter http.ResponseWriter, request *http.Request) {
+	var (
+		err                  error
+		format               string
+		i                    int
+		keyAsKey             sortedmap.Key
+		keyAsString          string
+		line                 string
+		longestKeyAsString   int
+		longestValueAsString int
+		memStats             runtime.MemStats
+		metricsFieldName     string
+		metricsFieldValuePtr *uint64
+		metricsLLRB          sortedmap.LLRBTree
+		metricsLLRBLen       int
+		metricsStructValue   reflect.Value
+		metricsValue         reflect.Value
+		ok                   bool
+		pauseNsAccumulator   uint64
+		valueAsString        string
+		valueAsValue         sortedmap.Value
+	)
+
+	runtime.ReadMemStats(&memStats)
+
+	metricsLLRB = sortedmap.NewLLRBTree(sortedmap.CompareString, nil)
+
+	// General statistics.
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_Alloc", memStats.Alloc)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_TotalAlloc", memStats.TotalAlloc)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_Sys", memStats.Sys)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_Lookups", memStats.Lookups)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_Mallocs", memStats.Mallocs)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_Frees", memStats.Frees)
+
+	// Main allocation heap statistics.
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_HeapAlloc", memStats.HeapAlloc)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_HeapSys", memStats.HeapSys)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_HeapIdle", memStats.HeapIdle)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_HeapInuse", memStats.HeapInuse)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_HeapReleased", memStats.HeapReleased)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_HeapObjects", memStats.HeapObjects)
+
+	// Low-level fixed-size structure allocator statistics.
+	//	Inuse is bytes used now.
+	//	Sys is bytes obtained from system.
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_StackInuse", memStats.StackInuse)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_StackSys", memStats.StackSys)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_MSpanInuse", memStats.MSpanInuse)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_MSpanSys", memStats.MSpanSys)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_MCacheInuse", memStats.MCacheInuse)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_MCacheSys", memStats.MCacheSys)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_BuckHashSys", memStats.BuckHashSys)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_GCSys", memStats.GCSys)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_OtherSys", memStats.OtherSys)
+
+	// Garbage collector statistics (fixed portion).
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_LastGC", memStats.LastGC)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_PauseTotalNs", memStats.PauseTotalNs)
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_NumGC", uint64(memStats.NumGC))
+	insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_GCCPUPercentage", uint64(100.0*memStats.GCCPUFraction))
+
+	// Garbage collector statistics (go_runtime_MemStats_PauseAverageNs).
+	if 0 == memStats.NumGC {
+		insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_PauseAverageNs", 0)
+	} else {
+		pauseNsAccumulator = 0
+		if memStats.NumGC < 255 {
+			for i = 0; i < int(memStats.NumGC); i++ {
+				pauseNsAccumulator += memStats.PauseNs[i]
+			}
+			insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_PauseAverageNs", pauseNsAccumulator/uint64(memStats.NumGC))
+		} else {
+			for i = 0; i < 256; i++ {
+				pauseNsAccumulator += memStats.PauseNs[i]
+			}
+			insertInMetricsLLRB(metricsLLRB, "go_runtime_MemStats_PauseAverageNs", pauseNsAccumulator/256)
+		}
+	}
+
+	// Add in locally generated metrics
+
+	metricsStructValue = reflect.Indirect(reflect.ValueOf(globals.metrics))
+	metricsValue = reflect.ValueOf(globals.metrics).Elem()
+
+	for i = 0; i < metricsStructValue.NumField(); i++ {
+		metricsFieldName = metricsStructValue.Type().Field(i).Name
+		metricsFieldValuePtr = metricsValue.Field(i).Addr().Interface().(*uint64)
+		insertInMetricsLLRB(metricsLLRB, metricsFieldName, atomic.LoadUint64(metricsFieldValuePtr))
+	}
+
+	// Produce sorted and column-aligned response
+
+	responseWriter.Header().Set("Content-Type", "text/plain")
+	responseWriter.WriteHeader(http.StatusOK)
+
+	metricsLLRBLen, err = metricsLLRB.Len()
+	if nil != err {
+		logFatalf("metricsLLRB.Len() failed: %v", err)
+	}
+
+	longestKeyAsString = 0
+	longestValueAsString = 0
+
+	for i = 0; i < metricsLLRBLen; i++ {
+		keyAsKey, valueAsValue, ok, err = metricsLLRB.GetByIndex(i)
+		if nil != err {
+			logFatalf("llrb.GetByIndex(%v) failed: %v", i, err)
+		}
+		if !ok {
+			logFatalf("llrb.GetByIndex(%v) returned ok == false", i)
+		}
+		keyAsString = keyAsKey.(string)
+		valueAsString = valueAsValue.(string)
+		if len(keyAsString) > longestKeyAsString {
+			longestKeyAsString = len(keyAsString)
+		}
+		if len(valueAsString) > longestValueAsString {
+			longestValueAsString = len(valueAsString)
+		}
+	}
+
+	format = fmt.Sprintf("%%-%vs %%%vs\n", longestKeyAsString, longestValueAsString)
+
+	for i = 0; i < metricsLLRBLen; i++ {
+		keyAsKey, valueAsValue, ok, err = metricsLLRB.GetByIndex(i)
+		if nil != err {
+			logFatalf("llrb.GetByIndex(%v) failed: %v", i, err)
+		}
+		if !ok {
+			logFatalf("llrb.GetByIndex(%v) returned ok == false", i)
+		}
+		keyAsString = keyAsKey.(string)
+		valueAsString = valueAsValue.(string)
+		line = fmt.Sprintf(format, keyAsString, valueAsString)
+		_, _ = responseWriter.Write([]byte(line))
+	}
+}
+
+func insertInMetricsLLRB(metricsLLRB sortedmap.LLRBTree, metricKey string, metricValueAsUint64 uint64) {
+	var (
+		err                 error
+		metricValueAsString string
+		ok                  bool
+	)
+
+	metricValueAsString = fmt.Sprintf("%v", metricValueAsUint64)
+
+	ok, err = metricsLLRB.Put(metricKey, metricValueAsString)
+	if nil != err {
+		logFatalf("metricsLLRB.Put(%v, %v) failed: %v", metricKey, metricValueAsString, err)
+	}
+	if !ok {
+		logFatalf("metricsLLRB.Put(%v, %v) returned ok == false", metricKey, metricValueAsString)
 	}
 }
 

--- a/stats/api_test.go
+++ b/stats/api_test.go
@@ -28,15 +28,6 @@ type testGlobalsStruct struct {
 
 var testGlobals testGlobalsStruct
 
-/*
-	useUDP           bool   //              Logically useTCP == !useUDP
-	udpLAddr         *net.UDPAddr
-	tcpLAddr         *net.TCPAddr
-	globals.ipAddr = "localhost" // Hard-coded since we only want to talk to the local StatsD
-		globals.udpLAddr, err = net.ResolveUDPAddr("udp", globals.ipAddr+":0")
-		globals.tcpLAddr, err = net.ResolveTCPAddr("tcp", globals.ipAddr+":0")
-*/
-
 func TestStatsAPIviaUDP(t *testing.T) {
 	var (
 		confMap     conf.ConfMap


### PR DESCRIPTION
Currently counts all FUSE upcalls.

Additionally for Reads:
  Counts bytes successfully read
  Counts # of ReadCache hits and misses
  Counts # of times the read is serviced from an unflushed LogSegment PUT

Additionally for Writes:
  Counts bytes successfully written