### PR TITLE
Track the number of bytes and nodes for BTrees flushed to disk.

### DIFF
--- a/headhunter/config.go
+++ b/headhunter/config.go
@@ -53,6 +53,8 @@ type bPlusTreeWrapperStruct struct {
 	//                                            only valid for liveView... nil otherwise
 	//                                          For createdObjectsWrapper & deletedObjectsWrapper:
 	//                                            all volumeView's share the corresponding one created for liveView
+	totalPutNodes uint64 // each call to PutNode() increments this
+	totalPutBytes uint64 // each call to PutNode() adds the buffer size
 }
 
 type volumeViewStruct struct {
@@ -236,10 +238,13 @@ type globalsStruct struct {
 	PutCheckpointBytes                  bucketstats.BucketLog2Round
 	PutCheckpointInodeRecUsec           bucketstats.BucketLog2Round
 	PutCheckpointInodeRecBytes          bucketstats.BucketLog2Round
+	PutCheckpointInodeRecNodes          bucketstats.BucketLog2Round
 	PutCheckpointLogSegmentUsec         bucketstats.BucketLog2Round
 	PutCheckpointLogSegmentBytes        bucketstats.BucketLog2Round
+	PutCheckpointLogSegmentNodes        bucketstats.BucketLog2Round
 	PutCheckpointbPlusTreeObjectUsec    bucketstats.BucketLog2Round
 	PutCheckpointbPlusTreeObjectBytes   bucketstats.BucketLog2Round
+	PutCheckpointbPlusTreeObjectNodes   bucketstats.BucketLog2Round
 	PutCheckpointSnapshotFlushUsec      bucketstats.BucketLog2Round
 	PutCheckpointTreeLayoutUsec         bucketstats.BucketLog2Round
 	PutCheckpointTreeLayoutBytes        bucketstats.BucketLog2Round

--- a/headhunter/sortedmap_helper.go
+++ b/headhunter/sortedmap_helper.go
@@ -78,6 +78,10 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) PutNode(nodeByteSlice []byte) (o
 		ok        bool
 	)
 
+	// track data written
+	bPlusTreeWrapper.totalPutNodes++
+	bPlusTreeWrapper.totalPutBytes += uint64(len(nodeByteSlice))
+
 	err = bPlusTreeWrapper.volumeView.volume.openCheckpointChunkedPutContextIfNecessary()
 	if nil != err {
 		return
@@ -197,4 +201,13 @@ func (bPlusTreeWrapper *bPlusTreeWrapperStruct) UnpackValue(payloadData []byte) 
 	bytesConsumed = 8 + valueSize
 	err = nil
 	return
+}
+
+// ClearCounters clears the counters that track the number of bytes and number
+// of nodes passed to PutNode().
+//
+func (bPlusTreeWrapper *bPlusTreeWrapperStruct) ClearCounters() {
+
+	bPlusTreeWrapper.totalPutNodes = 0
+	bPlusTreeWrapper.totalPutBytes = 0
 }


### PR DESCRIPTION
This is the "PutNode() version" of tracking the amount of BPlusTree
data flushed to disk.  See what you think.

Fields are added to bPlusTreeWrapperStruct to track the number
of bytes and number of nodes that are flushed.

PutNode() is modified to add the figures for node being flushed to its
bPlusTreeWrapperStruct and a ClearCounters method is added to clear
the counters.

Code added to putCheckpoing() clears the counters for a tree, flushes
the tree, and then updates the values in the counters to bucketstats.