### PR TITLE
Fix another issue with confgen.

### DIFF
--- a/confgen/api_internal.go
+++ b/confgen/api_internal.go
@@ -293,9 +293,14 @@ func computeInitial(envMap EnvMap, confFilePath string, confOverrides []string, 
 
 	for _, volume = range localVolumeMap {
 		if "" != volume.FUSEMountPointName {
+			// if the directory exists and the file system is mounted but
+			// proxyfs is not running, the '-d' test will return false and the
+			// mkdir will fail with EEXIST, so append "|| true" to the mkdir
+			// so the script won't fail
 			cmdString := ""
 			cmdString += fmt.Sprintf("if [ ! -d '%s' ]; then\n", volume.FUSEMountPointName)
-			cmdString += fmt.Sprintf("    mkdir -p -m 0%03o '%s'\n", fuseDirPerm, volume.FUSEMountPointName)
+			cmdString += fmt.Sprintf("    mkdir -p -m 0%03o '%s' || true\n",
+				fuseDirPerm, volume.FUSEMountPointName)
 			cmdString += fmt.Sprintf("fi\n")
 
 			_, err = fuseSetupFile.WriteString(cmdString)


### PR DESCRIPTION
the fuse_setup.bash script that it generates looks like:

set -e
if [ ! -d '/share/craigfs' ]; then
    mkdir -p -m 0000 '/share/craigfs'
fi

if '/share/craigfs' exists and has a file system mounted but proxyfs is
not running, the "-d '/share/craigfs'" will evaluate false so then the
mkdir will run.  the mkdir will fail with EEXIST and the script will abort
(due to "set -e").

about the only thing i can see to do is override the mkdir failure like so:

set -e
if [ ! -d '/share/craigfs' ]; then
    mkdir -p -m 0000 '/share/craigfs' || true
fi

Changed confgen to do that.