### PR TITLE
PFSAgent's ReadCache eviction logic fix

### DIFF
--- a/pfsagentd/io.go
+++ b/pfsagentd/io.go
@@ -1551,6 +1551,7 @@ func fetchLogSegmentCacheLine(containerName string, objectName string, offset ui
 		logSegmentCacheElementToEvictLRUElement = globals.logSegmentCacheLRU.Front()
 		logSegmentCacheElementToEvict = logSegmentCacheElementToEvictLRUElement.Value.(*logSegmentCacheElementStruct)
 		logSegmentCacheElementToEvictKey.logSegmentNumber, err = strconv.ParseUint(logSegmentCacheElementToEvict.objectName, 16, 64)
+		logSegmentCacheElementToEvictKey.cacheLineTag = logSegmentCacheElementToEvict.startingOffset / globals.config.ReadCacheLineSize
 		if nil != err {
 			logFatalf("fetchLogSegmentCacheLine() evicting hit un-parseable objectName: \"%s\" (err: %v)", logSegmentCacheElementToEvict.objectName, err)
 		}


### PR DESCRIPTION
For files larger than a single cache line (e.g. 1MiB), the tag in the
ReadCache was always (the LogSegment# and) a startingOffset-derived tag
of zero... meaning that we weren't actually evicting any cache lines
caching LogSegment portions beyond the first cache line (e.g. beyond 1MiB).