### PR TITLE
Return errors from RPCs

### DIFF
--- a/jrpcfs/retryrpc.go
+++ b/jrpcfs/retryrpc.go
@@ -8,16 +8,13 @@ import (
 	"github.com/swiftstack/ProxyFS/retryrpc"
 )
 
-func retryRPCServerUp(jserver *Server, ipAddr string, portString string) {
+func retryRPCServerUp(jserver *Server, ipAddr string, portString string, completedTTL time.Duration) {
 	var err error
 
 	port, _ := strconv.Atoi(portString)
 
-	// Create a new RetryRPC Server.  Completed request will live on
-	// completedRequests for 5 seconds.
-
-	// TODO - 10 minutes should be configurable
-	rrSvr := retryrpc.NewServer(10*time.Minute, ipAddr, port)
+	// Create a new RetryRPC Server.
+	rrSvr := retryrpc.NewServer(completedTTL, ipAddr, port)
 
 	// Register jrpcsfs methods with the retryrpc server
 	err = rrSvr.Register(jserver)

--- a/proxyfsd/rpc_server.conf
+++ b/proxyfsd/rpc_server.conf
@@ -3,6 +3,7 @@
 [JSONRPCServer]
 TCPPort:         12345
 FastTCPPort:     32345
-RetryRPCPort:    32356
 DataPathLogging: false
 Debug:           false
+RetryRPCPort:    32356
+RetryRPCTTLCompleted: 10m

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -98,15 +98,15 @@ type jsonRequest struct {
 
 // jsonReply is used to marshal an RPC response in/out of JSON
 type jsonReply struct {
-	MyUniqueID string `json:"myuniqueid"` // ID of client
-	RequestID  uint64 `json:"requestid"`  // ID of this request
-	Err        error  `json:"err"`
-	// TODO - include errno too?
-	Result interface{} `json:"result"`
+	MyUniqueID string      `json:"myuniqueid"` // ID of client
+	RequestID  uint64      `json:"requestid"`  // ID of this request
+	ErrStr     string      `json:"errstr"`
+	Result     interface{} `json:"result"`
 }
 
 // svrRequest is used with jsonRequest when we unmarshal the
-// parameters passed in an RPC
+// parameters passed in an RPC.  This is how we get the rpcReply
+// structure specific to the RPC
 type svrRequest struct {
 	Params [1]interface{} `json:"params"`
 }

--- a/retryrpc/rpctest/Makefile
+++ b/retryrpc/rpctest/Makefile
@@ -1,0 +1,3 @@
+gosubdir := github.com/swiftstack/ProxyFS/retryrpc/rpctest
+
+include ../../GoMakefile

--- a/retryrpc/rpctest/api.go
+++ b/retryrpc/rpctest/api.go
@@ -1,0 +1,24 @@
+package rpctest
+
+// rcptest is a set of RPC methods used to test retryrpc
+
+import ()
+
+// PingReq is the request object for RpcPing
+type PingReq struct {
+	Message string
+}
+
+// PingReply is the response object for RpcPutLocation
+type PingReply struct {
+	Message string
+}
+
+type Server struct{}
+
+// NewServer creates the Server object and returns the pointer
+func NewServer() *Server {
+	s := Server{}
+
+	return &s
+}

--- a/retryrpc/rpctest/ping.go
+++ b/retryrpc/rpctest/ping.go
@@ -1,0 +1,29 @@
+package rpctest
+
+// Simple ping for testing the RPC layer
+import (
+	"fmt"
+
+	"github.com/swiftstack/ProxyFS/blunder"
+)
+
+func encodeErrno(e *error) {
+	if *e != nil {
+		*e = fmt.Errorf("errno: %d", blunder.Errno(*e))
+	}
+}
+
+// RpcPing simply does a len on the message path and returns the result
+func (s *Server) RpcPing(in *PingReq, reply *PingReply) (err error) {
+
+	reply.Message = fmt.Sprintf("pong %d bytes", len(in.Message))
+	return nil
+}
+
+// RpcPingWithError returns an error
+func (s *Server) RpcPingWithError(in *PingReq, reply *PingReply) (err error) {
+	err = blunder.AddError(err, blunder.NotFoundError)
+	encodeErrno(&err)
+	reply.Message = fmt.Sprintf("pong %d bytes", len(in.Message))
+	return err
+}


### PR DESCRIPTION
Return errors from RPCs in our legacy format

Also, add tunable for how long completed requests live on the queue in
the server.

Move unit test to retryrpc and add new rpctest package which has RPCs for testing.