### PR TITLE
pfs_middleware: remove X-Bypass-ProxyFS header support

### DIFF
--- a/pfs_middleware/pfs_middleware/middleware.py
+++ b/pfs_middleware/pfs_middleware/middleware.py
@@ -778,9 +778,10 @@ class PfsMiddleware(object):
     def __call__(self, req):
         vrs, acc, con, obj = utils.parse_path(req.path)
 
-        # Alternate way to specify bypass mode: /proxyfs/AUTH_acct/...
+        # The only way to specify bypass mode: /proxyfs/AUTH_acct/...
+        proxyfs_path = False
         if vrs == 'proxyfs':
-            req.headers['X-Bypass-ProxyFS'] = 'true'
+            proxyfs_path = True
             req.path_info = req.path_info.replace('/proxyfs/', '/v1/', 1)
             vrs = 'v1'
 
@@ -829,7 +830,7 @@ class PfsMiddleware(object):
 
             ctx = RequestContext(req, proxyfsd_addrinfo, acc, con, obj)
             is_bypass_request = (
-                config_true_value(req.headers.get('X-Bypass-ProxyFS')) and
+                proxyfs_path and
                 self.bypass_mode in ('read-only', 'read-write'))
 
             # For requests that we make to Swift, we have to ensure that any

--- a/pfs_middleware/tests/test_pfs_middleware.py
+++ b/pfs_middleware/tests/test_pfs_middleware.py
@@ -263,13 +263,6 @@ class TestAccountGet(BaseMiddlewareTest):
             'GET', '/v1/AUTH_test', 200, {},
             '000000000000DACA\n000000000000DACC\n')
 
-        # Using header
-        req = swob.Request.blank("/v1/AUTH_test", headers={
-            "X-Bypass-ProxyFS": "true"}, environ={'swift_owner': True})
-        status, _, body = self.call_pfs(req)
-        self.assertEqual(status, '200 OK')
-        self.assertEqual(body, b'000000000000DACA\n000000000000DACC\n')
-
         # Using path
         req = swob.Request.blank("/proxyfs/AUTH_test", environ={
             'swift_owner': True})
@@ -284,14 +277,13 @@ class TestAccountGet(BaseMiddlewareTest):
         self.assertEqual(status, '200 OK')
         self.assertEqual(body, b'chickens\ncows\ngoats\npigs\n')
 
-        req = swob.Request.blank("/v1/AUTH_test", method='PUT', headers={
-            "X-Bypass-ProxyFS": "true"}, environ={'swift_owner': True})
+        req = swob.Request.blank("/proxyfs/AUTH_test", method='PUT',
+                                 environ={'swift_owner': True})
         status, _, _ = self.call_pfs(req)
         self.assertEqual(status, '405 Method Not Allowed')
 
         # Non-owner
-        req = swob.Request.blank("/v1/AUTH_test", headers={
-            "X-Bypass-ProxyFS": "true"})
+        req = swob.Request.blank("/proxyfs/AUTH_test")
         status, _, body = self.call_pfs(req)
         self.assertEqual(status, '200 OK')
         self.assertEqual(body, b'chickens\ncows\ngoats\npigs\n')


### PR DESCRIPTION
You need `/proxyfs/...` paths and new Swift to make things happy these days anyway.

While we're at it, make bimodal_checker aware of `/proxyfs/...` paths; how did this ever work before!?