### PR TITLE
Fixes for IP addresses with netmask.

### DIFF
--- a/confgen/template.go
+++ b/confgen/template.go
@@ -48,7 +48,7 @@ func createSMBConf(initialDirPath string, localVolumeGroupMap volumeGroupMap) (e
 	}
 
 	for _, volumeGroup = range localVolumeGroupMap {
-		vipDirPath = initialDirPath + "/" + vipsDirName + "/" + volumeGroup.VirtualIPAddr
+		vipDirPath = initialDirPath + "/" + vipsDirName + "/" + volumeGroup.VirtualIPAddr.String()
 
 		err = os.Mkdir(vipDirPath, confDirPerm)
 		if nil != err {

--- a/liveness/config.go
+++ b/liveness/config.go
@@ -597,10 +597,19 @@ func (dummy *globalsStruct) SignaledFinish(confMap conf.ConfMap) (err error) {
 				if "" == virtualIPAddr {
 					volumeGroup.virtualIPAddr = globals.myPublicIPAddr
 				} else {
+
+					// virtualIPAddr must be a valid IP address or valid
+					// IP address in CIDR notation
 					volumeGroup.virtualIPAddr = net.ParseIP(virtualIPAddr)
 					if nil == volumeGroup.virtualIPAddr {
-						err = fmt.Errorf("Cannot parse [VolumeGroup:%v]VirtualIPAddr", volumeGroupName)
-						return
+
+						volumeGroup.virtualIPAddr, _, err = net.ParseCIDR(virtualIPAddr)
+						if err != nil {
+							err = fmt.Errorf("Cannot parse [VolumeGroup:%v]VirtualIPAddr: '%s' "+
+								" as IP address or CIDR IP address: %v",
+								volumeGroupName, virtualIPAddr, err)
+							return
+						}
 					}
 				}
 
@@ -627,10 +636,19 @@ func (dummy *globalsStruct) SignaledFinish(confMap conf.ConfMap) (err error) {
 				if "" == virtualIPAddr {
 					volumeGroup.virtualIPAddr = peer.publicIPAddr
 				} else {
+
+					// virtualIPAddr must be a valid IP address or valid
+					// IP address in CIDR notation
 					volumeGroup.virtualIPAddr = net.ParseIP(virtualIPAddr)
 					if nil == volumeGroup.virtualIPAddr {
-						err = fmt.Errorf("Cannot parse [VolumeGroup:%v]VirtualIPAddr", volumeGroupName)
-						return
+
+						volumeGroup.virtualIPAddr, _, err = net.ParseCIDR(virtualIPAddr)
+						if err != nil {
+							err = fmt.Errorf("Cannot parse [VolumeGroup:%v]VirtualIPAddr: '%s' "+
+								" as IP address or CIDR IP address: %v",
+								volumeGroupName, virtualIPAddr, err)
+							return
+						}
 					}
 				}
 


### PR DESCRIPTION
Change confgen to parse VirutalIpAddr using net.ParseCIDR() to require
a valid CIDR notation IP address and fail the config push otherwise.
It also produces the IP address used for the virtual IP address directory
name in canonical form (in case it wasn't).  (For some reason this
doesn't affect what gets written in ProxyFS config files.)

Changed Proxyfs so it accepts the IP address for VirtualIPAddr in CIDR
form (with a netmask) and without.  Eventually we will figure out where
CIDR is required and where its not, and enforce that, but for now this
should fix the bug that caused ProxyFS to choke on CIDR notation.