### PR TITLE
Fix bugs in confgen's search for templates.

### DIFF
--- a/confgen/api_internal.go
+++ b/confgen/api_internal.go
@@ -38,7 +38,7 @@ const (
 	vipsDirName           = "vips"                 // Used to hold a set of VirtualIPAddr-named subdirectories
 	proxyfsConfDir0       = "/usr/lib/proxyfsd"    // proxyfs conf files (includingtemplates directory) are here
 	proxyfsConfDir1       = "/opt/ss/lib/proxyfsd" // or here
-	proxyfsConfDir2       = "."                    // or relative to the current directory!
+	proxyfsConfDir2       = "./templates"          // or relative to the current directory!
 	//                                                where each holds files specific to that VirtualIPAddr
 )
 

--- a/confgen/template.go
+++ b/confgen/template.go
@@ -18,21 +18,20 @@ func createSMBConf(initialDirPath string, localVolumeGroupMap volumeGroupMap) (e
 	confDirs := []string{proxyfsConfDir0, proxyfsConfDir1, proxyfsConfDir2}
 	for _, proxyfsConfDir = range confDirs {
 
-		// if the directory has a parsable "templates/smb_globals.tmpl"
-		// then its the right one
-		_, err = template.ParseFiles(proxyfsConfDir + "/" + "templates/smb_globals.tmpl")
+		// if the directory has a "smb_globals.tmpl"
+		_, err = os.Stat(proxyfsConfDir + "/" + "smb_globals.tmpl")
 		if err == nil {
 			break
 		}
 	}
 	if err != nil {
-		fmt.Printf("Could not find '%s' in any of %v\n", "templates/smb_globals.tmpl", confDirs)
+		fmt.Printf("Could not find '%s' in any of %v\n", "smb_globals.tmpl", confDirs)
 		return
 	}
 
 	// Load the template for the global section of smb.conf
 	// from one of several possible locations
-	globalTplate, err := template.ParseFiles(proxyfsConfDir + "/" + "templates/smb_globals.tmpl")
+	globalTplate, err := template.ParseFiles(proxyfsConfDir + "/" + "smb_globals.tmpl")
 	if nil != err {
 
 		// TODO - log this appropriately
@@ -41,7 +40,7 @@ func createSMBConf(initialDirPath string, localVolumeGroupMap volumeGroupMap) (e
 	}
 
 	// Load the template for the share section of smb.conf
-	sharesTplate, err := template.ParseFiles("templates/smb_shares.tmpl")
+	sharesTplate, err := template.ParseFiles(proxyfsConfDir + "/" + "smb_shares.tmpl")
 	if nil != err {
 		// TODO - log this appropriately
 		fmt.Printf("Parse of template file returned err: %v\n", err)


### PR DESCRIPTION
confgen no longers adds "template/<filename>" to the possible
configuration directory and now just tries "<filename>" so it can find
files that happen to reside in, say, /opt/ss/var/lib/proxyfsd as opposed
to expecting /opt/ss/var/lib/proxyfsd/templates.

confgen now chooses the first directory where it can Stat() the
`smb_globals.tmpl` file, instead of the first directory where it can
find and successfully parse such a file.

if, for some reason, we have a template file that can't be parsed this
will make for clearer error messages.  with the old code it would just
say that the file can't be found.  with this change "can't be found"
and "can't be parsed" will generate separate errors.