### PR TITLE
Fix bugs in confgen and mkproxyfs.

### DIFF
--- a/confgen/api_internal.go
+++ b/confgen/api_internal.go
@@ -294,7 +294,7 @@ func computeInitial(envMap EnvMap, confFilePath string, confOverrides []string, 
 	for _, volume = range localVolumeMap {
 		if "" != volume.FUSEMountPointName {
 			cmdString := ""
-			cmdString += fmt.Sprintf("if [ ! -d '%s'; then\n", volume.FUSEMountPointName)
+			cmdString += fmt.Sprintf("if [ ! -d '%s' ]; then\n", volume.FUSEMountPointName)
 			cmdString += fmt.Sprintf("    mkdir -p -m 0%03o '%s'\n", fuseDirPerm, volume.FUSEMountPointName)
 			cmdString += fmt.Sprintf("fi\n")
 

--- a/mkproxyfs/mkproxyfs/main.go
+++ b/mkproxyfs/mkproxyfs/main.go
@@ -55,7 +55,7 @@ func main() {
 	if nil == err {
 		os.Exit(0)
 	} else {
-		fmt.Printf("mkproxyfs.Format() returned error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "mkproxyfs: Format() returned error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
confen was emitting scripts to make /share directories that had syntax
errors so they wouldn't run (a missing closing `]` in an if statement.
annoyingly, running the script still exited with 0.

mkproxyfs was sending an error message to stdout so etcd-mgmt was not
picking it up.  change it to send the message to stderr.