### PR TITLE
Setup min for RetryRPCAckTrim and don't panic if can't find entry

### DIFF
--- a/jrpcfs/config.go
+++ b/jrpcfs/config.go
@@ -105,8 +105,8 @@ func (dummy *globalsStruct) Up(confMap conf.ConfMap) (err error) {
 		}
 		globals.retryRPCAckTrim, err = confMap.FetchOptionValueDuration("JSONRPCServer", "RetryRPCAckTrim")
 		if nil != err {
-			logger.ErrorfWithError(err, "failed to get JSONRPCServer.RetryRPCAckTrim from config file")
-			return
+			logger.Infof("failed to get JSONRPCServer.RetryRPCAckTrim from config file - defaulting to 100ms")
+			globals.retryRPCAckTrim = 100 * time.Millisecond
 		}
 	} else {
 		logger.Infof("failed to get JSONRPCServer.RetryRPCPort from config file - skipping......")

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -33,6 +33,7 @@ func (client *Client) send(method string, rpcRequest interface{}, rpcReply inter
 		// TODO - should this keep retrying the dial?
 		err = client.dial()
 		if err != nil {
+			client.Unlock()
 			return
 		}
 	}


### PR DESCRIPTION
Set a minimum for RetryRPCAckTrim

If we can't find entry in ci.completedRequest just skip it
