### PR TITLE
Close server sockets to clients before waiting for goroutines to finish

### DIFF
--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -109,6 +109,9 @@ func (server *Server) Close() {
 	}
 
 	server.listenersWG.Wait()
+
+	// Now close the client sockets to wakeup our blocked readers
+	server.closeClientConn()
 	server.goroutineWG.Wait()
 
 	server.Lock()


### PR DESCRIPTION
The server has goroutines reading requests from the clients.

During shutdown of the server, these sockets must be closed so that the
goroutines return and the server can shutdown.