### PR TITLE
Change PFSAgent mount point path in Runway

### DIFF
--- a/cookbooks/proxyfs/files/default/usr/lib/systemd/system/pfsagentd.service
+++ b/cookbooks/proxyfs/files/default/usr/lib/systemd/system/pfsagentd.service
@@ -8,7 +8,7 @@ Environment=PATH=/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin:/bin
 # Set GOTRACEBACK=crash to allow core dumps to be created
 Environment=GOTRACEBACK=1
 LimitCORE=0
-ExecStart=/usr/bin/pfsagentd /etc/pfsagentd/pfsagent.conf
+ExecStart=/usr/bin/pfsagentd /etc/pfsagentd/pfsagent.conf Agent.FUSEMountPointPath=/mnt/pfsa_proxyfs_mount
 ExecReload=/usr/bin/kill -HUP $MAINPID
 
 Restart=always

--- a/cookbooks/proxyfs/recipes/default.rb
+++ b/cookbooks/proxyfs/recipes/default.rb
@@ -188,13 +188,6 @@ directory '/CommonMountPoint' do
   owner 'root'
 end
 
-directory '/AgentMountPoint' do
-  # perms/owner don't really matter since it gets mounted over, but
-  # this helps stop a developer from accidentally dumping stuff on the
-  # root filesystem
-  owner 'root'
-end
-
 directory '/var/lib/proxyfs' do
   mode '0755'
   owner proxyfs_user
@@ -444,6 +437,12 @@ execute "Create NFS mount point" do
   command "mkdir /mnt/nfs_proxyfs_mount"
   not_if { ::Dir.exists?("/mnt/nfs_proxyfs_mount") }
 end
+
+execute "Create PFSAgent mount point" do
+  command "mkdir /mnt/pfsa_proxyfs_mount"
+  not_if { ::Dir.exists?("/mnt/pfsa_proxyfs_mount") }
+end
+
 ruby_block "Create exports entry" do
   block do
     unless File.exist?("/etc/exports")


### PR DESCRIPTION
It used to be /AgentMountPoint and now it will be
/mnt/pfsa_proxyfs_mount to match what we do for SMB and NFS.