### PR TITLE
Feature/pfsagent config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ gobinsubdirs = \
 	pfs-stress \
 	pfs-swift-load \
 	pfsagentd \
+	pfsagentConfig \
+	pfsagentConfig/pfsagentConfig \
 	pfsconfjson \
 	pfsconfjsonpacked \
 	pfsworkout \

--- a/pfsagentConfig/Makefile
+++ b/pfsagentConfig/Makefile
@@ -1,0 +1,3 @@
+gosubdir := github.com/swiftstack/ProxyFS/pfsagentConfig
+
+include ../GoMakefile

--- a/pfsagentConfig/dataStructures.go
+++ b/pfsagentConfig/dataStructures.go
@@ -1,0 +1,87 @@
+package pfsagentConfig
+
+import "fmt"
+
+type stringStack struct {
+	items []string
+}
+
+type stringArrayStack struct {
+	items [][]string
+}
+
+type stringMapStack struct {
+	items []map[string]string
+}
+
+func (s stringStack) push(val string) (err error) {
+	if len(val) == 0 {
+		err = fmt.Errorf("value cannot be zero-length")
+	} else {
+		s.items = append(s.items, val)
+	}
+	return
+}
+
+func (s stringStack) pop() (val string) {
+	if len(s.items) == 0 {
+		return
+	}
+	val = s.peek()
+	s.items = s.items[:len(s.items)-2]
+
+	return
+}
+
+func (s stringStack) peek() (val string) {
+	val = s.items[len(s.items)-1]
+	return
+}
+
+func (s stringArrayStack) push(val []string) (err error) {
+	if len(val) == 0 {
+		err = fmt.Errorf("value cannot be zero-length")
+	} else {
+		s.items = append(s.items, val)
+	}
+	return
+}
+
+func (s stringArrayStack) pop() (val []string) {
+	if len(s.items) == 0 {
+		return
+	}
+	val = s.peek()
+	s.items = s.items[:len(s.items)-2]
+
+	return
+}
+
+func (s stringArrayStack) peek() (val []string) {
+	val = s.items[len(s.items)-1]
+	return
+}
+
+func (s stringMapStack) push(val map[string]string) (err error) {
+	if len(val) == 0 {
+		err = fmt.Errorf("value cannot be zero-length")
+	} else {
+		s.items = append(s.items, val)
+	}
+	return
+}
+
+func (s stringMapStack) pop() (val map[string]string) {
+	if len(s.items) == 0 {
+		return
+	}
+	val = s.peek()
+	s.items = s.items[:len(s.items)-2]
+
+	return
+}
+
+func (s stringMapStack) peek() (val map[string]string) {
+	val = s.items[len(s.items)-1]
+	return
+}

--- a/pfsagentConfig/menu.go
+++ b/pfsagentConfig/menu.go
@@ -1,0 +1,37 @@
+package pfsagentConfig
+
+import (
+	"fmt"
+)
+
+func nextMenu(menuText string, menuOptions []string, menuOptionsTexts map[string]string) (userResponse string, err error) {
+	fmt.Println(menuText)
+	for {
+		displayOptions(menuOptions, menuOptionsTexts)
+		userResponse, err = getUserInput()
+		// fmt.Printf("raw response: %v\n", response)
+		if nil != err {
+			fmt.Println("Error retrieving user input", err)
+			continue
+		}
+		if len(userResponse) != 1 {
+			fmt.Printf("Input should be a single character. You entered %v. Please try again\n", userResponse)
+			continue
+		}
+		for _, validInput := range menuOptions {
+			if validInput == userResponse {
+				return menuOptionsTexts[userResponse], nil
+			}
+
+		}
+		fmt.Printf("Your input is not valid: '%v'. Options are: %v. Please try again\n\n", userResponse, menuOptions)
+	}
+	// return "", fmt.Errorf("Something went wrong trying to read user input")
+}
+
+func displayOptions(optionsList []string, optionsTextsMap map[string]string) {
+	for _, option := range optionsList {
+		fmt.Printf("%v:\t%v\n", option, optionsTextsMap[option])
+	}
+	fmt.Printf("\nYour Selection: ")
+}

--- a/pfsagentConfig/pfsagentConfig/Makefile
+++ b/pfsagentConfig/pfsagentConfig/Makefile
@@ -1,0 +1,3 @@
+gosubdir := github.com/swiftstack/ProxyFS/pfsagentConfig/pfsagentConfig
+
+include ../../GoMakefile

--- a/pfsagentConfig/pfsagentConfig/help.go
+++ b/pfsagentConfig/pfsagentConfig/help.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+var (
+	usageText string = fmt.Sprintf(`
+%v is a config utility for the SwiftStack ProxyFS Agent (pfsagentd).
+
+It can be used interactively by just calling it with no parameters, as such:
+%[1]v
+
+[FUTURE] Or it can be used non-interactively by stating the parameter(s) you wish to modify, as such:
+%[1]v swiftAuthURL <auth url> swiftAuthUser <username>....
+
+For both interactive and non-interactive, the utility expects to find the the PFSagent config file at %[2]v. If you wish to use a different path, type
+%[1]v configFile /path/to/config/file
+
+For a longer explanation, you can type
+%[1]v help
+
+Which will also list all paraemters available for change.
+For explanation about a specific parameter, type
+%[1]v help <parameter>
+
+To print this short usage message, type
+%[1]v usage
+
+`, os.Args[0], defaultConfigPath)
+)
+
+var version = fmt.Sprintf(`
+	pfsagentConfig
+		Client version: %v
+		API version: %v
+`, "0.0.1", "0.0.1")
+
+// `, globalConf.Version, globalConf.APIVersion)

--- a/pfsagentConfig/pfsagentConfig/main.go
+++ b/pfsagentConfig/pfsagentConfig/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	pfsagentConfig "github.com/swiftstack/ProxyFS/pfsagentConfig"
+)
+
+const (
+	defaultConfigPath string = "/etc/pfsagent/"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		loadError := pfsagentConfig.LoadConfig("")
+		if nil != loadError {
+			fmt.Println("Failed loading config. Error:", loadError)
+			os.Exit(1)
+		}
+		pfsagentConfig.RunStateMachine()
+		os.Exit(0)
+	}
+
+	switch os.Args[1] {
+	case "firstRun":
+		err := firstTimeRun()
+		if nil != err {
+			fmt.Println(err)
+			os.Exit(2)
+		}
+		os.Exit(0)
+	case "configPath":
+		if len(os.Args) > 1 {
+			pfsagentConfig.ConfigPath = os.Args[2]
+			loadError := pfsagentConfig.LoadConfig("")
+			if nil != loadError {
+				fmt.Println("Failed loading config. Error:", loadError)
+				os.Exit(1)
+			}
+			pfsagentConfig.RunStateMachine()
+			os.Exit(0)
+		}
+		fmt.Print(usageText)
+		os.Exit(2)
+	case "version":
+		fmt.Print(version)
+		os.Exit(0)
+	case "usage":
+		fmt.Print(usageText)
+		os.Exit(0)
+	default:
+		fmt.Print(usageText)
+		os.Exit(2)
+	}
+}
+
+func firstTimeRun() error {
+	return pfsagentConfig.FirstTimeRun()
+}

--- a/pfsagentConfig/stateMachine.go
+++ b/pfsagentConfig/stateMachine.go
@@ -1,0 +1,416 @@
+package pfsagentConfig
+
+import (
+	"fmt"
+	"os"
+)
+
+// RunStateMachine run the state machine controlling the wizard flow
+func RunStateMachine() (err error) {
+	// fmt.Println("runWizard starting")
+	prevMenuText := new(stringStack)
+	prevMenuOptions := new(stringArrayStack)
+	prevMenuOptionsTexts := new(stringMapStack)
+	prevMenuText.push(mainMenuText)
+	prevMenuOptions.push(mainMenuOptions)
+	prevMenuOptionsTexts.push(mainMenuOptionsTexts)
+
+	nextMenuText := mainMenuText
+	nextMenuOptions := mainMenuOptions
+	nextMenuOptionsTexts := mainMenuOptionsTexts
+	for {
+		menuResponse, displayErr := nextMenu(nextMenuText, nextMenuOptions, nextMenuOptionsTexts)
+		// fmt.Printf("menuResponse: %v\n", menuResponse)
+		if nil != displayErr {
+			// fmt.Println("ERROR while displaying menu item", displayErr)
+			err = fmt.Errorf("error trying to display menu item")
+			return
+		}
+		switch menuResponse {
+		case quitMenuOptionText:
+			fmt.Println("Thank you for using the pfsagent config util")
+			return
+		case backMenuOptionText:
+			nextMenuText = prevMenuText.pop()
+			nextMenuOptions = prevMenuOptions.pop()
+			nextMenuOptionsTexts = prevMenuOptionsTexts.pop()
+		case changeCredsOptionText:
+			// fmt.Printf("got %v\n", changeCredsOptionText)
+			prevMenuText.push(nextMenuText)
+			prevMenuOptions.push(nextMenuOptions)
+			prevMenuOptionsTexts.push(nextMenuOptionsTexts)
+			nextMenuText = credentialsMenuTexts
+			nextMenuOptions = credentialsMenuOptions
+			nextMenuOptionsTexts = credentialsMenuOptionsTexts
+		case changeOtherOptionText:
+			fmt.Printf("got %v\n", changeOtherOptionText)
+
+		case changeAuthURLOptionText:
+			userResponse, userInputErr := getValueFromUser("Swift Auth URL", "", confMap["Agent"]["SwiftAuthURL"][0])
+			if nil != userInputErr {
+				fmt.Printf(userInputErrorMessage, userInputErr)
+				return userInputErr
+			}
+			prevAuthURL := confMap["Agent"]["SwiftAuthURL"][0]
+			confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthURL", userResponse))
+			whatFailed, accessErr := ValidateAccess()
+			if nil != accessErr {
+				switch whatFailed {
+				case typeAuthURL:
+					confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthURL", prevAuthURL))
+					fmt.Printf(failureMessageHeader)
+					fmt.Printf(authURLFailedMessage, accessErr)
+					fmt.Printf(failureMessageFooter)
+				case typeCredentails:
+					fmt.Printf(needMoreInfoMessageHeader)
+					fmt.Printf(credentialsFailedMessage, confMap["Agent"]["SwiftAuthUser"][0], confMap["Agent"]["SwiftAuthKey"][0], accessErr)
+					SaveCurrentConfig()
+					fmt.Printf(authURLSetMessage, confMap["Agent"]["SwiftAuthURL"][0])
+					fmt.Printf(needMoreInfoMessageFooter)
+				case typeAccount:
+					fmt.Printf(needMoreInfoMessageHeader)
+					fmt.Printf(accountFailedMessage, confMap["Agent"]["SwiftAccountName"][0], confMap["Agent"]["SwiftAuthUser"][0], accessErr)
+					SaveCurrentConfig()
+					fmt.Printf(authURLSetMessage, confMap["Agent"]["SwiftAuthURL"][0])
+					fmt.Println(changesSavedMessage)
+					fmt.Printf(needMoreInfoMessageFooter)
+				}
+			} else {
+				fmt.Printf(successMessageHeader)
+				fmt.Printf(accessCheckSucceededMessage)
+				fmt.Printf(authURLSetMessage, confMap["Agent"]["SwiftAuthURL"][0])
+				SaveCurrentConfig()
+				fmt.Println(changesSavedMessage)
+				fmt.Printf(successMessageFooter)
+				nextMenuText = mainMenuText
+				nextMenuOptions = mainMenuOptions
+				nextMenuOptionsTexts = mainMenuOptionsTexts
+			}
+
+		case changeUsernameOptionText:
+			userResponse, userInputErr := getValueFromUser("Swift Username", "", confMap["Agent"]["SwiftAuthUser"][0])
+			if nil != userInputErr {
+				fmt.Printf(userInputErrorMessage, userInputErr)
+				return userInputErr
+			}
+			prevAuthUser := confMap["Agent"]["SwiftAuthUser"][0]
+			confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthUser", userResponse))
+			whatFailed, accessErr := ValidateAccess()
+			if nil != accessErr {
+				switch whatFailed {
+				case typeAuthURL:
+					confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthUser", prevAuthUser))
+					fmt.Printf(failureMessageHeader)
+					fmt.Printf(authURLFailedMessage, accessErr)
+					fmt.Printf(failureMessageFooter)
+				case typeCredentails:
+					fmt.Printf(userSetMessage, confMap["Agent"]["SwiftAuthUser"][0])
+					SaveCurrentConfig()
+					fmt.Println(changesSavedMessage)
+					fmt.Printf(failureMessageHeader)
+					fmt.Printf(credentialsFailedMessage, userResponse, confMap["Agent"]["SwiftAuthKey"][0], accessErr)
+					fmt.Printf(failureMessageFooter)
+				case typeAccount:
+					fmt.Printf(needMoreInfoMessageHeader)
+					fmt.Printf(accountFailedMessage, confMap["Agent"]["SwiftAccountName"][0], confMap["Agent"]["SwiftAuthUser"][0], accessErr)
+					// MyConfig.SwiftAuthUser = userResponse
+					fmt.Printf(userSetMessage, confMap["Agent"]["SwiftAuthUser"][0])
+					SaveCurrentConfig()
+					fmt.Println(changesSavedMessage)
+					fmt.Printf(needMoreInfoMessageFooter)
+				}
+			} else {
+				fmt.Printf(successMessageHeader)
+				fmt.Printf(accessCheckSucceededMessage)
+				// MyConfig.SwiftAuthUser = userResponse
+				fmt.Printf(userSetMessage, confMap["Agent"]["SwiftAuthUser"][0])
+				SaveCurrentConfig()
+				fmt.Println(changesSavedMessage)
+				fmt.Printf(successMessageFooter)
+				nextMenuText = mainMenuText
+				nextMenuOptions = mainMenuOptions
+				nextMenuOptionsTexts = mainMenuOptionsTexts
+			}
+
+		case changeKeyOptionText:
+			userResponse, userInputErr := getValueFromUser("Swift User Key", "", confMap["Agent"]["SwiftAuthKey"][0])
+			if nil != userInputErr {
+				fmt.Printf(userInputErrorMessage, userInputErr)
+				return userInputErr
+			}
+			prevAuthKey := confMap["Agent"]["SwiftAuthKey"][0]
+			confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthKey", userResponse))
+			whatFailed, accessErr := ValidateAccess()
+			if nil != accessErr {
+				switch whatFailed {
+				case typeAuthURL:
+					confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthKey", prevAuthKey))
+					fmt.Printf(failureMessageHeader)
+					fmt.Printf(authURLFailedMessage, accessErr)
+					fmt.Printf(failureMessageFooter)
+				case typeCredentails:
+					// MyConfig.SwiftAuthKey = prevAuthKey
+					fmt.Printf(keySetMessage, confMap["Agent"]["SwiftAuthKey"][0])
+					SaveCurrentConfig()
+					fmt.Println(changesSavedMessage)
+					fmt.Printf(failureMessageHeader)
+					fmt.Printf(credentialsFailedMessage, confMap["Agent"]["SwiftAuthUser"][0], userResponse, accessErr)
+					fmt.Printf(failureMessageFooter)
+				case typeAccount:
+					fmt.Printf(needMoreInfoMessageHeader)
+					fmt.Printf(accountFailedMessage, confMap["Agent"]["SwiftAccountName"][0], confMap["Agent"]["SwiftAuthUser"][0], accessErr)
+					// MyConfig.SwiftAuthKey = userResponse
+					fmt.Printf(keySetMessage, confMap["Agent"]["SwiftAuthKey"][0])
+					SaveCurrentConfig()
+					fmt.Println(changesSavedMessage)
+					fmt.Printf(needMoreInfoMessageFooter)
+				}
+			} else {
+				fmt.Printf(successMessageHeader)
+				fmt.Printf(accessCheckSucceededMessage)
+				// MyConfig.SwiftAuthKey = userResponse
+				fmt.Printf(keySetMessage, confMap["Agent"]["SwiftAuthKey"][0])
+				SaveCurrentConfig()
+				fmt.Println(changesSavedMessage)
+				fmt.Printf(successMessageFooter)
+				nextMenuText = mainMenuText
+				nextMenuOptions = mainMenuOptions
+				nextMenuOptionsTexts = mainMenuOptionsTexts
+			}
+
+		case changeAccountOptionText:
+			userResponse, userInputErr := getValueFromUser("Swift Account", "", confMap["Agent"]["SwiftAccountName"][0])
+			if nil != userInputErr {
+				fmt.Printf(userInputErrorMessage, userInputErr)
+				return userInputErr
+			}
+			prevAccountName := confMap["Agent"]["SwiftAccountName"][0]
+			confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAccountName", userResponse))
+			whatFailed, accessErr := ValidateAccess()
+			if nil != accessErr {
+				fmt.Printf(failureMessageHeader)
+				confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAccountName", prevAccountName))
+				switch whatFailed {
+				case typeAuthURL:
+					fmt.Printf(authURLFailedMessage, accessErr)
+				case typeCredentails:
+					fmt.Printf(credentialsFailedMessage, confMap["Agent"]["SwiftAuthUser"][0], confMap["Agent"]["SwiftAuthKey"][0], accessErr)
+				case typeAccount:
+					fmt.Printf(accountFailedMessage, confMap["Agent"]["SwiftAccountName"][0], confMap["Agent"]["SwiftAuthUser"][0], accessErr)
+				}
+				fmt.Printf(failureMessageFooter)
+			} else {
+				fmt.Printf(successMessageHeader)
+				fmt.Printf(accessCheckSucceededMessage)
+				// MyConfig.SwiftAccountName = userResponse
+				fmt.Printf(accountSetMessage, confMap["Agent"]["SwiftAccountName"][0])
+
+				SaveCurrentConfig()
+				fmt.Println(changesSavedMessage)
+				fmt.Printf(successMessageFooter)
+				nextMenuText = mainMenuText
+				nextMenuOptions = mainMenuOptions
+				nextMenuOptionsTexts = mainMenuOptionsTexts
+			}
+
+		default:
+			fmt.Printf("got unknown response: %v\n", menuResponse)
+		}
+	}
+}
+
+// FirstTimeRun is to be called for the first (initial) run of pfsagentConfig
+// to create an initial real config
+func FirstTimeRun() error {
+	loadError := LoadConfig("")
+	if nil != loadError {
+		fmt.Println("Failed loading config. Error:", loadError)
+		os.Exit(1)
+	}
+
+	var oldAuthURL string
+	var oldAuthUser string
+	var oldAuthKey string
+	var oldAccount string
+	var oldMount string
+	var oldVolName string
+	var oldLogPath string
+
+	if len(confMap["Agent"]["SwiftAuthURL"]) > 0 {
+		oldAuthURL = confMap["Agent"]["SwiftAuthURL"][0]
+	}
+	if len(confMap["Agent"]["SwiftAuthUser"]) > 0 {
+		oldAuthUser = confMap["Agent"]["SwiftAuthUser"][0]
+	}
+	if len(confMap["Agent"]["SwiftAuthKey"]) > 0 {
+		oldAuthKey = confMap["Agent"]["SwiftAuthKey"][0]
+	}
+	if len(confMap["Agent"]["SwiftAccountName"]) > 0 {
+		oldAccount = confMap["Agent"]["SwiftAccountName"][0]
+	}
+	if len(confMap["Agent"]["FUSEMountPointPath"]) > 0 {
+		oldMount = confMap["Agent"]["FUSEMountPointPath"][0]
+	}
+	if len(confMap["Agent"]["FUSEVolumeName"]) > 0 {
+		oldVolName = confMap["Agent"]["FUSEVolumeName"][0]
+	}
+	if len(confMap["Agent"]["LogFilePath"]) > 0 {
+		oldLogPath = confMap["Agent"]["LogFilePath"][0]
+	}
+
+	fmt.Println(firstTimeCredentialsMenu)
+	mySwiftParams := new(SwiftParams)
+
+	me := confMap["Agent"]
+	fmt.Println(me)
+	// validAuthURL := false
+	for {
+		userURLResponse, userURLInputErr := getValueFromUser("Swift Auth URL", authURLHint, "")
+		fmt.Println()
+		if nil != userURLInputErr {
+			return fmt.Errorf(userInputErrorMessage, userURLInputErr)
+		}
+		mySwiftParams.AuthURL = userURLResponse
+		userURLValidateErr := validateURL(mySwiftParams)
+		if nil != userURLValidateErr {
+			fmt.Printf(failureMessageHeader)
+			fmt.Printf("%v\n\n", userURLValidateErr)
+			fmt.Printf(failureMessageFooter)
+		} else {
+			confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthURL", userURLResponse))
+			break
+		}
+	}
+
+	for {
+		userUserResponse, userUserInputErr := getValueFromUser("Swift Auth User", usernameHint, "")
+		fmt.Println()
+		if nil != userUserInputErr {
+			return fmt.Errorf(userInputErrorMessage, userUserInputErr)
+		}
+
+		userKeyResponse, userKeyInputErr := getValueFromUser("Swift Auth Key", keyHint, "")
+		fmt.Println()
+		if nil != userKeyInputErr {
+			return fmt.Errorf(userInputErrorMessage, userKeyInputErr)
+		}
+		mySwiftParams.User = userUserResponse
+		mySwiftParams.Key = userKeyResponse
+
+		token, credValidationErr := validateCredentails(mySwiftParams)
+		if nil != credValidationErr {
+			fmt.Printf(failureMessageHeader)
+			fmt.Printf("%v\n\n", credValidationErr)
+			fmt.Printf(failureMessageFooter)
+		} else {
+			confMap.UpdateFromStrings([]string{
+				fmt.Sprintf("%v : %v", "Agent.SwiftAuthUser", userUserResponse),
+				fmt.Sprintf("%v : %v", "Agent.SwiftAuthKey", userKeyResponse),
+			})
+			mySwiftParams.AuthToken = token
+			break
+		}
+	}
+	fmt.Printf("mySwiftParams: %v\n", mySwiftParams)
+
+	validAccount := false
+	for !validAccount {
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAccountName", fmt.Sprintf("AUTH_%v", confMap["Agent"]["SwiftAuthUser"][0])))
+
+		userAccountResponse, userAccountInputErr := getValueFromUser("Swift Account", accountHint, confMap["Agent"]["SwiftAccountName"][0])
+		fmt.Println()
+		if nil != userAccountInputErr {
+			return fmt.Errorf(userInputErrorMessage, userAccountInputErr)
+		}
+		if len(userAccountResponse) == 0 {
+			userAccountResponse = confMap["Agent"]["SwiftAccountName"][0]
+		}
+
+		mySwiftParams.Account = userAccountResponse
+		accountValidationErr := validateAccount(mySwiftParams)
+		if nil != accountValidationErr {
+			fmt.Printf(failureMessageHeader)
+			fmt.Printf("%v\n\n", accountValidationErr)
+			fmt.Printf(failureMessageFooter)
+			mySwiftParams.StorageURL = ""
+		} else {
+			confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAccountName", userAccountResponse))
+			validAccount = true
+		}
+	}
+
+	suggestedMount := fmt.Sprintf("%v/vol_%v", defaultMountPath, confMap["Agent"]["SwiftAccountName"][0])
+	suggestedLogs := fmt.Sprintf("%v/log.%v", defaultLogPath, confMap["Agent"]["SwiftAccountName"][0])
+
+	confMap.UpdateFromStrings([]string{
+		fmt.Sprintf("%v : %v", "Agent.LogFilePath", suggestedLogs),
+		fmt.Sprintf("%v : %v", "Agent.FUSEMountPointPath", suggestedMount),
+		fmt.Sprintf("%v : %v", "Agent.FUSEVolumeName", confMap["Agent"]["SwiftAccountName"][0]),
+	})
+
+	volNameResponse, volNameInputErr := getValueFromUser("Volume Name", volNameHint, confMap["Agent"]["SwiftAccountName"][0])
+	fmt.Println()
+	if nil != volNameInputErr {
+		return fmt.Errorf(userInputErrorMessage, volNameInputErr)
+	}
+	if len(volNameResponse) > 0 {
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.FUSEVolumeName", volNameResponse))
+	}
+
+	mountPathResponse, mountPathInputErr := getValueFromUser("Mount Point", mountPointHint, confMap["Agent"]["FUSEMountPointPath"][0])
+	fmt.Println()
+	if nil != mountPathInputErr {
+		return fmt.Errorf(userInputErrorMessage, mountPathInputErr)
+	}
+	if len(mountPathResponse) > 0 {
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.FUSEMountPointPath", mountPathResponse))
+	}
+
+	whatFailed, accessErr := ValidateAccess()
+	if nil != accessErr {
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthURL", oldAuthURL))
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthUser", oldAuthUser))
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAuthKey", oldAuthKey))
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.SwiftAccountName", oldAccount))
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.FUSEMountPointPath", oldMount))
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.FUSEVolumeName", oldVolName))
+		confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.LogFilePath", oldLogPath))
+		fmt.Printf(failureMessageHeader)
+		switch whatFailed {
+		case typeAuthURL:
+			fmt.Printf(authURLFailedMessage, accessErr)
+		case typeCredentails:
+			fmt.Printf(credentialsFailedMessage, confMap["Agent"]["SwiftAuthUser"][0], confMap["Agent"]["SwiftAuthKey"][0], accessErr)
+			fmt.Printf(authURLSetMessage, confMap["Agent"]["SwiftAuthURL"][0])
+		case typeAccount:
+			fmt.Printf(accountFailedMessage, confMap["Agent"]["SwiftAccountName"][0], confMap["Agent"]["SwiftAuthUser"][0], accessErr)
+			fmt.Printf(authURLSetMessage, confMap["Agent"]["SwiftAuthURL"][0])
+			fmt.Println(changesSavedMessage)
+		}
+		fmt.Printf(failureMessageFooter)
+	} else {
+		fmt.Printf(successMessageHeader)
+		fmt.Println(accessCheckSucceededMessage)
+
+		if _, err := os.Stat(confMap["Agent"]["LogFilePath"][0]); os.IsNotExist(err) {
+			err = os.MkdirAll(confMap["Agent"]["LogFilePath"][0], 0755)
+			if err != nil {
+				fmt.Printf(failureMessageHeader)
+				panic(err)
+			}
+		}
+
+		if _, err := os.Stat(confMap["Agent"]["FUSEMountPointPath"][0]); os.IsNotExist(err) {
+			err = os.MkdirAll(confMap["Agent"]["FUSEMountPointPath"][0], 0755)
+			if err != nil {
+				fmt.Printf(failureMessageHeader)
+				panic(err)
+			}
+		}
+		SaveCurrentConfig()
+		fmt.Println(changesSavedMessage)
+		fmt.Printf(successMessageFooter)
+	}
+
+	return nil
+}

--- a/pfsagentConfig/strings.go
+++ b/pfsagentConfig/strings.go
@@ -1,0 +1,76 @@
+package pfsagentConfig
+
+const (
+	typeAuthURL int = iota
+	typeCredentails
+	typeAccount
+)
+
+const (
+	mainMenuText = `
+This is a utility to set the parameters for your PFSagentd. It can help you set/modify the access credentials or change any runtime parameters.
+Please choose the right option from the menu below:
+`
+
+	firstTimeCredentialsMenu = `It seems like this is the first time, so let's run through everything:`
+
+	credentialsMenuTexts = `
+This menu lets you set the access parameters.
+`
+
+	mainMenuOptionText = "Return To Main Menu"
+	quitMenuOptionText = "Quit"
+	backMenuOptionText = "Back"
+
+	changeCredsOptionText = "Change Access Credentials"
+	changeOtherOptionText = "Change Other Parameters"
+
+	changeAuthURLOptionText   = "Change Auth URL"
+	changeUsernameOptionText  = "Change Username"
+	changeKeyOptionText       = "Change User Key"
+	changeAccountOptionText   = "Change Account"
+	changeMountOptionText     = "Change Mount Point"
+	successMessageHeader      = "\n\n++++++++++++++++++++++++++    SUCCESS    ++++++++++++++++++++++++++\n\n"
+	successMessageFooter      = "\n+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n\n"
+	failureMessageHeader      = "\n\n**************************     ERROR     **************************\n\n"
+	failureMessageFooter      = "\n*******************************************************************\n\n"
+	needMoreInfoMessageHeader = "\n\n//////////////////////////   ATTENTION   //////////////////////////\n\n"
+	needMoreInfoMessageFooter = "\n///////////////////////////////////////////////////////////////////\n\n"
+	authURLHint               = "The Auth URL Is Used To Authenticate And Get An Auth Token"
+	usernameHint              = "A Valid User For The SwiftStack Cluster"
+	keyHint                   = "A Valid Key (Password) For The SwiftStack Cluster User"
+	accountHint               = "The Account To Log Into. Usually In This Form: AUTH_xxxx"
+	volNameHint               = "The Name For This Volume .This Will Be Used To Identify This Configuration, As Well As The Mount Point And Log File"
+	mountPointHint            = "The Mount Point For This Volume"
+)
+
+var (
+	mainMenuOptions      = []string{"1", "2", "q"}
+	mainMenuOptionsTexts = map[string]string{
+		mainMenuOptions[0]: changeCredsOptionText,
+		mainMenuOptions[1]: changeOtherOptionText,
+		mainMenuOptions[2]: quitMenuOptionText,
+	}
+	credentialsMenuOptions      = []string{"1", "2", "3", "4", "b", "q"}
+	credentialsMenuOptionsTexts = map[string]string{
+		credentialsMenuOptions[0]: changeAuthURLOptionText,
+		credentialsMenuOptions[1]: changeUsernameOptionText,
+		credentialsMenuOptions[2]: changeKeyOptionText,
+		credentialsMenuOptions[3]: changeAccountOptionText,
+		credentialsMenuOptions[4]: mainMenuOptionText,
+		credentialsMenuOptions[5]: quitMenuOptionText,
+	}
+)
+
+const (
+	userInputErrorMessage       = "Error Reading Input From User\n%v"
+	authURLFailedMessage        = "Auth URL Failed, So I Could Not Check User And Key. Please Verify Auth URL\n%v\n\n"
+	credentialsFailedMessage    = "Auth URL Works, But I Got An Error Trying To Login With Credentails\nUser: %v\nKey: %v\n%v\n\n"
+	accountFailedMessage        = "Auth URL And Credentials Works, But I Could Not Gain Access To Account %v. Please Verify The Account Exists And User %v Has The Correct Access Permissions\n%v\n\n"
+	changesSavedMessage         = "Changes Saved To File"
+	accessCheckSucceededMessage = "All Access Checks Succeeded"
+	accountSetMessage           = "Swift Account Set To %v\n"
+	userSetMessage              = "Swift User Set To %v\n"
+	keySetMessage               = "Swift User Key Set to %v\n"
+	authURLSetMessage           = "Swift Auth URL Set To %v\n"
+)

--- a/pfsagentConfig/swiftStuff.go
+++ b/pfsagentConfig/swiftStuff.go
@@ -1,0 +1,114 @@
+package pfsagentConfig
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// SwiftParams is a struct to hold all parameters needed to connect to a swift account
+type SwiftParams struct {
+	// Account is the account name
+	Account string
+	// User is the username
+	User string
+	// Key is the username's key (password)
+	Key string
+	// AuthURL is the URL to get an auth token with
+	AuthURL string
+	// StorageURL is the URL for data access
+	StorageURL string
+	// AuthToken is the token used for data access
+	AuthToken string
+}
+
+// ConstructStorageURL calculates the storage URL based on the auth URL and the account name
+func ConstructStorageURL(mySwiftParams *SwiftParams) (storageURL string, err error) {
+	upTo := strings.Index(mySwiftParams.AuthURL, "/auth")
+	if upTo < 0 {
+		err = fmt.Errorf("Could Not Construct Storage URL From Auth URL %v. Missing '/auth/ in URL'", mySwiftParams.AuthURL)
+		return
+	}
+	storageURL = fmt.Sprintf("%v/v1/%v", mySwiftParams.AuthURL[:upTo], mySwiftParams.Account)
+	return
+}
+
+// GetAuthToken retrieves the auth token for the user/key combination
+func GetAuthToken(mySwiftParams *SwiftParams) (authToken string, err error) {
+	authClient := &http.Client{}
+	authTokenRequest, err := http.NewRequest("GET", mySwiftParams.AuthURL, nil)
+	if nil != err {
+		fmt.Printf("tokenErr:\n%v\n", err)
+		return
+	}
+	authTokenRequest.Header.Add("x-auth-user", mySwiftParams.User)
+	authTokenRequest.Header.Add("x-auth-key", mySwiftParams.Key)
+	// authTokenRequest.Header.Add("Content-Type", "application/json")
+	// fmt.Printf("auth request:\n%v\n", authTokenRequest)
+	authTokenResponse, authErr := authClient.Do(authTokenRequest)
+	// fmt.Printf("authTokenResponse: %v", authTokenResponse)
+	if nil != authErr {
+		err = fmt.Errorf("Error executing auth token request:\n\tError: %v", authErr)
+		return
+	}
+	defer authTokenResponse.Body.Close()
+	if authTokenResponse.StatusCode > 400 {
+		err = fmt.Errorf("Error authenticating for auth token. Check your user and key:\n\tStatus code: %v", authTokenResponse.Status)
+		return
+	}
+	if authTokenResponse.StatusCode > 299 {
+		err = fmt.Errorf("Error response status code from %v\n\tStatus code: %v", confMap["Agent"]["SwiftAuthURL"][0], authTokenResponse.StatusCode)
+		return
+	}
+	authToken = authTokenResponse.Header.Get("X-Auth-Token")
+	// authTokenBody, authTokenBodyReadErr := ioutil.ReadAll(authTokenResponse.Body)
+	if len(authToken) == 0 {
+		err = fmt.Errorf("Error finding auth token in response from %v\n\tResponse: %v", confMap["Agent"]["SwiftAuthURL"][0], authTokenResponse)
+		return
+	}
+	// fmt.Printf("auth token:\n%v\n", authToken)
+	return
+}
+
+// GetAccountHeaders retrieves the headers for an account
+func GetAccountHeaders(mySwiftParams *SwiftParams) (headers http.Header, err error) {
+	if len(mySwiftParams.StorageURL) == 0 {
+		tempStorageURL, urlErr := ConstructStorageURL(mySwiftParams)
+		if nil != urlErr {
+			err = urlErr
+			return
+		}
+		mySwiftParams.StorageURL = tempStorageURL
+	}
+	// fmt.Printf("mySwiftParams.StorageURL: %v\n", mySwiftParams.StorageURL)
+
+	if len(mySwiftParams.AuthToken) == 0 {
+		tempAuthToken, authTokenErr := GetAuthToken(mySwiftParams)
+		if nil != authTokenErr {
+			err = authTokenErr
+			return
+		}
+		mySwiftParams.AuthToken = tempAuthToken
+	}
+	headClient := &http.Client{}
+	accountHeadRequest, accountHeadErr := http.NewRequest("HEAD", mySwiftParams.StorageURL, nil)
+	if nil != accountHeadErr {
+		err = fmt.Errorf("Error executing HEAD request:\n\tError: %v", accountHeadErr)
+		return
+	}
+	accountHeadRequest.Header.Add("x-auth-token", mySwiftParams.AuthToken)
+	accountHeadResponse, accountHeadErr := headClient.Do(accountHeadRequest)
+
+	// fmt.Printf("accountHeadResponse: %v", accountHeadResponse)
+	if nil != accountHeadErr {
+		err = fmt.Errorf("Error executing HEAD request:\n\tError: %v", accountHeadErr)
+		return
+	}
+	if accountHeadResponse.StatusCode >= 400 {
+		err = fmt.Errorf("Bad Status Code Getting Account Headers:\n\tStatus Code: %v", accountHeadResponse.StatusCode)
+		return
+	}
+	// fmt.Printf("accountHeadResponse: %v", accountHeadResponse)
+	headers = accountHeadResponse.Header
+	return
+}

--- a/pfsagentConfig/util_test.go
+++ b/pfsagentConfig/util_test.go
@@ -1,0 +1,8 @@
+package pfsagentConfig
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+}

--- a/pfsagentConfig/utils.go
+++ b/pfsagentConfig/utils.go
@@ -1,0 +1,135 @@
+package pfsagentConfig
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+
+	"github.com/swiftstack/ProxyFS/conf"
+)
+
+const (
+	defaultConfigPath string = "/etc/pfsagent"
+	defaultLogPath    string = "/var/log/pfsagent"
+	configTmplFile    string = "pfsagent.tmpl"
+)
+
+var (
+	confMap          conf.ConfMap
+	defaultMountPath = func() string {
+		usr, err := user.Current()
+		if err != nil {
+			log.Fatal(err)
+		}
+		return usr.HomeDir
+	}() + "/pfsagentMount"
+	ConfigPath = defaultConfigPath
+)
+
+func cloneFromTemplate() (configName string, err error) {
+	tmplPath := fmt.Sprintf("%v/%v", ConfigPath, configTmplFile)
+	// fmt.Printf("tmplPath: %v\n", tmplPath)
+	if _, err = os.Stat(tmplPath); err != nil {
+		fmt.Println("Template file not found at", tmplPath, err)
+		return
+	}
+	confMap, err = conf.MakeConfMapFromFile(tmplPath)
+	if err != nil {
+		log.Println("Failed loading template file", tmplPath, err)
+		return
+	}
+	return
+}
+
+func renameConfig(newName string) (err error) {
+	if len(newName) == 0 {
+		err = fmt.Errorf("no new name provided")
+		return
+	}
+	oldName := confMap["Agent"]["FUSEVolumeName"][0]
+	if newName == oldName {
+		return
+	}
+	oldFilePath := fmt.Sprintf("%v/%v", ConfigPath, oldName)
+	if _, err = os.Stat(oldFilePath); err != nil {
+		log.Printf("Config file not found at %v\n%v\n", oldFilePath, err)
+		return
+	}
+	newFilePath := fmt.Sprintf("%v/%v", ConfigPath, newName)
+	if _, err = os.Stat(newFilePath); err == nil {
+		log.Printf("%v already has a file: %v\n%v\n", newName, newFilePath, err)
+		return
+	}
+	confMap.UpdateFromString(fmt.Sprintf("%v : %v", "Agent.FUSEVolumeName", newName))
+	err = SaveCurrentConfig()
+	if err == nil {
+		os.Remove(oldFilePath)
+	}
+	return
+}
+
+func LoadConfig(configName string) (err error) {
+	if len(configName) == 0 {
+		log.Printf("Cloning config from %v\n", configTmplFile)
+		configName, err = cloneFromTemplate()
+		return
+	}
+
+	log.Printf("Initializing config from %v/%v\n", ConfigPath, configName)
+	configFilePath := fmt.Sprintf("%v/%v", ConfigPath, configName)
+	if _, err = os.Stat(configFilePath); err != nil {
+		log.Println("Config file not found at", configFilePath, err)
+		return
+	}
+	confMap, err = conf.MakeConfMapFromFile(configFilePath)
+	// iniContent, loadErr := ini.Load(ConfigPath)
+	if err != nil {
+		log.Println("Failed loading config file", ConfigPath, err)
+		return
+	}
+	return
+}
+
+func SaveCurrentConfig() (err error) {
+	if confMap == nil {
+		log.Println("Config is not initialized in the utility. did loadConfig() run?")
+		err = errors.New("no config found")
+		return
+	}
+	configName := confMap["Agent"]["FUSEVolumeName"][0]
+	configFilePath := fmt.Sprintf("%v/%v.conf", ConfigPath, configName)
+	fmt.Printf("saving config to %v\n", configFilePath)
+	confMap.DumpConfMapToFile(configFilePath, os.ModePerm)
+
+	return nil
+}
+
+func getUserInput() (response string, err error) {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		if err = scanner.Err(); err != nil {
+			log.Println("Error reading standard input:", err)
+			return
+		}
+		response = scanner.Text()
+		return
+	}
+	err = fmt.Errorf("Error retrieving user input")
+	return
+}
+
+func getValueFromUser(title string, text string, currentValue string) (response string, err error) {
+	fmt.Printf("** Changing %v **", title)
+	if len(text) > 0 {
+		fmt.Printf("\n\t%v", text)
+	}
+	fmt.Printf("\n\nCurrent Value: %v\nNew Value: ", currentValue)
+	response, err = getUserInput()
+	if err != nil {
+		log.Println("Error retrieving user input", err)
+	}
+	return
+}

--- a/pfsagentConfig/validators.go
+++ b/pfsagentConfig/validators.go
@@ -1,0 +1,125 @@
+package pfsagentConfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// ValidateAuthURL checks that an AUTH URL pointing to a SwiftStack cluster
+// func ValidateAuthURL(urlToBeTested string) error {
+// 	return nil
+// }
+
+// ValidateAccess runs all
+func ValidateAccess() (errorType int, err error) {
+	mySwiftParams := new(SwiftParams)
+	mySwiftParams.User = confMap["Agent"]["SwiftAuthUser"][0]
+	mySwiftParams.Key = confMap["Agent"]["SwiftAuthKey"][0]
+	mySwiftParams.Account = confMap["Agent"]["SwiftAccountName"][0]
+	mySwiftParams.AuthURL = confMap["Agent"]["SwiftAuthURL"][0]
+
+	err = validateURL(mySwiftParams)
+	if nil != err {
+		errorType = typeAuthURL
+		return
+	}
+	_, err = validateCredentails(mySwiftParams)
+	if nil != err {
+		errorType = typeCredentails
+		return
+	}
+	err = validateAccount(mySwiftParams)
+	if nil != err {
+		errorType = typeAccount
+		return
+	}
+	return -1, nil
+}
+
+func validateURL(mySwiftParams *SwiftParams) error {
+	parts := strings.Split(mySwiftParams.AuthURL, "/")
+	if len(parts) < 5 {
+		return fmt.Errorf(`
+Auth URL should be of the form:
+<protocol>://<url>/auth/v<API version>
+where
+        - protocol is either 'http' or 'https'
+        - url is the public address of the cluster (such as 'swiftcluster.com' or '192.168.2.100')
+        - API version is usually in the format of 1.0, 2.0 etc.
+`)
+	}
+	protocol := parts[0]
+	if strings.Index(protocol, "http") != 0 && strings.Index(protocol, "https") != 0 {
+		return fmt.Errorf("Auth URL Should Start With http:// Or https://\n\tYour Protocol is %v", protocol)
+	}
+	if parts[3] != "auth" {
+		return fmt.Errorf("A Valid Auth URL Should Have The Word 'auth' After The Address.\n\tExample: https://swiftcluster.com/auth/v1.0")
+	}
+	if strings.Index(parts[4], "v") != 0 || len(parts[4]) != 4 {
+		return fmt.Errorf("A Valid Auth URL Should Have The Protocol Version After The Term 'auth'.\n\tExample: https://swiftcluster.com/auth/v1.0")
+	}
+	address := strings.Split(parts[2], "/")[0]
+	url := fmt.Sprintf("%v//%v", protocol, address)
+	response, generalAccessErr := http.Get(url)
+	if nil != generalAccessErr {
+		return fmt.Errorf("Error Connecting To The Cluster's URL, Which Probably Means The URL Has Errors.\n\tDetected Cluster URL: %v\n\tError: %v", url, generalAccessErr)
+	}
+	infoURL := fmt.Sprintf("%v/info", url)
+	response, httpErr := http.Get(infoURL)
+	if nil != httpErr {
+		return fmt.Errorf("Error Connecting To The Cluster's 'info' URL (%v), Though The URL Itself (%v) Is Reponding.\n\tPlease Check Your URL\n\tError: %v", infoURL, url, httpErr)
+	}
+	defer response.Body.Close()
+	infoBody, bodyReadErr := ioutil.ReadAll(response.Body)
+	if nil != bodyReadErr {
+		return fmt.Errorf("Error Reading Response From %v\n\tError: %v", infoURL, bodyReadErr)
+	}
+	var infoInterface interface{}
+	jsonErr := json.Unmarshal(infoBody, &infoInterface)
+	if nil != jsonErr {
+		return fmt.Errorf("Error Parsing Info From %v.\nBody Text: %v\n\tError: %v", infoURL, string(infoBody), jsonErr)
+	}
+	validJSON := infoInterface.(map[string]interface{})
+	if nil == validJSON["swift"] {
+		return fmt.Errorf("Error Finding The Term 'swift' In Parsed JSON\n\tError: %v", validJSON)
+	}
+
+	authClient := &http.Client{}
+	authTokenRequest, authTokenErr := http.NewRequest("GET", mySwiftParams.AuthURL, nil)
+	if nil != authTokenErr {
+		fmt.Printf("Error Creting Auth Request:\n%v\n", authTokenErr)
+	}
+	authURLResponse, authURLErr := authClient.Do(authTokenRequest)
+	if nil != authURLErr {
+		return fmt.Errorf("Error Executing Auth URL Request:\n\tURL: %v\n\tError: %v", mySwiftParams.AuthURL, authURLErr)
+	}
+	if authURLResponse.StatusCode != 401 {
+		return fmt.Errorf("Error Response From Auth URL. Get On Auth URL With No User/Key Should Result In Status '401 Unauthorize'\n\tStatus code: %v", authURLResponse.Status)
+	}
+
+	return nil
+}
+
+func validateCredentails(mySwiftParams *SwiftParams) (authToken string, err error) {
+	authToken, err = GetAuthToken(mySwiftParams)
+	if nil != err {
+		return
+	}
+	mySwiftParams.AuthToken = authToken
+	return
+}
+
+func validateAccount(mySwiftParams *SwiftParams) error {
+	headers, headErr := GetAccountHeaders(mySwiftParams)
+	fmt.Printf("\n\nvalidation succeeded? %v\n\n", nil == headErr)
+	if nil != headErr {
+		return headErr
+	}
+	if len(headers) == 0 {
+		return fmt.Errorf("Though The Request Succeeded There Were No Headers Returned")
+	}
+	return nil
+}


### PR DESCRIPTION
currently supported: changing AUTH URL, username, key, account

run options:
* `pfsagentConfig` (no subcommand or param) - run the interactive wizard mod
* `pfsagentConfig firstRun` - clone config from template, ask about:
  - AUTH URL
  - username
  - key
  - account (default: `AUTH_<username>`)
  - volume name (default: account name)
  - mount location (default: `/root/pfsagentMount/vol_<account name>`)
  - log location (default: `/var/log/pfsagent/log.<account name>`)
it then saves the config to `/etc/pfsagent/<volumne name>.conf`


Validations:
* AUTH URL:
  - check address part of URL is a live IP/address
  - check URL is a SwiftStack cluster (by GETting `/info` and parsing it)
  - check URL is indeed an AUTH URL (structure: `http[s]://<address>/auth/v<auth version>`)
  - verify AUTH URL by GETting it (expecting 401)
* user/key:
  - use AUTH URL with user/key and get AUTH token
* account:
  - use AUTH URL and AUTH token to HEAD of account
* mount location, log location: confirm existing and create if not 


TBD:
* non-interactive mode:
  - flag for each config entry
* `pfsagentConfig edit <config name>` - edit an existing config
* `pfsagentConfig create <config name>` (supersedes `pfsagentConfig firstRun`)
