### PR TITLE
Adaptive server per client

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 507cdad2b107171995114d3f71bff50fe13b93076c4a6b97fbe87432461c96cf
-updated: 2020-01-14T14:33:57.074303-08:00
+hash: 085caff19534031af680c5b253a3fe45a1ea1e875080fb2f8e5703b3445ccf5c
+updated: 2020-02-06T15:28:21.145919-08:00
 imports:
 - name: bazil.org/fuse
   version: 371fbbdaa8987b715bdd21d6adc4c9b20155f748
@@ -36,8 +36,12 @@ imports:
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
+- name: github.com/google/btree
+  version: 4030bb1f1f0c35b30ca7009e9ebd06849dd45306
 - name: github.com/google/uuid
   version: c2e93f3ae59f2904160ceaab466009f965df46d6
+- name: github.com/konsorten/go-windows-terminal-sequences
+  version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
 - name: github.com/pkg/profile
   version: 5b67d428864e92711fcbd2f8629456121a56d91f
 - name: github.com/sirupsen/logrus

--- a/glide.yaml
+++ b/glide.yaml
@@ -151,6 +151,8 @@ import:
   - stats
   - status
   - tap
+- package: github.com/google/btree
+  version: ~1.0.0
 testImport:
 - package: github.com/davecgh/go-spew
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9

--- a/jrpcfs/config.go
+++ b/jrpcfs/config.go
@@ -26,6 +26,7 @@ type globalsStruct struct {
 	fastPortString           string
 	retryRPCPort             uint16
 	retryRPCTTLCompleted     time.Duration
+	retryRPCAckTrim          time.Duration
 	rootCAx509CertificatePEM []byte
 	dataPathLogging          bool
 
@@ -102,6 +103,11 @@ func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 			logger.ErrorfWithError(err, "failed to get JSONRPCServer.RetryRPCTTLCompleted from config file")
 			return
 		}
+		globals.retryRPCAckTrim, err = confMap.FetchOptionValueDuration("JSONRPCServer", "RetryRPCAckTrim")
+		if nil != err {
+			logger.ErrorfWithError(err, "failed to get JSONRPCServer.RetryRPCAckTrim from config file")
+			return
+		}
 	} else {
 		logger.Infof("failed to get JSONRPCServer.RetryRPCPort from config file - skipping......")
 		globals.retryRPCPort = 0
@@ -135,7 +141,7 @@ func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 	ioServerUp(globals.privateIPAddr, globals.fastPortString)
 
 	// Init Retry RPC server
-	retryRPCServerUp(jserver, globals.publicIPAddr, globals.retryRPCPort, globals.retryRPCTTLCompleted)
+	retryRPCServerUp(jserver, globals.publicIPAddr, globals.retryRPCPort, globals.retryRPCTTLCompleted, globals.retryRPCAckTrim)
 
 	return
 }

--- a/jrpcfs/middleware_test.go
+++ b/jrpcfs/middleware_test.go
@@ -152,6 +152,7 @@ func testSetup() []func() {
 		"JSONRPCServer.FastTCPPort=32346",  // ...and similarly here...
 		"JSONRPCServer.RetryRPCPort=32357", // ...and similarly here...
 		"JSONRPCServer.RetryRPCTTLCompleted=10s",
+		"JSONRPCServer.RetryRPCAckTrim=10ms",
 		"JSONRPCServer.DataPathLogging=false",
 	}
 

--- a/jrpcfs/retryrpc.go
+++ b/jrpcfs/retryrpc.go
@@ -7,7 +7,7 @@ import (
 	"github.com/swiftstack/ProxyFS/retryrpc"
 )
 
-func retryRPCServerUp(jserver *Server, publicIPAddr string, retryRPCPort uint16, retryRPCTTLCompleted time.Duration) {
+func retryRPCServerUp(jserver *Server, publicIPAddr string, retryRPCPort uint16, retryRPCTTLCompleted time.Duration, retryRPCAckTrim time.Duration) {
 	var err error
 
 	if globals.retryRPCPort == 0 {
@@ -15,7 +15,7 @@ func retryRPCServerUp(jserver *Server, publicIPAddr string, retryRPCPort uint16,
 	}
 
 	// Create a new RetryRPC Server.
-	rrSvr := retryrpc.NewServer(retryRPCTTLCompleted, publicIPAddr, int(retryRPCPort))
+	rrSvr := retryrpc.NewServer(retryRPCTTLCompleted, retryRPCAckTrim, publicIPAddr, int(retryRPCPort))
 
 	// Register jrpcsfs methods with the retryrpc server
 	err = rrSvr.Register(jserver)

--- a/pfsagentd/request.go
+++ b/pfsagentd/request.go
@@ -43,7 +43,7 @@ func doMountProxyFS() {
 
 	globals.retryRPCClient, err = retryrpc.NewClient(string(globals.mountID), globals.retryRPCPublicIPAddr, int(globals.retryRPCPort), globals.rootCAx509CertificatePEM)
 	if nil != err {
-		logFatalf("unable to retryRPCClient.NewClient(%v,%v): %v", globals.retryRPCPublicIPAddr, globals.retryRPCPort, globals.config.SwiftAccountName, err)
+		logFatalf("unable to retryRPCClient.NewClient(%v,%v): SwiftAccountName: %v err: %v", globals.retryRPCPublicIPAddr, globals.retryRPCPort, globals.config.SwiftAccountName, err)
 	}
 }
 

--- a/pfsagentd/setup_teardown_test.go
+++ b/pfsagentd/setup_teardown_test.go
@@ -210,6 +210,7 @@ func testSetup(t *testing.T) {
 		"JSONRPCServer.FastTCPPort=32346",  // ...and similarly here...
 		"JSONRPCServer.RetryRPCPort=32357", // ...and similarly here...
 		"JSONRPCServer.RetryRPCTTLCompleted=10s",
+		"JSONRPCServer.RetryRPCAckTrim=10ms",
 		"JSONRPCServer.DataPathLogging=false",
 	}
 

--- a/proxyfsd/rpc_server.conf
+++ b/proxyfsd/rpc_server.conf
@@ -7,3 +7,4 @@ DataPathLogging:      false
 Debug:                false
 RetryRPCPort:         32356
 RetryRPCTTLCompleted:   10m
+RetryRPCAckTrim:   100ms

--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -153,15 +153,6 @@ func (server *Server) Close() {
 	server.closeClientConn()
 	server.goroutineWG.Wait()
 
-	/*
-			server.Lock()
-			x := len(server.pendingRequest)
-			server.Unlock()
-		if x != 0 {
-			logger.Errorf("pendingRequest count is: %v when should be zero", x)
-		}
-	*/
-
 	server.completedLongTicker.Stop()
 	server.completedShortTicker.Stop()
 	server.completedTickerDone <- true
@@ -186,21 +177,21 @@ func (server *Server) CloseClientConn() {
 // CompletedCnt returns count of pendingRequests
 //
 // This is only useful for testing.
-func (server *Server) CompletedCnt() int {
-	/*
-		return len(server.completedRequest)
-	*/
-	return 0
+func (server *Server) CompletedCnt() (totalCnt int) {
+	for _, v := range server.perUniqueIDInfo {
+		totalCnt += v.completedCnt()
+	}
+	return
 }
 
 // PendingCnt returns count of pendingRequests
 //
 // This is only useful for testing.
-func (server *Server) PendingCnt() int {
-	/*
-		return len(server.pendingRequest)
-	*/
-	return 0
+func (server *Server) PendingCnt() (totalCnt int) {
+	for _, v := range server.perUniqueIDInfo {
+		totalCnt += v.pendingCnt()
+	}
+	return
 }
 
 // Client methods

--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -48,7 +48,7 @@ type Server struct {
 	Creds                *ServerCreds
 	listenersWG          sync.WaitGroup
 	receiver             reflect.Value            // Package receiver being served
-	perUniqueIDInfo      map[string]*myUniqueInfo // Key: "MyUniqueID"
+	perUniqueIDInfo      map[string]*myUniqueInfo // Key: "MyUniqueID".  Tracks clients
 	completedTickerDone  chan bool
 	completedLongTicker  *time.Ticker // Longer ~10 minute timer to trim
 	completedShortTicker *time.Ticker // Shorter ~100ms timer to trim known completed
@@ -119,11 +119,9 @@ func (server *Server) Start() (err error) {
 				server.completedDoneWG.Done()
 				return
 			case tl := <-server.completedLongTicker.C:
-				server.trimCompleted(tl)
-				/*
-					case ts := <-server.completedShortTicker.C:
-						server.trimAlreadAcked(ts)
-				*/
+				server.trimCompleted(tl, true)
+			case ts := <-server.completedShortTicker.C:
+				server.trimCompleted(ts, false)
 			}
 		}
 	}()

--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -218,12 +218,12 @@ type connectionTracker struct {
 type Client struct {
 	sync.Mutex
 	halting          bool
-	currentRequestID uint64 // Last request ID - start from clock
+	currentRequestID requestID // Last request ID - start from clock
 	// tick at mount and increment from there?
 	// Handle reset of time?
 	connection         connectionTracker
-	myUniqueID         string             // Unique ID across all clients
-	outstandingRequest map[uint64]*reqCtx // Map of outstanding requests sent
+	myUniqueID         string                // Unique ID across all clients
+	outstandingRequest map[requestID]*reqCtx // Map of outstanding requests sent
 	// or to be sent to server.  Key is assigned from currentRequestID
 	highestConsecutive requestID // Highest requestID that can be
 	// trimmed
@@ -247,7 +247,7 @@ func NewClient(myUniqueID string, ipaddr string, port int, rootCAx509Certificate
 	portStr := fmt.Sprintf("%d", port)
 	client.connection.state = INITIAL
 	client.connection.hostPortStr = net.JoinHostPort(ipaddr, portStr)
-	client.outstandingRequest = make(map[uint64]*reqCtx)
+	client.outstandingRequest = make(map[requestID]*reqCtx)
 	client.connection.x509CertPool = x509.NewCertPool()
 	client.bt = btree.New(2)
 

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -39,7 +39,7 @@ type requestID uint64
 
 // Server side data structure storing per client information
 // such as completed requests, etc
-type myUniqueInfo struct {
+type clientInfo struct {
 	sync.Mutex
 	pendingRequest           map[requestID]*pendingCtx     // Key: "RequestID"
 	completedRequest         map[requestID]*completedEntry // Key: "RequestID"

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -107,7 +107,7 @@ type reqCtx struct {
 // jsonRequest is used to marshal an RPC request in/out of JSON
 type jsonRequest struct {
 	MyUniqueID string         `json:"myuniqueid"` // ID of client
-	RequestID  uint64         `json:"requestid"`  // ID of this request
+	RequestID  requestID      `json:"requestid"`  // ID of this request
 	Method     string         `json:"method"`
 	Params     [1]interface{} `json:"params"`
 }
@@ -115,7 +115,7 @@ type jsonRequest struct {
 // jsonReply is used to marshal an RPC response in/out of JSON
 type jsonReply struct {
 	MyUniqueID string      `json:"myuniqueid"` // ID of client
-	RequestID  uint64      `json:"requestid"`  // ID of this request
+	RequestID  requestID   `json:"requestid"`  // ID of this request
 	ErrStr     string      `json:"errstr"`
 	Result     interface{} `json:"result"`
 }

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -41,10 +41,16 @@ type requestID uint64
 // such as completed requests, etc
 type myUniqueInfo struct {
 	sync.Mutex
-	pendingRequest      map[string]*pendingCtx // Key: "MyUniqueID:RequestID"
-	completedRequest    map[string]*ioReply    // Key: "MyUniqueID:RequestID"
-	completedRequestLRU *list.List             // LRU used to remove completed request in ticker
-	highestReplySeen    requestID              // Highest consectutive requestID client has seen
+	pendingRequest           map[requestID]*pendingCtx     // Key: "RequestID"
+	completedRequest         map[requestID]*completedEntry // Key: "RequestID"
+	completedRequestLRU      *list.List                    // LRU used to remove completed request in ticker
+	highestReplySeen         requestID                     // Highest consectutive requestID client has seen
+	previousHighestReplySeen requestID                     // Previous highest consectutive requestID client has seen
+}
+
+type completedEntry struct {
+	reply   *ioReply
+	lruElem *list.Element
 }
 
 // connCtx tracks a conn which has been accepted.
@@ -74,7 +80,7 @@ type methodArgs struct {
 // completedLRUEntry tracks time entry was completed for
 // expiration from cache
 type completedLRUEntry struct {
-	queueKey      string
+	requestID     requestID
 	timeCompleted time.Time
 }
 

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -34,6 +34,8 @@ const (
 	currentRetryVersion = 1
 )
 
+type requestID uint64
+
 // connCtx tracks a conn which has been accepted.
 //
 // It also contains the lock used for serialization when

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -56,6 +56,8 @@ func (client *Client) send(method string, rpcRequest interface{}, rpcReply inter
 	// Setup ioreq to write structure on socket to server
 	ioreq, err := buildIoRequest(method, jreq)
 	if err != nil {
+		e := fmt.Errorf("Client buildIoRequest returned err: %v", err)
+		logger.PanicfWithError(e, "")
 		return err
 	}
 

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -38,7 +38,7 @@ func (client *Client) send(method string, rpcRequest interface{}, rpcReply inter
 	}
 
 	// Put request data into structure to be be marshaled into JSON
-	jreq := jsonRequest{Method: method}
+	jreq := jsonRequest{Method: method, HighestReplySeen: client.highestConsecutive}
 	jreq.Params[0] = rpcRequest
 	jreq.MyUniqueID = client.myUniqueID
 

--- a/retryrpc/client_tracking.go
+++ b/retryrpc/client_tracking.go
@@ -25,3 +25,11 @@ func (mui *myUniqueInfo) isEmpty() bool {
 	}
 	return false
 }
+
+func (mui *myUniqueInfo) completedCnt() int {
+	return len(mui.completedRequest)
+}
+
+func (mui *myUniqueInfo) pendingCnt() int {
+	return len(mui.pendingRequest)
+}

--- a/retryrpc/client_tracking.go
+++ b/retryrpc/client_tracking.go
@@ -3,33 +3,33 @@ package retryrpc
 // This file contains functions in the server which
 // keep track of clients.
 
-func (mui *myUniqueInfo) buildAndQPendingCtx(rID requestID, buf []byte, cCtx *connCtx, lockHeld bool) {
+func (ci *clientInfo) buildAndQPendingCtx(rID requestID, buf []byte, cCtx *connCtx, lockHeld bool) {
 	pc := &pendingCtx{buf: buf, cCtx: cCtx}
 
 	if lockHeld == false {
-		mui.Lock()
+		ci.Lock()
 	}
 
-	mui.pendingRequest[rID] = pc
+	ci.pendingRequest[rID] = pc
 
 	if lockHeld == false {
-		mui.Unlock()
+		ci.Unlock()
 	}
 }
 
-// NOTE: This function assumes mui Lock is held
-func (mui *myUniqueInfo) isEmpty() bool {
-	if len(mui.completedRequest) == 0 &&
-		len(mui.pendingRequest) == 0 {
+// NOTE: This function assumes ci Lock is held
+func (ci *clientInfo) isEmpty() bool {
+	if len(ci.completedRequest) == 0 &&
+		len(ci.pendingRequest) == 0 {
 		return true
 	}
 	return false
 }
 
-func (mui *myUniqueInfo) completedCnt() int {
-	return len(mui.completedRequest)
+func (ci *clientInfo) completedCnt() int {
+	return len(ci.completedRequest)
 }
 
-func (mui *myUniqueInfo) pendingCnt() int {
-	return len(mui.pendingRequest)
+func (ci *clientInfo) pendingCnt() int {
+	return len(ci.pendingRequest)
 }

--- a/retryrpc/client_tracking.go
+++ b/retryrpc/client_tracking.go
@@ -1,0 +1,27 @@
+package retryrpc
+
+// This file contains functions in the server which
+// keep track of clients.
+
+func (mui *myUniqueInfo) buildAndQPendingCtx(rID requestID, buf []byte, cCtx *connCtx, lockHeld bool) {
+	pc := &pendingCtx{buf: buf, cCtx: cCtx}
+
+	if lockHeld == false {
+		mui.Lock()
+	}
+
+	mui.pendingRequest[rID] = pc
+
+	if lockHeld == false {
+		mui.Unlock()
+	}
+}
+
+// NOTE: This function assumes mui Lock is held
+func (mui *myUniqueInfo) isEmpty() bool {
+	if len(mui.completedRequest) == 0 &&
+		len(mui.pendingRequest) == 0 {
+		return true
+	}
+	return false
+}

--- a/retryrpc/retryrpc_test.go
+++ b/retryrpc/retryrpc_test.go
@@ -47,7 +47,7 @@ func getNewServer() (rrSvr *Server, ip string, p int) {
 
 	// Create a new RetryRPC Server.  Completed request will live on
 	// completedRequests for 10 seconds.
-	rrSvr = NewServer(10*time.Second, ipaddr, port)
+	rrSvr = NewServer(10*time.Second, 100*time.Millisecond, ipaddr, port)
 	ip = ipaddr
 	p = port
 	return
@@ -101,6 +101,10 @@ func testServer(t *testing.T) {
 
 	assert.Equal(0, rrSvr.PendingCnt())
 	assert.Equal(2, rrSvr.CompletedCnt())
+
+	// TODO - TODO - TODO....
+	// Verify that the server has seen the updated
+	// highestReplySeen
 
 	// Send an RPC which should return an error
 	pingRequest = &rpctest.PingReq{Message: "Ping Me!"}

--- a/retryrpc/retryrpc_test.go
+++ b/retryrpc/retryrpc_test.go
@@ -120,49 +120,36 @@ type RequestID uint64
 // If !a.Less(b) && !b.Less(a), we treat this to mean a == b (i.e. we can only
 // hold one of either a or b in the tree).
 func (a RequestID) Less(b btree.Item) bool {
-	//fmt.Printf("\tLess() - a: %v b.(RequestID): %v return: %v\n", a, b.(RequestID), a < b.(RequestID))
 	return a < b.(RequestID)
 }
 
 /* TODO - test case
-1. simulate responses coming in out of order - 5, 10, 20, 1, 3, 2, etc
-2. find "highest consecutive RequestID - (no gaps in numbers)"
-3. simulate gaps being filled
-4. simulate deleting and asserting that have correct numbers
 5. evaluate storing outstandingRequest as btree or having only numbers in btree
+	== probably only want ints in btree and not complete data structure in
+	case one RPC hangs....
 */
 
 func setHighestConsecutive(highestConsecutiveNum *RequestID, tr *btree.BTree) {
 	fmt.Printf("setHighestConsecutive()\n")
 	tr.Ascend(func(a btree.Item) bool {
 		r := a.(RequestID)
-		/*
-			c := *highestConsecutiveNum
-		*/
-		fmt.Printf("r is: %v\n", r)
+		c := *highestConsecutiveNum
 
-		/*
-			// If this item is a consecutive number then keep going.
-			// Otherwise stop the Ascend now
-			c++
-			if r == *highestConsecutiveNum {
-				*highestConsecutiveNum = r
-				fmt.Printf("highestConsecutiveNum now: %v\n", highestConsecutiveNum)
-				return true
-			}
-		*/
-		if r == tr.Max() {
+		// If this item is a consecutive number then keep going.
+		// Otherwise stop the Ascend now
+		c++
+		if r == c {
+			*highestConsecutiveNum = r
+		} else {
+			// If not consective just return
 			return false
 		}
 		return true
 	})
-	return
 }
 
 func wrapper(tr *btree.BTree, r RequestID) {
-	//fmt.Printf("BEFORE - ReplaceOrInsert(): %v - Min(): %v\n", r, tr.Min())
 	tr.ReplaceOrInsert(r)
-	fmt.Printf("AFTER - ReplaceOrInsert(): %v - Min(): %v\n", r, tr.Min())
 }
 
 func testBtree(t *testing.T) {
@@ -177,8 +164,6 @@ func testBtree(t *testing.T) {
 	wrapper(tr, RequestID(5))
 	wrapper(tr, RequestID(11))
 
-	fmt.Printf("minimum value: %v\n", tr.Min())
-
 	setHighestConsecutive(&highestConsecutiveNum, tr)
 	assert.Equal(RequestID(0), highestConsecutiveNum)
 
@@ -187,27 +172,29 @@ func testBtree(t *testing.T) {
 	wrapper(tr, RequestID(3))
 	wrapper(tr, RequestID(2))
 	wrapper(tr, RequestID(1))
-	fmt.Printf("new minimum value: %v len: %v\n", tr.Min(), tr.Len())
 	assert.Equal(int(7), tr.Len())
 
 	setHighestConsecutive(&highestConsecutiveNum, tr)
 	assert.Equal(RequestID(5), highestConsecutiveNum)
 
-	/*
-		for i := RequestID(0); i < 10; i++ {
-			tr.ReplaceOrInsert(i)
-		}
-		fmt.Println("len:       ", tr.Len())
-		fmt.Println("get3:      ", tr.Get(RequestID(3)))
-		fmt.Println("get100:    ", tr.Get(RequestID(100)))
-		fmt.Println("del4:      ", tr.Delete(RequestID(4)))
-		fmt.Println("del100:    ", tr.Delete(RequestID(100)))
-		fmt.Println("replace5:  ", tr.ReplaceOrInsert(RequestID(5)))
-		fmt.Println("replace100:", tr.ReplaceOrInsert(RequestID(100)))
-		fmt.Println("min:       ", tr.Min())
-		fmt.Println("delmin:    ", tr.DeleteMin())
-		fmt.Println("max:       ", tr.Max())
-		fmt.Println("delmax:    ", tr.DeleteMax())
-		fmt.Println("len:       ", tr.Len())
-	*/
+	// Now fillin next set of gaps and getting highestConsecutiveNum
+	wrapper(tr, RequestID(6))
+	wrapper(tr, RequestID(7))
+	wrapper(tr, RequestID(8))
+	wrapper(tr, RequestID(9))
+	assert.Equal(int(11), tr.Len())
+
+	setHighestConsecutive(&highestConsecutiveNum, tr)
+	assert.Equal(RequestID(11), highestConsecutiveNum)
+
+	// Now delete client list and btree entry...
+	// TODO - setHighestConsecutive() should probably
+	// delete earlier btree entries since no longer
+	// needed..
+	for i := 1; i < 12; i++ {
+		tr.Delete(RequestID(i))
+	}
+	assert.Equal(int(0), tr.Len())
+	setHighestConsecutive(&highestConsecutiveNum, tr)
+	assert.Equal(RequestID(11), highestConsecutiveNum)
 }

--- a/retryrpc/retryrpc_test.go
+++ b/retryrpc/retryrpc_test.go
@@ -130,30 +130,30 @@ func testBtree(t *testing.T) {
 	assert.Nil(newErr)
 
 	// Simulate requests completing out of order
-	client.bt.ReplaceOrInsert(requestID(10))
-	client.bt.ReplaceOrInsert(requestID(5))
-	client.bt.ReplaceOrInsert(requestID(11))
+	client.updateHighestConsecutiveNum(requestID(10))
+	client.updateHighestConsecutiveNum(requestID(5))
+	client.updateHighestConsecutiveNum(requestID(11))
 
 	client.setHighestConsecutive()
 	assert.Equal(requestID(0), client.highestConsecutive)
 
 	// Now fillin first gap
-	client.bt.ReplaceOrInsert(requestID(4))
-	client.bt.ReplaceOrInsert(requestID(3))
-	client.bt.ReplaceOrInsert(requestID(2))
-	client.bt.ReplaceOrInsert(requestID(1))
-	assert.Equal(int(7), client.bt.Len())
+	client.updateHighestConsecutiveNum(requestID(4))
+	client.updateHighestConsecutiveNum(requestID(3))
+	client.updateHighestConsecutiveNum(requestID(2))
+	client.updateHighestConsecutiveNum(requestID(1))
+	assert.Equal(int(3), client.bt.Len())
 
 	client.setHighestConsecutive()
 	assert.Equal(int(3), client.bt.Len())
 	assert.Equal(requestID(5), client.highestConsecutive)
 
 	// Now fillin next set of gaps
-	client.bt.ReplaceOrInsert(requestID(6))
-	client.bt.ReplaceOrInsert(requestID(7))
-	client.bt.ReplaceOrInsert(requestID(8))
-	client.bt.ReplaceOrInsert(requestID(9))
-	assert.Equal(int(7), client.bt.Len())
+	client.updateHighestConsecutiveNum(requestID(6))
+	client.updateHighestConsecutiveNum(requestID(7))
+	client.updateHighestConsecutiveNum(requestID(8))
+	client.updateHighestConsecutiveNum(requestID(9))
+	assert.Equal(int(1), client.bt.Len())
 
 	client.setHighestConsecutive()
 	assert.Equal(int(1), client.bt.Len())

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -55,8 +55,8 @@ func (server *Server) run() {
 	}
 }
 
-func keyString(myUniqueID string, requestID uint64) string {
-	return fmt.Sprintf("%v:%v", myUniqueID, requestID)
+func keyString(myUniqueID string, rID requestID) string {
+	return fmt.Sprintf("%v:%v", myUniqueID, rID)
 }
 
 // First check if we already completed this request by looking on completed

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -130,7 +130,6 @@ func (server *Server) processRequest(cCtx *connCtx, buf []byte) {
 		return
 	}
 
-	logger.Infof("processRequest() - highestReplySeen: %v\n", jReq.HighestReplySeen)
 	server.Lock()
 	mui, ok := server.perUniqueIDInfo[jReq.MyUniqueID]
 	if !ok {

--- a/vendor/github.com/google/btree/.travis.yml
+++ b/vendor/github.com/google/btree/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/vendor/github.com/google/btree/LICENSE
+++ b/vendor/github.com/google/btree/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/btree/README.md
+++ b/vendor/github.com/google/btree/README.md
@@ -1,0 +1,12 @@
+# BTree implementation for Go
+
+![Travis CI Build Status](https://api.travis-ci.org/google/btree.svg?branch=master)
+
+This package provides an in-memory B-Tree implementation for Go, useful as
+an ordered, mutable data structure.
+
+The API is based off of the wonderful
+http://godoc.org/github.com/petar/GoLLRB/llrb, and is meant to allow btree to
+act as a drop-in replacement for gollrb trees.
+
+See http://godoc.org/github.com/google/btree for documentation.

--- a/vendor/github.com/google/btree/btree.go
+++ b/vendor/github.com/google/btree/btree.go
@@ -1,0 +1,890 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package btree implements in-memory B-Trees of arbitrary degree.
+//
+// btree implements an in-memory B-Tree for use as an ordered data structure.
+// It is not meant for persistent storage solutions.
+//
+// It has a flatter structure than an equivalent red-black or other binary tree,
+// which in some cases yields better memory usage and/or performance.
+// See some discussion on the matter here:
+//   http://google-opensource.blogspot.com/2013/01/c-containers-that-save-memory-and-time.html
+// Note, though, that this project is in no way related to the C++ B-Tree
+// implementation written about there.
+//
+// Within this tree, each node contains a slice of items and a (possibly nil)
+// slice of children.  For basic numeric values or raw structs, this can cause
+// efficiency differences when compared to equivalent C++ template code that
+// stores values in arrays within the node:
+//   * Due to the overhead of storing values as interfaces (each
+//     value needs to be stored as the value itself, then 2 words for the
+//     interface pointing to that value and its type), resulting in higher
+//     memory use.
+//   * Since interfaces can point to values anywhere in memory, values are
+//     most likely not stored in contiguous blocks, resulting in a higher
+//     number of cache misses.
+// These issues don't tend to matter, though, when working with strings or other
+// heap-allocated structures, since C++-equivalent structures also must store
+// pointers and also distribute their values across the heap.
+//
+// This implementation is designed to be a drop-in replacement to gollrb.LLRB
+// trees, (http://github.com/petar/gollrb), an excellent and probably the most
+// widely used ordered tree implementation in the Go ecosystem currently.
+// Its functions, therefore, exactly mirror those of
+// llrb.LLRB where possible.  Unlike gollrb, though, we currently don't
+// support storing multiple equivalent values.
+package btree
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Item represents a single object in the tree.
+type Item interface {
+	// Less tests whether the current item is less than the given argument.
+	//
+	// This must provide a strict weak ordering.
+	// If !a.Less(b) && !b.Less(a), we treat this to mean a == b (i.e. we can only
+	// hold one of either a or b in the tree).
+	Less(than Item) bool
+}
+
+const (
+	DefaultFreeListSize = 32
+)
+
+var (
+	nilItems    = make(items, 16)
+	nilChildren = make(children, 16)
+)
+
+// FreeList represents a free list of btree nodes. By default each
+// BTree has its own FreeList, but multiple BTrees can share the same
+// FreeList.
+// Two Btrees using the same freelist are safe for concurrent write access.
+type FreeList struct {
+	mu       sync.Mutex
+	freelist []*node
+}
+
+// NewFreeList creates a new free list.
+// size is the maximum size of the returned free list.
+func NewFreeList(size int) *FreeList {
+	return &FreeList{freelist: make([]*node, 0, size)}
+}
+
+func (f *FreeList) newNode() (n *node) {
+	f.mu.Lock()
+	index := len(f.freelist) - 1
+	if index < 0 {
+		f.mu.Unlock()
+		return new(node)
+	}
+	n = f.freelist[index]
+	f.freelist[index] = nil
+	f.freelist = f.freelist[:index]
+	f.mu.Unlock()
+	return
+}
+
+// freeNode adds the given node to the list, returning true if it was added
+// and false if it was discarded.
+func (f *FreeList) freeNode(n *node) (out bool) {
+	f.mu.Lock()
+	if len(f.freelist) < cap(f.freelist) {
+		f.freelist = append(f.freelist, n)
+		out = true
+	}
+	f.mu.Unlock()
+	return
+}
+
+// ItemIterator allows callers of Ascend* to iterate in-order over portions of
+// the tree.  When this function returns false, iteration will stop and the
+// associated Ascend* function will immediately return.
+type ItemIterator func(i Item) bool
+
+// New creates a new B-Tree with the given degree.
+//
+// New(2), for example, will create a 2-3-4 tree (each node contains 1-3 items
+// and 2-4 children).
+func New(degree int) *BTree {
+	return NewWithFreeList(degree, NewFreeList(DefaultFreeListSize))
+}
+
+// NewWithFreeList creates a new B-Tree that uses the given node free list.
+func NewWithFreeList(degree int, f *FreeList) *BTree {
+	if degree <= 1 {
+		panic("bad degree")
+	}
+	return &BTree{
+		degree: degree,
+		cow:    &copyOnWriteContext{freelist: f},
+	}
+}
+
+// items stores items in a node.
+type items []Item
+
+// insertAt inserts a value into the given index, pushing all subsequent values
+// forward.
+func (s *items) insertAt(index int, item Item) {
+	*s = append(*s, nil)
+	if index < len(*s) {
+		copy((*s)[index+1:], (*s)[index:])
+	}
+	(*s)[index] = item
+}
+
+// removeAt removes a value at a given index, pulling all subsequent values
+// back.
+func (s *items) removeAt(index int) Item {
+	item := (*s)[index]
+	copy((*s)[index:], (*s)[index+1:])
+	(*s)[len(*s)-1] = nil
+	*s = (*s)[:len(*s)-1]
+	return item
+}
+
+// pop removes and returns the last element in the list.
+func (s *items) pop() (out Item) {
+	index := len(*s) - 1
+	out = (*s)[index]
+	(*s)[index] = nil
+	*s = (*s)[:index]
+	return
+}
+
+// truncate truncates this instance at index so that it contains only the
+// first index items. index must be less than or equal to length.
+func (s *items) truncate(index int) {
+	var toClear items
+	*s, toClear = (*s)[:index], (*s)[index:]
+	for len(toClear) > 0 {
+		toClear = toClear[copy(toClear, nilItems):]
+	}
+}
+
+// find returns the index where the given item should be inserted into this
+// list.  'found' is true if the item already exists in the list at the given
+// index.
+func (s items) find(item Item) (index int, found bool) {
+	i := sort.Search(len(s), func(i int) bool {
+		return item.Less(s[i])
+	})
+	if i > 0 && !s[i-1].Less(item) {
+		return i - 1, true
+	}
+	return i, false
+}
+
+// children stores child nodes in a node.
+type children []*node
+
+// insertAt inserts a value into the given index, pushing all subsequent values
+// forward.
+func (s *children) insertAt(index int, n *node) {
+	*s = append(*s, nil)
+	if index < len(*s) {
+		copy((*s)[index+1:], (*s)[index:])
+	}
+	(*s)[index] = n
+}
+
+// removeAt removes a value at a given index, pulling all subsequent values
+// back.
+func (s *children) removeAt(index int) *node {
+	n := (*s)[index]
+	copy((*s)[index:], (*s)[index+1:])
+	(*s)[len(*s)-1] = nil
+	*s = (*s)[:len(*s)-1]
+	return n
+}
+
+// pop removes and returns the last element in the list.
+func (s *children) pop() (out *node) {
+	index := len(*s) - 1
+	out = (*s)[index]
+	(*s)[index] = nil
+	*s = (*s)[:index]
+	return
+}
+
+// truncate truncates this instance at index so that it contains only the
+// first index children. index must be less than or equal to length.
+func (s *children) truncate(index int) {
+	var toClear children
+	*s, toClear = (*s)[:index], (*s)[index:]
+	for len(toClear) > 0 {
+		toClear = toClear[copy(toClear, nilChildren):]
+	}
+}
+
+// node is an internal node in a tree.
+//
+// It must at all times maintain the invariant that either
+//   * len(children) == 0, len(items) unconstrained
+//   * len(children) == len(items) + 1
+type node struct {
+	items    items
+	children children
+	cow      *copyOnWriteContext
+}
+
+func (n *node) mutableFor(cow *copyOnWriteContext) *node {
+	if n.cow == cow {
+		return n
+	}
+	out := cow.newNode()
+	if cap(out.items) >= len(n.items) {
+		out.items = out.items[:len(n.items)]
+	} else {
+		out.items = make(items, len(n.items), cap(n.items))
+	}
+	copy(out.items, n.items)
+	// Copy children
+	if cap(out.children) >= len(n.children) {
+		out.children = out.children[:len(n.children)]
+	} else {
+		out.children = make(children, len(n.children), cap(n.children))
+	}
+	copy(out.children, n.children)
+	return out
+}
+
+func (n *node) mutableChild(i int) *node {
+	c := n.children[i].mutableFor(n.cow)
+	n.children[i] = c
+	return c
+}
+
+// split splits the given node at the given index.  The current node shrinks,
+// and this function returns the item that existed at that index and a new node
+// containing all items/children after it.
+func (n *node) split(i int) (Item, *node) {
+	item := n.items[i]
+	next := n.cow.newNode()
+	next.items = append(next.items, n.items[i+1:]...)
+	n.items.truncate(i)
+	if len(n.children) > 0 {
+		next.children = append(next.children, n.children[i+1:]...)
+		n.children.truncate(i + 1)
+	}
+	return item, next
+}
+
+// maybeSplitChild checks if a child should be split, and if so splits it.
+// Returns whether or not a split occurred.
+func (n *node) maybeSplitChild(i, maxItems int) bool {
+	if len(n.children[i].items) < maxItems {
+		return false
+	}
+	first := n.mutableChild(i)
+	item, second := first.split(maxItems / 2)
+	n.items.insertAt(i, item)
+	n.children.insertAt(i+1, second)
+	return true
+}
+
+// insert inserts an item into the subtree rooted at this node, making sure
+// no nodes in the subtree exceed maxItems items.  Should an equivalent item be
+// be found/replaced by insert, it will be returned.
+func (n *node) insert(item Item, maxItems int) Item {
+	i, found := n.items.find(item)
+	if found {
+		out := n.items[i]
+		n.items[i] = item
+		return out
+	}
+	if len(n.children) == 0 {
+		n.items.insertAt(i, item)
+		return nil
+	}
+	if n.maybeSplitChild(i, maxItems) {
+		inTree := n.items[i]
+		switch {
+		case item.Less(inTree):
+			// no change, we want first split node
+		case inTree.Less(item):
+			i++ // we want second split node
+		default:
+			out := n.items[i]
+			n.items[i] = item
+			return out
+		}
+	}
+	return n.mutableChild(i).insert(item, maxItems)
+}
+
+// get finds the given key in the subtree and returns it.
+func (n *node) get(key Item) Item {
+	i, found := n.items.find(key)
+	if found {
+		return n.items[i]
+	} else if len(n.children) > 0 {
+		return n.children[i].get(key)
+	}
+	return nil
+}
+
+// min returns the first item in the subtree.
+func min(n *node) Item {
+	if n == nil {
+		return nil
+	}
+	for len(n.children) > 0 {
+		n = n.children[0]
+	}
+	if len(n.items) == 0 {
+		return nil
+	}
+	return n.items[0]
+}
+
+// max returns the last item in the subtree.
+func max(n *node) Item {
+	if n == nil {
+		return nil
+	}
+	for len(n.children) > 0 {
+		n = n.children[len(n.children)-1]
+	}
+	if len(n.items) == 0 {
+		return nil
+	}
+	return n.items[len(n.items)-1]
+}
+
+// toRemove details what item to remove in a node.remove call.
+type toRemove int
+
+const (
+	removeItem toRemove = iota // removes the given item
+	removeMin                  // removes smallest item in the subtree
+	removeMax                  // removes largest item in the subtree
+)
+
+// remove removes an item from the subtree rooted at this node.
+func (n *node) remove(item Item, minItems int, typ toRemove) Item {
+	var i int
+	var found bool
+	switch typ {
+	case removeMax:
+		if len(n.children) == 0 {
+			return n.items.pop()
+		}
+		i = len(n.items)
+	case removeMin:
+		if len(n.children) == 0 {
+			return n.items.removeAt(0)
+		}
+		i = 0
+	case removeItem:
+		i, found = n.items.find(item)
+		if len(n.children) == 0 {
+			if found {
+				return n.items.removeAt(i)
+			}
+			return nil
+		}
+	default:
+		panic("invalid type")
+	}
+	// If we get to here, we have children.
+	if len(n.children[i].items) <= minItems {
+		return n.growChildAndRemove(i, item, minItems, typ)
+	}
+	child := n.mutableChild(i)
+	// Either we had enough items to begin with, or we've done some
+	// merging/stealing, because we've got enough now and we're ready to return
+	// stuff.
+	if found {
+		// The item exists at index 'i', and the child we've selected can give us a
+		// predecessor, since if we've gotten here it's got > minItems items in it.
+		out := n.items[i]
+		// We use our special-case 'remove' call with typ=maxItem to pull the
+		// predecessor of item i (the rightmost leaf of our immediate left child)
+		// and set it into where we pulled the item from.
+		n.items[i] = child.remove(nil, minItems, removeMax)
+		return out
+	}
+	// Final recursive call.  Once we're here, we know that the item isn't in this
+	// node and that the child is big enough to remove from.
+	return child.remove(item, minItems, typ)
+}
+
+// growChildAndRemove grows child 'i' to make sure it's possible to remove an
+// item from it while keeping it at minItems, then calls remove to actually
+// remove it.
+//
+// Most documentation says we have to do two sets of special casing:
+//   1) item is in this node
+//   2) item is in child
+// In both cases, we need to handle the two subcases:
+//   A) node has enough values that it can spare one
+//   B) node doesn't have enough values
+// For the latter, we have to check:
+//   a) left sibling has node to spare
+//   b) right sibling has node to spare
+//   c) we must merge
+// To simplify our code here, we handle cases #1 and #2 the same:
+// If a node doesn't have enough items, we make sure it does (using a,b,c).
+// We then simply redo our remove call, and the second time (regardless of
+// whether we're in case 1 or 2), we'll have enough items and can guarantee
+// that we hit case A.
+func (n *node) growChildAndRemove(i int, item Item, minItems int, typ toRemove) Item {
+	if i > 0 && len(n.children[i-1].items) > minItems {
+		// Steal from left child
+		child := n.mutableChild(i)
+		stealFrom := n.mutableChild(i - 1)
+		stolenItem := stealFrom.items.pop()
+		child.items.insertAt(0, n.items[i-1])
+		n.items[i-1] = stolenItem
+		if len(stealFrom.children) > 0 {
+			child.children.insertAt(0, stealFrom.children.pop())
+		}
+	} else if i < len(n.items) && len(n.children[i+1].items) > minItems {
+		// steal from right child
+		child := n.mutableChild(i)
+		stealFrom := n.mutableChild(i + 1)
+		stolenItem := stealFrom.items.removeAt(0)
+		child.items = append(child.items, n.items[i])
+		n.items[i] = stolenItem
+		if len(stealFrom.children) > 0 {
+			child.children = append(child.children, stealFrom.children.removeAt(0))
+		}
+	} else {
+		if i >= len(n.items) {
+			i--
+		}
+		child := n.mutableChild(i)
+		// merge with right child
+		mergeItem := n.items.removeAt(i)
+		mergeChild := n.children.removeAt(i + 1)
+		child.items = append(child.items, mergeItem)
+		child.items = append(child.items, mergeChild.items...)
+		child.children = append(child.children, mergeChild.children...)
+		n.cow.freeNode(mergeChild)
+	}
+	return n.remove(item, minItems, typ)
+}
+
+type direction int
+
+const (
+	descend = direction(-1)
+	ascend  = direction(+1)
+)
+
+// iterate provides a simple method for iterating over elements in the tree.
+//
+// When ascending, the 'start' should be less than 'stop' and when descending,
+// the 'start' should be greater than 'stop'. Setting 'includeStart' to true
+// will force the iterator to include the first item when it equals 'start',
+// thus creating a "greaterOrEqual" or "lessThanEqual" rather than just a
+// "greaterThan" or "lessThan" queries.
+func (n *node) iterate(dir direction, start, stop Item, includeStart bool, hit bool, iter ItemIterator) (bool, bool) {
+	var ok, found bool
+	var index int
+	switch dir {
+	case ascend:
+		if start != nil {
+			index, _ = n.items.find(start)
+		}
+		for i := index; i < len(n.items); i++ {
+			if len(n.children) > 0 {
+				if hit, ok = n.children[i].iterate(dir, start, stop, includeStart, hit, iter); !ok {
+					return hit, false
+				}
+			}
+			if !includeStart && !hit && start != nil && !start.Less(n.items[i]) {
+				hit = true
+				continue
+			}
+			hit = true
+			if stop != nil && !n.items[i].Less(stop) {
+				return hit, false
+			}
+			if !iter(n.items[i]) {
+				return hit, false
+			}
+		}
+		if len(n.children) > 0 {
+			if hit, ok = n.children[len(n.children)-1].iterate(dir, start, stop, includeStart, hit, iter); !ok {
+				return hit, false
+			}
+		}
+	case descend:
+		if start != nil {
+			index, found = n.items.find(start)
+			if !found {
+				index = index - 1
+			}
+		} else {
+			index = len(n.items) - 1
+		}
+		for i := index; i >= 0; i-- {
+			if start != nil && !n.items[i].Less(start) {
+				if !includeStart || hit || start.Less(n.items[i]) {
+					continue
+				}
+			}
+			if len(n.children) > 0 {
+				if hit, ok = n.children[i+1].iterate(dir, start, stop, includeStart, hit, iter); !ok {
+					return hit, false
+				}
+			}
+			if stop != nil && !stop.Less(n.items[i]) {
+				return hit, false //	continue
+			}
+			hit = true
+			if !iter(n.items[i]) {
+				return hit, false
+			}
+		}
+		if len(n.children) > 0 {
+			if hit, ok = n.children[0].iterate(dir, start, stop, includeStart, hit, iter); !ok {
+				return hit, false
+			}
+		}
+	}
+	return hit, true
+}
+
+// Used for testing/debugging purposes.
+func (n *node) print(w io.Writer, level int) {
+	fmt.Fprintf(w, "%sNODE:%v\n", strings.Repeat("  ", level), n.items)
+	for _, c := range n.children {
+		c.print(w, level+1)
+	}
+}
+
+// BTree is an implementation of a B-Tree.
+//
+// BTree stores Item instances in an ordered structure, allowing easy insertion,
+// removal, and iteration.
+//
+// Write operations are not safe for concurrent mutation by multiple
+// goroutines, but Read operations are.
+type BTree struct {
+	degree int
+	length int
+	root   *node
+	cow    *copyOnWriteContext
+}
+
+// copyOnWriteContext pointers determine node ownership... a tree with a write
+// context equivalent to a node's write context is allowed to modify that node.
+// A tree whose write context does not match a node's is not allowed to modify
+// it, and must create a new, writable copy (IE: it's a Clone).
+//
+// When doing any write operation, we maintain the invariant that the current
+// node's context is equal to the context of the tree that requested the write.
+// We do this by, before we descend into any node, creating a copy with the
+// correct context if the contexts don't match.
+//
+// Since the node we're currently visiting on any write has the requesting
+// tree's context, that node is modifiable in place.  Children of that node may
+// not share context, but before we descend into them, we'll make a mutable
+// copy.
+type copyOnWriteContext struct {
+	freelist *FreeList
+}
+
+// Clone clones the btree, lazily.  Clone should not be called concurrently,
+// but the original tree (t) and the new tree (t2) can be used concurrently
+// once the Clone call completes.
+//
+// The internal tree structure of b is marked read-only and shared between t and
+// t2.  Writes to both t and t2 use copy-on-write logic, creating new nodes
+// whenever one of b's original nodes would have been modified.  Read operations
+// should have no performance degredation.  Write operations for both t and t2
+// will initially experience minor slow-downs caused by additional allocs and
+// copies due to the aforementioned copy-on-write logic, but should converge to
+// the original performance characteristics of the original tree.
+func (t *BTree) Clone() (t2 *BTree) {
+	// Create two entirely new copy-on-write contexts.
+	// This operation effectively creates three trees:
+	//   the original, shared nodes (old b.cow)
+	//   the new b.cow nodes
+	//   the new out.cow nodes
+	cow1, cow2 := *t.cow, *t.cow
+	out := *t
+	t.cow = &cow1
+	out.cow = &cow2
+	return &out
+}
+
+// maxItems returns the max number of items to allow per node.
+func (t *BTree) maxItems() int {
+	return t.degree*2 - 1
+}
+
+// minItems returns the min number of items to allow per node (ignored for the
+// root node).
+func (t *BTree) minItems() int {
+	return t.degree - 1
+}
+
+func (c *copyOnWriteContext) newNode() (n *node) {
+	n = c.freelist.newNode()
+	n.cow = c
+	return
+}
+
+type freeType int
+
+const (
+	ftFreelistFull freeType = iota // node was freed (available for GC, not stored in freelist)
+	ftStored                       // node was stored in the freelist for later use
+	ftNotOwned                     // node was ignored by COW, since it's owned by another one
+)
+
+// freeNode frees a node within a given COW context, if it's owned by that
+// context.  It returns what happened to the node (see freeType const
+// documentation).
+func (c *copyOnWriteContext) freeNode(n *node) freeType {
+	if n.cow == c {
+		// clear to allow GC
+		n.items.truncate(0)
+		n.children.truncate(0)
+		n.cow = nil
+		if c.freelist.freeNode(n) {
+			return ftStored
+		} else {
+			return ftFreelistFull
+		}
+	} else {
+		return ftNotOwned
+	}
+}
+
+// ReplaceOrInsert adds the given item to the tree.  If an item in the tree
+// already equals the given one, it is removed from the tree and returned.
+// Otherwise, nil is returned.
+//
+// nil cannot be added to the tree (will panic).
+func (t *BTree) ReplaceOrInsert(item Item) Item {
+	if item == nil {
+		panic("nil item being added to BTree")
+	}
+	if t.root == nil {
+		t.root = t.cow.newNode()
+		t.root.items = append(t.root.items, item)
+		t.length++
+		return nil
+	} else {
+		t.root = t.root.mutableFor(t.cow)
+		if len(t.root.items) >= t.maxItems() {
+			item2, second := t.root.split(t.maxItems() / 2)
+			oldroot := t.root
+			t.root = t.cow.newNode()
+			t.root.items = append(t.root.items, item2)
+			t.root.children = append(t.root.children, oldroot, second)
+		}
+	}
+	out := t.root.insert(item, t.maxItems())
+	if out == nil {
+		t.length++
+	}
+	return out
+}
+
+// Delete removes an item equal to the passed in item from the tree, returning
+// it.  If no such item exists, returns nil.
+func (t *BTree) Delete(item Item) Item {
+	return t.deleteItem(item, removeItem)
+}
+
+// DeleteMin removes the smallest item in the tree and returns it.
+// If no such item exists, returns nil.
+func (t *BTree) DeleteMin() Item {
+	return t.deleteItem(nil, removeMin)
+}
+
+// DeleteMax removes the largest item in the tree and returns it.
+// If no such item exists, returns nil.
+func (t *BTree) DeleteMax() Item {
+	return t.deleteItem(nil, removeMax)
+}
+
+func (t *BTree) deleteItem(item Item, typ toRemove) Item {
+	if t.root == nil || len(t.root.items) == 0 {
+		return nil
+	}
+	t.root = t.root.mutableFor(t.cow)
+	out := t.root.remove(item, t.minItems(), typ)
+	if len(t.root.items) == 0 && len(t.root.children) > 0 {
+		oldroot := t.root
+		t.root = t.root.children[0]
+		t.cow.freeNode(oldroot)
+	}
+	if out != nil {
+		t.length--
+	}
+	return out
+}
+
+// AscendRange calls the iterator for every value in the tree within the range
+// [greaterOrEqual, lessThan), until iterator returns false.
+func (t *BTree) AscendRange(greaterOrEqual, lessThan Item, iterator ItemIterator) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(ascend, greaterOrEqual, lessThan, true, false, iterator)
+}
+
+// AscendLessThan calls the iterator for every value in the tree within the range
+// [first, pivot), until iterator returns false.
+func (t *BTree) AscendLessThan(pivot Item, iterator ItemIterator) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(ascend, nil, pivot, false, false, iterator)
+}
+
+// AscendGreaterOrEqual calls the iterator for every value in the tree within
+// the range [pivot, last], until iterator returns false.
+func (t *BTree) AscendGreaterOrEqual(pivot Item, iterator ItemIterator) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(ascend, pivot, nil, true, false, iterator)
+}
+
+// Ascend calls the iterator for every value in the tree within the range
+// [first, last], until iterator returns false.
+func (t *BTree) Ascend(iterator ItemIterator) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(ascend, nil, nil, false, false, iterator)
+}
+
+// DescendRange calls the iterator for every value in the tree within the range
+// [lessOrEqual, greaterThan), until iterator returns false.
+func (t *BTree) DescendRange(lessOrEqual, greaterThan Item, iterator ItemIterator) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(descend, lessOrEqual, greaterThan, true, false, iterator)
+}
+
+// DescendLessOrEqual calls the iterator for every value in the tree within the range
+// [pivot, first], until iterator returns false.
+func (t *BTree) DescendLessOrEqual(pivot Item, iterator ItemIterator) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(descend, pivot, nil, true, false, iterator)
+}
+
+// DescendGreaterThan calls the iterator for every value in the tree within
+// the range (pivot, last], until iterator returns false.
+func (t *BTree) DescendGreaterThan(pivot Item, iterator ItemIterator) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(descend, nil, pivot, false, false, iterator)
+}
+
+// Descend calls the iterator for every value in the tree within the range
+// [last, first], until iterator returns false.
+func (t *BTree) Descend(iterator ItemIterator) {
+	if t.root == nil {
+		return
+	}
+	t.root.iterate(descend, nil, nil, false, false, iterator)
+}
+
+// Get looks for the key item in the tree, returning it.  It returns nil if
+// unable to find that item.
+func (t *BTree) Get(key Item) Item {
+	if t.root == nil {
+		return nil
+	}
+	return t.root.get(key)
+}
+
+// Min returns the smallest item in the tree, or nil if the tree is empty.
+func (t *BTree) Min() Item {
+	return min(t.root)
+}
+
+// Max returns the largest item in the tree, or nil if the tree is empty.
+func (t *BTree) Max() Item {
+	return max(t.root)
+}
+
+// Has returns true if the given key is in the tree.
+func (t *BTree) Has(key Item) bool {
+	return t.Get(key) != nil
+}
+
+// Len returns the number of items currently in the tree.
+func (t *BTree) Len() int {
+	return t.length
+}
+
+// Clear removes all items from the btree.  If addNodesToFreelist is true,
+// t's nodes are added to its freelist as part of this call, until the freelist
+// is full.  Otherwise, the root node is simply dereferenced and the subtree
+// left to Go's normal GC processes.
+//
+// This can be much faster
+// than calling Delete on all elements, because that requires finding/removing
+// each element in the tree and updating the tree accordingly.  It also is
+// somewhat faster than creating a new tree to replace the old one, because
+// nodes from the old tree are reclaimed into the freelist for use by the new
+// one, instead of being lost to the garbage collector.
+//
+// This call takes:
+//   O(1): when addNodesToFreelist is false, this is a single operation.
+//   O(1): when the freelist is already full, it breaks out immediately
+//   O(freelist size):  when the freelist is empty and the nodes are all owned
+//       by this tree, nodes are added to the freelist until full.
+//   O(tree size):  when all nodes are owned by another tree, all nodes are
+//       iterated over looking for nodes to add to the freelist, and due to
+//       ownership, none are.
+func (t *BTree) Clear(addNodesToFreelist bool) {
+	if t.root != nil && addNodesToFreelist {
+		t.root.reset(t.cow)
+	}
+	t.root, t.length = nil, 0
+}
+
+// reset returns a subtree to the freelist.  It breaks out immediately if the
+// freelist is full, since the only benefit of iterating is to fill that
+// freelist up.  Returns true if parent reset call should continue.
+func (n *node) reset(c *copyOnWriteContext) bool {
+	for _, child := range n.children {
+		if !child.reset(c) {
+			return false
+		}
+	}
+	return c.freeNode(n) != ftFreelistFull
+}
+
+// Int implements the Item interface for integers.
+type Int int
+
+// Less returns true if int(a) < int(b).
+func (a Int) Less(b Item) bool {
+	return a < b.(Int)
+}

--- a/vendor/github.com/google/btree/btree_mem.go
+++ b/vendor/github.com/google/btree/btree_mem.go
@@ -1,0 +1,76 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build ignore
+
+// This binary compares memory usage between btree and gollrb.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"runtime"
+	"time"
+
+	"github.com/google/btree"
+	"github.com/petar/GoLLRB/llrb"
+)
+
+var (
+	size   = flag.Int("size", 1000000, "size of the tree to build")
+	degree = flag.Int("degree", 8, "degree of btree")
+	gollrb = flag.Bool("llrb", false, "use llrb instead of btree")
+)
+
+func main() {
+	flag.Parse()
+	vals := rand.Perm(*size)
+	var t, v interface{}
+	v = vals
+	var stats runtime.MemStats
+	for i := 0; i < 10; i++ {
+		runtime.GC()
+	}
+	fmt.Println("-------- BEFORE ----------")
+	runtime.ReadMemStats(&stats)
+	fmt.Printf("%+v\n", stats)
+	start := time.Now()
+	if *gollrb {
+		tr := llrb.New()
+		for _, v := range vals {
+			tr.ReplaceOrInsert(llrb.Int(v))
+		}
+		t = tr // keep it around
+	} else {
+		tr := btree.New(*degree)
+		for _, v := range vals {
+			tr.ReplaceOrInsert(btree.Int(v))
+		}
+		t = tr // keep it around
+	}
+	fmt.Printf("%v inserts in %v\n", *size, time.Since(start))
+	fmt.Println("-------- AFTER ----------")
+	runtime.ReadMemStats(&stats)
+	fmt.Printf("%+v\n", stats)
+	for i := 0; i < 10; i++ {
+		runtime.GC()
+	}
+	fmt.Println("-------- AFTER GC ----------")
+	runtime.ReadMemStats(&stats)
+	fmt.Printf("%+v\n", stats)
+	if t == v {
+		fmt.Println("to make sure vals and tree aren't GC'd")
+	}
+}

--- a/vendor/github.com/google/btree/btree_test.go
+++ b/vendor/github.com/google/btree/btree_test.go
@@ -1,0 +1,785 @@
+// Copyright 2014 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package btree
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+func init() {
+	seed := time.Now().Unix()
+	fmt.Println(seed)
+	rand.Seed(seed)
+}
+
+// perm returns a random permutation of n Int items in the range [0, n).
+func perm(n int) (out []Item) {
+	for _, v := range rand.Perm(n) {
+		out = append(out, Int(v))
+	}
+	return
+}
+
+// rang returns an ordered list of Int items in the range [0, n).
+func rang(n int) (out []Item) {
+	for i := 0; i < n; i++ {
+		out = append(out, Int(i))
+	}
+	return
+}
+
+// all extracts all items from a tree in order as a slice.
+func all(t *BTree) (out []Item) {
+	t.Ascend(func(a Item) bool {
+		out = append(out, a)
+		return true
+	})
+	return
+}
+
+// rangerev returns a reversed ordered list of Int items in the range [0, n).
+func rangrev(n int) (out []Item) {
+	for i := n - 1; i >= 0; i-- {
+		out = append(out, Int(i))
+	}
+	return
+}
+
+// allrev extracts all items from a tree in reverse order as a slice.
+func allrev(t *BTree) (out []Item) {
+	t.Descend(func(a Item) bool {
+		out = append(out, a)
+		return true
+	})
+	return
+}
+
+var btreeDegree = flag.Int("degree", 32, "B-Tree degree")
+
+func TestBTree(t *testing.T) {
+	tr := New(*btreeDegree)
+	const treeSize = 10000
+	for i := 0; i < 10; i++ {
+		if min := tr.Min(); min != nil {
+			t.Fatalf("empty min, got %+v", min)
+		}
+		if max := tr.Max(); max != nil {
+			t.Fatalf("empty max, got %+v", max)
+		}
+		for _, item := range perm(treeSize) {
+			if x := tr.ReplaceOrInsert(item); x != nil {
+				t.Fatal("insert found item", item)
+			}
+		}
+		for _, item := range perm(treeSize) {
+			if x := tr.ReplaceOrInsert(item); x == nil {
+				t.Fatal("insert didn't find item", item)
+			}
+		}
+		if min, want := tr.Min(), Item(Int(0)); min != want {
+			t.Fatalf("min: want %+v, got %+v", want, min)
+		}
+		if max, want := tr.Max(), Item(Int(treeSize-1)); max != want {
+			t.Fatalf("max: want %+v, got %+v", want, max)
+		}
+		got := all(tr)
+		want := rang(treeSize)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("mismatch:\n got: %v\nwant: %v", got, want)
+		}
+
+		gotrev := allrev(tr)
+		wantrev := rangrev(treeSize)
+		if !reflect.DeepEqual(gotrev, wantrev) {
+			t.Fatalf("mismatch:\n got: %v\nwant: %v", got, want)
+		}
+
+		for _, item := range perm(treeSize) {
+			if x := tr.Delete(item); x == nil {
+				t.Fatalf("didn't find %v", item)
+			}
+		}
+		if got = all(tr); len(got) > 0 {
+			t.Fatalf("some left!: %v", got)
+		}
+	}
+}
+
+func ExampleBTree() {
+	tr := New(*btreeDegree)
+	for i := Int(0); i < 10; i++ {
+		tr.ReplaceOrInsert(i)
+	}
+	fmt.Println("len:       ", tr.Len())
+	fmt.Println("get3:      ", tr.Get(Int(3)))
+	fmt.Println("get100:    ", tr.Get(Int(100)))
+	fmt.Println("del4:      ", tr.Delete(Int(4)))
+	fmt.Println("del100:    ", tr.Delete(Int(100)))
+	fmt.Println("replace5:  ", tr.ReplaceOrInsert(Int(5)))
+	fmt.Println("replace100:", tr.ReplaceOrInsert(Int(100)))
+	fmt.Println("min:       ", tr.Min())
+	fmt.Println("delmin:    ", tr.DeleteMin())
+	fmt.Println("max:       ", tr.Max())
+	fmt.Println("delmax:    ", tr.DeleteMax())
+	fmt.Println("len:       ", tr.Len())
+	// Output:
+	// len:        10
+	// get3:       3
+	// get100:     <nil>
+	// del4:       4
+	// del100:     <nil>
+	// replace5:   5
+	// replace100: <nil>
+	// min:        0
+	// delmin:     0
+	// max:        100
+	// delmax:     100
+	// len:        8
+}
+
+func TestDeleteMin(t *testing.T) {
+	tr := New(3)
+	for _, v := range perm(100) {
+		tr.ReplaceOrInsert(v)
+	}
+	var got []Item
+	for v := tr.DeleteMin(); v != nil; v = tr.DeleteMin() {
+		got = append(got, v)
+	}
+	if want := rang(100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ascendrange:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestDeleteMax(t *testing.T) {
+	tr := New(3)
+	for _, v := range perm(100) {
+		tr.ReplaceOrInsert(v)
+	}
+	var got []Item
+	for v := tr.DeleteMax(); v != nil; v = tr.DeleteMax() {
+		got = append(got, v)
+	}
+	// Reverse our list.
+	for i := 0; i < len(got)/2; i++ {
+		got[i], got[len(got)-i-1] = got[len(got)-i-1], got[i]
+	}
+	if want := rang(100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ascendrange:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestAscendRange(t *testing.T) {
+	tr := New(2)
+	for _, v := range perm(100) {
+		tr.ReplaceOrInsert(v)
+	}
+	var got []Item
+	tr.AscendRange(Int(40), Int(60), func(a Item) bool {
+		got = append(got, a)
+		return true
+	})
+	if want := rang(100)[40:60]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ascendrange:\n got: %v\nwant: %v", got, want)
+	}
+	got = got[:0]
+	tr.AscendRange(Int(40), Int(60), func(a Item) bool {
+		if a.(Int) > 50 {
+			return false
+		}
+		got = append(got, a)
+		return true
+	})
+	if want := rang(100)[40:51]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ascendrange:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestDescendRange(t *testing.T) {
+	tr := New(2)
+	for _, v := range perm(100) {
+		tr.ReplaceOrInsert(v)
+	}
+	var got []Item
+	tr.DescendRange(Int(60), Int(40), func(a Item) bool {
+		got = append(got, a)
+		return true
+	})
+	if want := rangrev(100)[39:59]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("descendrange:\n got: %v\nwant: %v", got, want)
+	}
+	got = got[:0]
+	tr.DescendRange(Int(60), Int(40), func(a Item) bool {
+		if a.(Int) < 50 {
+			return false
+		}
+		got = append(got, a)
+		return true
+	})
+	if want := rangrev(100)[39:50]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("descendrange:\n got: %v\nwant: %v", got, want)
+	}
+}
+func TestAscendLessThan(t *testing.T) {
+	tr := New(*btreeDegree)
+	for _, v := range perm(100) {
+		tr.ReplaceOrInsert(v)
+	}
+	var got []Item
+	tr.AscendLessThan(Int(60), func(a Item) bool {
+		got = append(got, a)
+		return true
+	})
+	if want := rang(100)[:60]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ascendrange:\n got: %v\nwant: %v", got, want)
+	}
+	got = got[:0]
+	tr.AscendLessThan(Int(60), func(a Item) bool {
+		if a.(Int) > 50 {
+			return false
+		}
+		got = append(got, a)
+		return true
+	})
+	if want := rang(100)[:51]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ascendrange:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestDescendLessOrEqual(t *testing.T) {
+	tr := New(*btreeDegree)
+	for _, v := range perm(100) {
+		tr.ReplaceOrInsert(v)
+	}
+	var got []Item
+	tr.DescendLessOrEqual(Int(40), func(a Item) bool {
+		got = append(got, a)
+		return true
+	})
+	if want := rangrev(100)[59:]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("descendlessorequal:\n got: %v\nwant: %v", got, want)
+	}
+	got = got[:0]
+	tr.DescendLessOrEqual(Int(60), func(a Item) bool {
+		if a.(Int) < 50 {
+			return false
+		}
+		got = append(got, a)
+		return true
+	})
+	if want := rangrev(100)[39:50]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("descendlessorequal:\n got: %v\nwant: %v", got, want)
+	}
+}
+func TestAscendGreaterOrEqual(t *testing.T) {
+	tr := New(*btreeDegree)
+	for _, v := range perm(100) {
+		tr.ReplaceOrInsert(v)
+	}
+	var got []Item
+	tr.AscendGreaterOrEqual(Int(40), func(a Item) bool {
+		got = append(got, a)
+		return true
+	})
+	if want := rang(100)[40:]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ascendrange:\n got: %v\nwant: %v", got, want)
+	}
+	got = got[:0]
+	tr.AscendGreaterOrEqual(Int(40), func(a Item) bool {
+		if a.(Int) > 50 {
+			return false
+		}
+		got = append(got, a)
+		return true
+	})
+	if want := rang(100)[40:51]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ascendrange:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestDescendGreaterThan(t *testing.T) {
+	tr := New(*btreeDegree)
+	for _, v := range perm(100) {
+		tr.ReplaceOrInsert(v)
+	}
+	var got []Item
+	tr.DescendGreaterThan(Int(40), func(a Item) bool {
+		got = append(got, a)
+		return true
+	})
+	if want := rangrev(100)[:59]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("descendgreaterthan:\n got: %v\nwant: %v", got, want)
+	}
+	got = got[:0]
+	tr.DescendGreaterThan(Int(40), func(a Item) bool {
+		if a.(Int) < 50 {
+			return false
+		}
+		got = append(got, a)
+		return true
+	})
+	if want := rangrev(100)[:50]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("descendgreaterthan:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+const benchmarkTreeSize = 10000
+
+func BenchmarkInsert(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	b.StartTimer()
+	i := 0
+	for i < b.N {
+		tr := New(*btreeDegree)
+		for _, item := range insertP {
+			tr.ReplaceOrInsert(item)
+			i++
+			if i >= b.N {
+				return
+			}
+		}
+	}
+}
+
+func BenchmarkSeek(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	insertP := perm(size)
+	tr := New(*btreeDegree)
+	for _, item := range insertP {
+		tr.ReplaceOrInsert(item)
+	}
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		tr.AscendGreaterOrEqual(Int(i%size), func(i Item) bool { return false })
+	}
+}
+
+func BenchmarkDeleteInsert(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, item := range insertP {
+		tr.ReplaceOrInsert(item)
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tr.Delete(insertP[i%benchmarkTreeSize])
+		tr.ReplaceOrInsert(insertP[i%benchmarkTreeSize])
+	}
+}
+
+func BenchmarkDeleteInsertCloneOnce(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, item := range insertP {
+		tr.ReplaceOrInsert(item)
+	}
+	tr = tr.Clone()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tr.Delete(insertP[i%benchmarkTreeSize])
+		tr.ReplaceOrInsert(insertP[i%benchmarkTreeSize])
+	}
+}
+
+func BenchmarkDeleteInsertCloneEachTime(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, item := range insertP {
+		tr.ReplaceOrInsert(item)
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tr = tr.Clone()
+		tr.Delete(insertP[i%benchmarkTreeSize])
+		tr.ReplaceOrInsert(insertP[i%benchmarkTreeSize])
+	}
+}
+
+func BenchmarkDelete(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	removeP := perm(benchmarkTreeSize)
+	b.StartTimer()
+	i := 0
+	for i < b.N {
+		b.StopTimer()
+		tr := New(*btreeDegree)
+		for _, v := range insertP {
+			tr.ReplaceOrInsert(v)
+		}
+		b.StartTimer()
+		for _, item := range removeP {
+			tr.Delete(item)
+			i++
+			if i >= b.N {
+				return
+			}
+		}
+		if tr.Len() > 0 {
+			panic(tr.Len())
+		}
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	removeP := perm(benchmarkTreeSize)
+	b.StartTimer()
+	i := 0
+	for i < b.N {
+		b.StopTimer()
+		tr := New(*btreeDegree)
+		for _, v := range insertP {
+			tr.ReplaceOrInsert(v)
+		}
+		b.StartTimer()
+		for _, item := range removeP {
+			tr.Get(item)
+			i++
+			if i >= b.N {
+				return
+			}
+		}
+	}
+}
+
+func BenchmarkGetCloneEachTime(b *testing.B) {
+	b.StopTimer()
+	insertP := perm(benchmarkTreeSize)
+	removeP := perm(benchmarkTreeSize)
+	b.StartTimer()
+	i := 0
+	for i < b.N {
+		b.StopTimer()
+		tr := New(*btreeDegree)
+		for _, v := range insertP {
+			tr.ReplaceOrInsert(v)
+		}
+		b.StartTimer()
+		for _, item := range removeP {
+			tr = tr.Clone()
+			tr.Get(item)
+			i++
+			if i >= b.N {
+				return
+			}
+		}
+	}
+}
+
+type byInts []Item
+
+func (a byInts) Len() int {
+	return len(a)
+}
+
+func (a byInts) Less(i, j int) bool {
+	return a[i].(Int) < a[j].(Int)
+}
+
+func (a byInts) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func BenchmarkAscend(b *testing.B) {
+	arr := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, v := range arr {
+		tr.ReplaceOrInsert(v)
+	}
+	sort.Sort(byInts(arr))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j := 0
+		tr.Ascend(func(item Item) bool {
+			if item.(Int) != arr[j].(Int) {
+				b.Fatalf("mismatch: expected: %v, got %v", arr[j].(Int), item.(Int))
+			}
+			j++
+			return true
+		})
+	}
+}
+
+func BenchmarkDescend(b *testing.B) {
+	arr := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, v := range arr {
+		tr.ReplaceOrInsert(v)
+	}
+	sort.Sort(byInts(arr))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j := len(arr) - 1
+		tr.Descend(func(item Item) bool {
+			if item.(Int) != arr[j].(Int) {
+				b.Fatalf("mismatch: expected: %v, got %v", arr[j].(Int), item.(Int))
+			}
+			j--
+			return true
+		})
+	}
+}
+func BenchmarkAscendRange(b *testing.B) {
+	arr := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, v := range arr {
+		tr.ReplaceOrInsert(v)
+	}
+	sort.Sort(byInts(arr))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j := 100
+		tr.AscendRange(Int(100), arr[len(arr)-100], func(item Item) bool {
+			if item.(Int) != arr[j].(Int) {
+				b.Fatalf("mismatch: expected: %v, got %v", arr[j].(Int), item.(Int))
+			}
+			j++
+			return true
+		})
+		if j != len(arr)-100 {
+			b.Fatalf("expected: %v, got %v", len(arr)-100, j)
+		}
+	}
+}
+
+func BenchmarkDescendRange(b *testing.B) {
+	arr := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, v := range arr {
+		tr.ReplaceOrInsert(v)
+	}
+	sort.Sort(byInts(arr))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j := len(arr) - 100
+		tr.DescendRange(arr[len(arr)-100], Int(100), func(item Item) bool {
+			if item.(Int) != arr[j].(Int) {
+				b.Fatalf("mismatch: expected: %v, got %v", arr[j].(Int), item.(Int))
+			}
+			j--
+			return true
+		})
+		if j != 100 {
+			b.Fatalf("expected: %v, got %v", len(arr)-100, j)
+		}
+	}
+}
+func BenchmarkAscendGreaterOrEqual(b *testing.B) {
+	arr := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, v := range arr {
+		tr.ReplaceOrInsert(v)
+	}
+	sort.Sort(byInts(arr))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j := 100
+		k := 0
+		tr.AscendGreaterOrEqual(Int(100), func(item Item) bool {
+			if item.(Int) != arr[j].(Int) {
+				b.Fatalf("mismatch: expected: %v, got %v", arr[j].(Int), item.(Int))
+			}
+			j++
+			k++
+			return true
+		})
+		if j != len(arr) {
+			b.Fatalf("expected: %v, got %v", len(arr), j)
+		}
+		if k != len(arr)-100 {
+			b.Fatalf("expected: %v, got %v", len(arr)-100, k)
+		}
+	}
+}
+func BenchmarkDescendLessOrEqual(b *testing.B) {
+	arr := perm(benchmarkTreeSize)
+	tr := New(*btreeDegree)
+	for _, v := range arr {
+		tr.ReplaceOrInsert(v)
+	}
+	sort.Sort(byInts(arr))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j := len(arr) - 100
+		k := len(arr)
+		tr.DescendLessOrEqual(arr[len(arr)-100], func(item Item) bool {
+			if item.(Int) != arr[j].(Int) {
+				b.Fatalf("mismatch: expected: %v, got %v", arr[j].(Int), item.(Int))
+			}
+			j--
+			k--
+			return true
+		})
+		if j != -1 {
+			b.Fatalf("expected: %v, got %v", -1, j)
+		}
+		if k != 99 {
+			b.Fatalf("expected: %v, got %v", 99, k)
+		}
+	}
+}
+
+const cloneTestSize = 10000
+
+func cloneTest(t *testing.T, b *BTree, start int, p []Item, wg *sync.WaitGroup, trees *[]*BTree) {
+	t.Logf("Starting new clone at %v", start)
+	*trees = append(*trees, b)
+	for i := start; i < cloneTestSize; i++ {
+		b.ReplaceOrInsert(p[i])
+		if i%(cloneTestSize/5) == 0 {
+			wg.Add(1)
+			go cloneTest(t, b.Clone(), i+1, p, wg, trees)
+		}
+	}
+	wg.Done()
+}
+
+func TestCloneConcurrentOperations(t *testing.T) {
+	b := New(*btreeDegree)
+	trees := []*BTree{}
+	p := perm(cloneTestSize)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go cloneTest(t, b, 0, p, &wg, &trees)
+	wg.Wait()
+	want := rang(cloneTestSize)
+	t.Logf("Starting equality checks on %d trees", len(trees))
+	for i, tree := range trees {
+		if !reflect.DeepEqual(want, all(tree)) {
+			t.Errorf("tree %v mismatch", i)
+		}
+	}
+	t.Log("Removing half from first half")
+	toRemove := rang(cloneTestSize)[cloneTestSize/2:]
+	for i := 0; i < len(trees)/2; i++ {
+		tree := trees[i]
+		wg.Add(1)
+		go func() {
+			for _, item := range toRemove {
+				tree.Delete(item)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	t.Log("Checking all values again")
+	for i, tree := range trees {
+		var wantpart []Item
+		if i < len(trees)/2 {
+			wantpart = want[:cloneTestSize/2]
+		} else {
+			wantpart = want
+		}
+		if got := all(tree); !reflect.DeepEqual(wantpart, got) {
+			t.Errorf("tree %v mismatch, want %v got %v", i, len(want), len(got))
+		}
+	}
+}
+
+func BenchmarkDeleteAndRestore(b *testing.B) {
+	items := perm(16392)
+	b.ResetTimer()
+	b.Run(`CopyBigFreeList`, func(b *testing.B) {
+		fl := NewFreeList(16392)
+		tr := NewWithFreeList(*btreeDegree, fl)
+		for _, v := range items {
+			tr.ReplaceOrInsert(v)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			dels := make([]Item, 0, tr.Len())
+			tr.Ascend(ItemIterator(func(b Item) bool {
+				dels = append(dels, b)
+				return true
+			}))
+			for _, del := range dels {
+				tr.Delete(del)
+			}
+			// tr is now empty, we make a new empty copy of it.
+			tr = NewWithFreeList(*btreeDegree, fl)
+			for _, v := range items {
+				tr.ReplaceOrInsert(v)
+			}
+		}
+	})
+	b.Run(`Copy`, func(b *testing.B) {
+		tr := New(*btreeDegree)
+		for _, v := range items {
+			tr.ReplaceOrInsert(v)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			dels := make([]Item, 0, tr.Len())
+			tr.Ascend(ItemIterator(func(b Item) bool {
+				dels = append(dels, b)
+				return true
+			}))
+			for _, del := range dels {
+				tr.Delete(del)
+			}
+			// tr is now empty, we make a new empty copy of it.
+			tr = New(*btreeDegree)
+			for _, v := range items {
+				tr.ReplaceOrInsert(v)
+			}
+		}
+	})
+	b.Run(`ClearBigFreelist`, func(b *testing.B) {
+		fl := NewFreeList(16392)
+		tr := NewWithFreeList(*btreeDegree, fl)
+		for _, v := range items {
+			tr.ReplaceOrInsert(v)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tr.Clear(true)
+			for _, v := range items {
+				tr.ReplaceOrInsert(v)
+			}
+		}
+	})
+	b.Run(`Clear`, func(b *testing.B) {
+		tr := New(*btreeDegree)
+		for _, v := range items {
+			tr.ReplaceOrInsert(v)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tr.Clear(true)
+			for _, v := range items {
+				tr.ReplaceOrInsert(v)
+			}
+		}
+	})
+}

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/LICENSE
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/LICENSE
@@ -1,0 +1,9 @@
+(The MIT License)
+
+Copyright (c) 2017 marvin + konsorten GmbH (open-source@konsorten.de)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
@@ -1,0 +1,41 @@
+# Windows Terminal Sequences
+
+This library allow for enabling Windows terminal color support for Go.
+
+See [Console Virtual Terminal Sequences](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) for details.
+
+## Usage
+
+```go
+import (
+	"syscall"
+	
+	sequences "github.com/konsorten/go-windows-terminal-sequences"
+)
+
+func main() {
+	sequences.EnableVirtualTerminalProcessing(syscall.Stdout, true)
+}
+
+```
+
+## Authors
+
+The tool is sponsored by the [marvin + konsorten GmbH](http://www.konsorten.de).
+
+We thank all the authors who provided code to this library:
+
+* Felix Kollmann
+* Nicolas Perraut
+
+## License
+
+(The MIT License)
+
+Copyright (c) 2018 marvin + konsorten GmbH (open-source@konsorten.de)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
@@ -1,0 +1,1 @@
+module github.com/konsorten/go-windows-terminal-sequences

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences.go
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences.go
@@ -1,0 +1,36 @@
+// +build windows
+
+package sequences
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32Dll    *syscall.LazyDLL  = syscall.NewLazyDLL("Kernel32.dll")
+	setConsoleMode *syscall.LazyProc = kernel32Dll.NewProc("SetConsoleMode")
+)
+
+func EnableVirtualTerminalProcessing(stream syscall.Handle, enable bool) error {
+	const ENABLE_VIRTUAL_TERMINAL_PROCESSING uint32 = 0x4
+
+	var mode uint32
+	err := syscall.GetConsoleMode(syscall.Stdout, &mode)
+	if err != nil {
+		return err
+	}
+
+	if enable {
+		mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING
+	} else {
+		mode &^= ENABLE_VIRTUAL_TERMINAL_PROCESSING
+	}
+
+	ret, _, err := setConsoleMode.Call(uintptr(unsafe.Pointer(stream)), uintptr(mode))
+	if ret == 0 {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences_dummy.go
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences_dummy.go
@@ -1,0 +1,11 @@
+// +build linux darwin
+
+package sequences
+
+import (
+	"fmt"
+)
+
+func EnableVirtualTerminalProcessing(stream uintptr, enable bool) error {
+	return fmt.Errorf("windows only package")
+}

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences_test.go
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences_test.go
@@ -1,0 +1,48 @@
+// +build windows
+
+package sequences
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestStdoutSequencesOn(t *testing.T) {
+	err := EnableVirtualTerminalProcessing(syscall.Stdout, true)
+	if err != nil {
+		t.Fatalf("Failed to enable VTP: %v", err)
+	}
+	defer EnableVirtualTerminalProcessing(syscall.Stdout, false)
+
+	fmt.Fprintf(os.Stdout, "\x1b[34mHello \x1b[35mWorld\x1b[0m!\n")
+}
+
+func TestStdoutSequencesOff(t *testing.T) {
+	err := EnableVirtualTerminalProcessing(syscall.Stdout, false)
+	if err != nil {
+		t.Fatalf("Failed to enable VTP: %v", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "\x1b[34mHello \x1b[35mWorld\x1b[0m!\n")
+}
+
+func TestStderrSequencesOn(t *testing.T) {
+	err := EnableVirtualTerminalProcessing(syscall.Stderr, true)
+	if err != nil {
+		t.Fatalf("Failed to enable VTP: %v", err)
+	}
+	defer EnableVirtualTerminalProcessing(syscall.Stderr, false)
+
+	fmt.Fprintf(os.Stderr, "\x1b[34mHello \x1b[35mWorld\x1b[0m!\n")
+}
+
+func TestStderrSequencesOff(t *testing.T) {
+	err := EnableVirtualTerminalProcessing(syscall.Stderr, false)
+	if err != nil {
+		t.Fatalf("Failed to enable VTP: %v", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "\x1b[34mHello \x1b[35mWorld\x1b[0m!\n")
+}


### PR DESCRIPTION
Adaptive trimming of completedRequests on server

* client keeps track of highest consecutive requestID which can be trimmed on server
* client piggybacks highest consecutive requestID on new requests
* every 100ms server trims completedRequests based on clients HCR.   This is controlled by tunable JSONRPCServer.RetryRPCAckTrim
* still trim completedRequests that are older than 10 minutes to handle long lived requests or requests which have hung