### PR TITLE
Bypass rpc

### DIFF
--- a/jrpcfs/api.go
+++ b/jrpcfs/api.go
@@ -165,6 +165,23 @@ import (
 type MountIDAsByteArray [16]byte
 type MountIDAsString string
 
+// BypassReply contains response to BypassReq
+type BypassReply struct {
+	// TODO - update all error vs result vs, etc
+	// want to include Result and Error???
+	ID     uint64      `json:"id"`
+	Result interface{} `json:"result"`
+	Error  string      `json:"error"`
+}
+
+// BypassReq tunnels file system RPCs from pfsagentd to proxyfsd
+type BypassReq struct {
+	JSONrpc string         `json:"jsonrpc"`
+	Method  string         `json:"method"`
+	ID      uint64         `json:"id"`
+	Params  [1]interface{} `json:"params"`
+}
+
 // InodeHandle is embedded in a number of the request objects.
 type InodeHandle struct {
 	MountID     MountIDAsString

--- a/jrpcfs/api.go
+++ b/jrpcfs/api.go
@@ -176,10 +176,10 @@ type BypassReply struct {
 
 // BypassReq tunnels file system RPCs from pfsagentd to proxyfsd
 type BypassReq struct {
-	JSONrpc string         `json:"jsonrpc"`
-	Method  string         `json:"method"`
-	ID      uint64         `json:"id"`
-	Params  [1]interface{} `json:"params"`
+	JSONrpc string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	ID      uint64 `json:"id"`
+	Params  []byte `json:"params"`
 }
 
 // InodeHandle is embedded in a number of the request objects.

--- a/jrpcfs/api.go
+++ b/jrpcfs/api.go
@@ -170,7 +170,7 @@ type BypassReply struct {
 	// TODO - update all error vs result vs, etc
 	// want to include Result and Error???
 	ID     uint64 `json:"id"`
-	Result []byte `json:"result"`
+	Result [1]interface{}
 	Error  string `json:"error"`
 }
 
@@ -179,7 +179,7 @@ type BypassReq struct {
 	JSONrpc string `json:"jsonrpc"`
 	Method  string `json:"method"`
 	ID      uint64 `json:"id"`
-	Params  []byte
+	Params  [1]interface{}
 }
 
 // InodeHandle is embedded in a number of the request objects.

--- a/jrpcfs/api.go
+++ b/jrpcfs/api.go
@@ -169,9 +169,9 @@ type MountIDAsString string
 type BypassReply struct {
 	// TODO - update all error vs result vs, etc
 	// want to include Result and Error???
-	ID     uint64      `json:"id"`
-	Result interface{} `json:"result"`
-	Error  string      `json:"error"`
+	ID     uint64 `json:"id"`
+	Result []byte `json:"result"`
+	Error  string `json:"error"`
 }
 
 // BypassReq tunnels file system RPCs from pfsagentd to proxyfsd
@@ -179,7 +179,7 @@ type BypassReq struct {
 	JSONrpc string `json:"jsonrpc"`
 	Method  string `json:"method"`
 	ID      uint64 `json:"id"`
-	Params  []byte `json:"params"`
+	Params  []byte
 }
 
 // InodeHandle is embedded in a number of the request objects.

--- a/jrpcfs/bypass_test.go
+++ b/jrpcfs/bypass_test.go
@@ -2,6 +2,7 @@ package jrpcfs
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,45 +14,51 @@ func TestRpcBypass(t *testing.T) {
 	testBasicRpcBypass(t, s)
 }
 
-// testMarshal will marshal the RPC request into the RpcBypass request
 // TODO - move to API???
-func testBypassMarshal(requestMethod string, request interface{}) (requestID uint64, bypassReq *BypassReq, marshalErr error) {
-	var (
-		dummyRequestID uint64 = 1
-		jsonReq        []byte
-	)
+func bypassMarshalReq(requestMethod string, ID uint64, tunnelReq interface{}) (bypassReq *BypassReq, err error) {
 
-	// Convert the tunneled request to JSON and save in bypass request
-	jsonReq, marshalErr = json.Marshal(request)
-
+	// Create request struct and convert tunnelReq to JSON
 	// TODO - need mount ID???
 	bypassReq = &BypassReq{
 		JSONrpc: "2.0",
 		Method:  requestMethod,
-		ID:      dummyRequestID,
-		Params:  jsonReq,
+		ID:      ID,
 	}
+
+	// Convert the tunneled request to JSON and save in bypass Params
+	bypassReq.Params, err = json.Marshal(tunnelReq)
 
 	return
 }
 
 // testBasicRpcBypass tests the bypass RPC
 func testBasicRpcBypass(t *testing.T, server *Server) {
+	var (
+		dummyRequestID uint64 = 1
+	)
+
 	assert := assert.New(t)
 
-	// Create a RpcPing request and tunnel via RpcBypass
-	pingReply := &PingReply{}
-	_, bypassReq, marshalErr := testBypassMarshal("Server.RpcPing", pingReply)
-	if nil != marshalErr {
-		/*
-			logFatalf("unable to marshal request (jrpcMethod=%s jrpcParam=%v): %#v", jrpcSwiftProxyBypassRequest.jrpcMethod, jrpcSwiftProxyBypassRequest.jrpcParam, marshalErr)
-		*/
+	// Create a RpcPing request
+	pingReq := &PingReq{
+		Message: "TestMessage",
 	}
 
-	response := BypassReply{}
-	err := server.RpcBypass(bypassReq, &response)
+	// Create bypass request
+	bypassReq, marshalErr := bypassMarshalReq("Server.RpcPing", dummyRequestID, pingReq)
+	assert.Nil(marshalErr)
 
-	// TODO - verify the results with assert
-
+	// Send the bypass request
+	bypassReply := BypassReply{}
+	err := server.RpcBypass(bypassReq, &bypassReply)
 	assert.Nil(err)
+
+	// Unmarshal reply to bypass request
+	var pingReply PingReply
+	err = json.Unmarshal(bypassReply.Result, &pingReply)
+	assert.Nil(err)
+
+	// Verify the results with assert
+	x := fmt.Sprintf("pong %d bytes", len(pingReq.Message))
+	assert.Equal(x, pingReply.Message)
 }

--- a/jrpcfs/bypass_test.go
+++ b/jrpcfs/bypass_test.go
@@ -1,7 +1,6 @@
 package jrpcfs
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -25,8 +24,7 @@ func bypassMarshalReq(requestMethod string, ID uint64, tunnelReq interface{}) (b
 		ID:      ID,
 	}
 
-	// Convert the tunneled request to JSON and save in bypass Params
-	bypassReq.Params, err = json.Marshal(tunnelReq)
+	bypassReq.Params[0] = tunnelReq
 
 	return
 }
@@ -40,7 +38,7 @@ func testBasicRpcBypass(t *testing.T, server *Server) {
 	assert := assert.New(t)
 
 	// Create a RpcPing request
-	pingReq := &PingReq{
+	pingReq := PingReq{
 		Message: "TestMessage",
 	}
 
@@ -54,9 +52,7 @@ func testBasicRpcBypass(t *testing.T, server *Server) {
 	assert.Nil(err)
 
 	// Unmarshal reply to bypass request
-	var pingReply PingReply
-	err = json.Unmarshal(bypassReply.Result, &pingReply)
-	assert.Nil(err)
+	pingReply := bypassReply.Result[0].(PingReply)
 
 	// Verify the results with assert
 	x := fmt.Sprintf("pong %d bytes", len(pingReq.Message))

--- a/jrpcfs/bypass_test.go
+++ b/jrpcfs/bypass_test.go
@@ -1,0 +1,57 @@
+package jrpcfs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRpcBypass(t *testing.T) {
+	s := &Server{}
+
+	testBasicRpcBypass(t, s)
+}
+
+// testMarshal will marshal the RPC request into the RpcBypass request
+// TODO - move to API???
+func testBypassMarshal(requestMethod string, request interface{}) (requestID uint64, bypassReq *BypassReq, marshalErr error) {
+	var (
+		dummyRequestID uint64 = 1
+		jsonReq        []byte
+	)
+
+	// Convert the tunneled request to JSON and save in bypass request
+	jsonReq, marshalErr = json.Marshal(request)
+
+	// TODO - need mount ID???
+	bypassReq = &BypassReq{
+		JSONrpc: "2.0",
+		Method:  requestMethod,
+		ID:      dummyRequestID,
+		Params:  [1]interface{}{jsonReq},
+	}
+
+	return
+}
+
+// testBasicRpcBypass tests the bypass RPC
+func testBasicRpcBypass(t *testing.T, server *Server) {
+	assert := assert.New(t)
+
+	// Create a RpcPing request and tunnel via RpcBypass
+	pingReply := &PingReply{}
+	_, bypassReq, marshalErr := testBypassMarshal("Server.RpcPing", pingReply)
+	if nil != marshalErr {
+		/*
+			logFatalf("unable to marshal request (jrpcMethod=%s jrpcParam=%v): %#v", jrpcSwiftProxyBypassRequest.jrpcMethod, jrpcSwiftProxyBypassRequest.jrpcParam, marshalErr)
+		*/
+	}
+
+	response := BypassReply{}
+	err := server.RpcBypass(bypassReq, &response)
+
+	// TODO - verify the results with assert
+
+	assert.Nil(err)
+}

--- a/jrpcfs/bypass_test.go
+++ b/jrpcfs/bypass_test.go
@@ -29,7 +29,7 @@ func testBypassMarshal(requestMethod string, request interface{}) (requestID uin
 		JSONrpc: "2.0",
 		Method:  requestMethod,
 		ID:      dummyRequestID,
-		Params:  [1]interface{}{jsonReq},
+		Params:  jsonReq,
 	}
 
 	return

--- a/jrpcfs/filesystem.go
+++ b/jrpcfs/filesystem.go
@@ -4,7 +4,6 @@ package jrpcfs
 import (
 	"container/list"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/rpc"
@@ -2164,8 +2163,7 @@ func (s *Server) RpcSnapShotLookupByName(in *SnapShotLookupByNameRequest, reply 
 	return
 }
 
-func bypassUnmarshal(params interface{}) (req interface{}, err error) {
-	tunReq, mErr := json.Unmarshal(params)
+func bypassUnmarshal(params []byte) (req interface{}, err error) {
 	/*
 		var (
 			braceDepth      uint32
@@ -2183,7 +2181,10 @@ func bypassUnmarshal(params interface{}) (req interface{}, err error) {
 		insideString = false
 		nextByteEscaped = false
 	*/
-	fmt.Printf("bypassUnmarshal() params: %v\n", params)
+	fmt.Printf("bypassUnmarshal() params: %v\n", string(params))
+
+	// TODO - do loop below to figure out method and then unmarshal to
+	// appropriate reques type
 
 	/*
 		jrpcReadBuf = []byte(params)
@@ -2233,6 +2234,7 @@ func (s *Server) RpcBypass(in *BypassReq, reply *BypassReply) (err error) {
 	fmt.Printf("RpcBypass() - show original message!!! req.Params: %+v\n", string(in.Params))
 
 	// TODO - make function unmarshal() or something like that....
+	// Know method already so know structure to Unmarshal() into....
 	tunReq, bypassErr := bypassUnmarshal(in.Params)
 	if bypassErr != nil {
 		// TODO - log?
@@ -2240,13 +2242,14 @@ func (s *Server) RpcBypass(in *BypassReq, reply *BypassReply) (err error) {
 	}
 
 	// TODO - call the RPC
-	fmt.Printf("Tunnedled request is: %v\n", tunReq)
+	fmt.Printf("Tunneled request is: %v\n", tunReq)
 
 	// TODO - return results in reply
 	// marshal() result
 	// return results to caller...
 
 	/*
+		// Return results of tunneled request to caller
 		reply.SnapShot, ok = headhunterVolumeHandle.SnapShotLookupByName(in.Name)
 		if ok {
 			err = nil

--- a/jrpcfs/filesystem.go
+++ b/jrpcfs/filesystem.go
@@ -2166,32 +2166,258 @@ func (s *Server) RpcSnapShotLookupByName(in *SnapShotLookupByNameRequest, reply 
 // RpcBypass tunnels RPCs from pfsagent to proxyfsd
 func (s *Server) RpcBypass(breq *BypassReq, breply *BypassReply) (err error) {
 
-	// Break out the original RPC request
+	// TODO - how handle RpcMount?
+
 	// TODO - way to avoid strcmp() and just use type?
+	// assume not since can you guarantee that "type" has same value on two different systems?
+
+	breply.ID = breq.ID
+
 	switch breq.Method {
+	case "Server.RpcChmod":
+		q := breq.Params[0].(ChmodRequest)
+		p := Reply{}
+		err = s.RpcChmod(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcChown":
+		q := breq.Params[0].(ChownRequest)
+		p := Reply{}
+		err = s.RpcChown(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcCreate":
+		q := breq.Params[0].(CreateRequest)
+		// TODO - which is correct? p := Reply{}
+		p := InodeReply{}
+		err = s.RpcCreate(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcFetchExtentMapChunk":
+		q := breq.Params[0].(FetchExtentMapChunkRequest)
+		p := FetchExtentMapChunkReply{}
+		err = s.RpcFetchExtentMapChunk(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcGetStat":
+		q := breq.Params[0].(GetStatRequest)
+		p := StatStruct{}
+		err = s.RpcGetStat(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcGetXAttr":
+		q := breq.Params[0].(GetXAttrRequest)
+		p := GetXAttrReply{}
+		err = s.RpcGetXAttr(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcLink":
+		q := breq.Params[0].(LinkRequest)
+		p := Reply{}
+		err = s.RpcLink(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcListXAttr":
+		q := breq.Params[0].(ListXAttrRequest)
+		p := ListXAttrReply{}
+		err = s.RpcListXAttr(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcLookup":
+		q := breq.Params[0].(LookupRequest)
+		p := InodeReply{}
+		err = s.RpcLookup(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcMkdir":
+		q := breq.Params[0].(MkdirRequest)
+		// TODO - which is correct? p := Reply{}
+		p := InodeReply{}
+		err = s.RpcMkdir(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcMountByAccountName":
+		// TODO - how do this?  Need this?
+
 	case "Server.RpcPing":
-		var (
-			req   PingReq
-			reply PingReply
-		)
-		fmt.Printf("RpcBypass() - show original message!!! breq.Params: %+v\n", breq.Params[0].(PingReq))
-
-		breply.ID = breq.ID
-
-		// Pull out the RpcPing parameters
-		req = breq.Params[0].(PingReq)
+		q := breq.Params[0].(PingReq)
+		p := PingReply{}
+		err = s.RpcPing(&q, &p)
 		if err != nil {
 			breply.Error = err.Error()
 			return
 		}
+		breply.Result[0] = p
 
-		// Execute RpcPing and marshal the results
-		err = s.RpcPing(&req, &reply)
+	case "Server.RpcProvisionObject":
+		q := breq.Params[0].(ProvisionObjectRequest)
+		p := ProvisionObjectReply{}
+		err = s.RpcProvisionObject(&q, &p)
 		if err != nil {
 			breply.Error = err.Error()
 			return
 		}
-		breply.Result[0] = reply
+		breply.Result[0] = p
+
+	case "Server.RpcReadSymlink":
+		q := breq.Params[0].(ReadSymlinkRequest)
+		p := ReadSymlinkReply{}
+		err = s.RpcReadSymlink(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcReaddirByLoc":
+		q := breq.Params[0].(ReaddirByLocRequest)
+		p := ReaddirReply{}
+		err = s.RpcReaddirByLoc(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcRemoveXAttr":
+		q := breq.Params[0].(RemoveXAttrRequest)
+		p := Reply{}
+		err = s.RpcRemoveXAttr(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcRename":
+		q := breq.Params[0].(RenameRequest)
+		p := Reply{}
+		err = s.RpcRename(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcResize":
+		q := breq.Params[0].(ResizeRequest)
+		p := Reply{}
+		err = s.RpcResize(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcRmdir":
+		q := breq.Params[0].(UnlinkRequest)
+		p := Reply{}
+		err = s.RpcRmdir(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcSetTime":
+		q := breq.Params[0].(SetTimeRequest)
+		p := Reply{}
+		err = s.RpcSetTime(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcSetXAttr":
+		q := breq.Params[0].(SetXAttrRequest)
+		p := Reply{}
+		err = s.RpcSetXAttr(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcStatVFS":
+		q := breq.Params[0].(StatVFSRequest)
+		p := StatVFS{}
+		err = s.RpcStatVFS(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcSymlink":
+		q := breq.Params[0].(SymlinkRequest)
+		p := Reply{}
+		err = s.RpcSymlink(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcUnlink":
+		q := breq.Params[0].(UnlinkRequest)
+		p := Reply{}
+		err = s.RpcUnlink(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
+
+	case "Server.RpcWrote":
+		q := breq.Params[0].(WroteRequest)
+		p := WroteReply{}
+		err = s.RpcWrote(&q, &p)
+		if err != nil {
+			breply.Error = err.Error()
+			return
+		}
+		breply.Result[0] = p
 
 	default:
 		fmt.Printf("Invalid tunnel request method: %v\n", breq.Method)

--- a/jrpcfs/filesystem.go
+++ b/jrpcfs/filesystem.go
@@ -4,6 +4,7 @@ package jrpcfs
 import (
 	"container/list"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/rpc"
@@ -2159,6 +2160,100 @@ func (s *Server) RpcSnapShotLookupByName(in *SnapShotLookupByNameRequest, reply 
 	} else {
 		err = blunder.NewError(blunder.NotFoundError, "ENOENT")
 	}
+
+	return
+}
+
+func bypassUnmarshal(params interface{}) (req interface{}, err error) {
+	tunReq, mErr := json.Unmarshal(params)
+	/*
+		var (
+			braceDepth      uint32
+			insideString    bool
+			jrpcReadBuf     []byte
+			jrpcReadByte    byte
+			jrpcReadBufPos  int
+			nextByteEscaped bool
+			numBytesRead    int
+		)
+	*/
+
+	/*
+		braceDepth = 0
+		insideString = false
+		nextByteEscaped = false
+	*/
+	fmt.Printf("bypassUnmarshal() params: %v\n", params)
+
+	/*
+		jrpcReadBuf = []byte(params)
+			for jrpcReadBufPos = 0; jrpcReadBufPos < numBytesRead; jrpcReadBufPos++ {
+				jrpcReadByte = jrpcReadBuf[jrpcReadBufPos]
+				jrpcReq = append(jrpcReq, jrpcReadByte)
+				if insideString {
+					if nextByteEscaped {
+						nextByteEscaped = false
+					} else if '\\' == jrpcReadByte {
+						nextByteEscaped = true
+					} else if '"' == jrpcReadByte {
+						insideString = false
+					} else {
+						// No change to any state
+					}
+				} else {
+					if '{' == jrpcReadByte {
+						braceDepth++
+					} else if '}' == jrpcReadByte {
+						if 0 == braceDepth {
+							logFatalf("malformed JSONRPC 2.0 received... closing brace with no opening brace")
+						} else {
+							braceDepth--
+							if 0 == braceDepth {
+								globals.jrpcSwiftProxyBypassResponseChan <- jrpcReq
+								jrpcReq = make([]byte, 0)
+							}
+						}
+					} else if '"' == jrpcReadByte {
+						insideString = true
+					} else {
+						// No change to any state
+					}
+				}
+			}
+	*/
+
+	return
+}
+
+// RpcBypass tunnels RPCs from pfsagent to proxyfsd
+func (s *Server) RpcBypass(in *BypassReq, reply *BypassReply) (err error) {
+
+	// Break out the original RPC request
+	fmt.Printf("RpcBypass() - show original message!!! req: %+v\n", in)
+	fmt.Printf("RpcBypass() - show original message!!! req.Params: %+v\n", string(in.Params))
+
+	// TODO - make function unmarshal() or something like that....
+	tunReq, bypassErr := bypassUnmarshal(in.Params)
+	if bypassErr != nil {
+		// TODO - log?
+		return bypassErr
+	}
+
+	// TODO - call the RPC
+	fmt.Printf("Tunnedled request is: %v\n", tunReq)
+
+	// TODO - return results in reply
+	// marshal() result
+	// return results to caller...
+
+	/*
+		reply.SnapShot, ok = headhunterVolumeHandle.SnapShotLookupByName(in.Name)
+		if ok {
+			err = nil
+		} else {
+			err = blunder.NewError(blunder.NotFoundError, "ENOENT")
+		}
+	*/
 
 	return
 }

--- a/jrpcfs/filesystem.go
+++ b/jrpcfs/filesystem.go
@@ -4,7 +4,6 @@ package jrpcfs
 import (
 	"container/list"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/rpc"
@@ -2168,19 +2167,19 @@ func (s *Server) RpcSnapShotLookupByName(in *SnapShotLookupByNameRequest, reply 
 func (s *Server) RpcBypass(breq *BypassReq, breply *BypassReply) (err error) {
 
 	// Break out the original RPC request
-	fmt.Printf("RpcBypass() - show original message!!! breq.Params: %+v\n", string(breq.Params))
-
+	// TODO - way to avoid strcmp() and just use type?
 	switch breq.Method {
 	case "Server.RpcPing":
 		var (
 			req   PingReq
 			reply PingReply
 		)
+		fmt.Printf("RpcBypass() - show original message!!! breq.Params: %+v\n", breq.Params[0].(PingReq))
 
 		breply.ID = breq.ID
 
 		// Pull out the RpcPing parameters
-		err = json.Unmarshal(breq.Params, &req)
+		req = breq.Params[0].(PingReq)
 		if err != nil {
 			breply.Error = err.Error()
 			return
@@ -2192,11 +2191,8 @@ func (s *Server) RpcBypass(breq *BypassReq, breply *BypassReply) (err error) {
 			breply.Error = err.Error()
 			return
 		}
-		breply.Result, err = json.Marshal(reply)
-		if err != nil {
-			breply.Error = err.Error()
-			return
-		}
+		breply.Result[0] = reply
+
 	default:
 		fmt.Printf("Invalid tunnel request method: %v\n", breq.Method)
 	}


### PR DESCRIPTION
Bypass RPC which tunnels metadata operations to proxyfsd.

Eventually, this RPC will be "hardended" to handle lost connections and retries as well as TLS