### PR TITLE
Don't panic if invalid method name is passed

### DIFF
--- a/retryrpc/retryrpc_test.go
+++ b/retryrpc/retryrpc_test.go
@@ -96,6 +96,15 @@ func testServer(t *testing.T) {
 	assert.Equal(0, rrSvr.PendingCnt())
 	assert.Equal(2, rrSvr.CompletedCnt())
 
+	// Send an RPC which should return an error
+	pingRequest = &rpctest.PingReq{Message: "Ping Me!"}
+	pingReply = &rpctest.PingReply{}
+	sendErr = rrClnt.Send("RpcInvalidMethod", pingRequest, pingReply)
+	assert.NotNil(sendErr)
+
+	assert.Equal(0, rrSvr.PendingCnt())
+	assert.Equal(3, rrSvr.CompletedCnt())
+
 	// Stop the client before exiting
 	rrClnt.Close()
 


### PR DESCRIPTION
Return errors from RPCs in our legacy format

Also, add tunable for how long completed requests live on the queue in
the server.

Move unit test to retryrpc and add new rpctest package which has RPCs for testing.