### PR TITLE
Add retransmit stress test and related fixes

### DIFF
--- a/docs/source/architecture/uml/retryrpc-send.uml
+++ b/docs/source/architecture/uml/retryrpc-send.uml
@@ -1,0 +1,37 @@
+@startuml
+
+title RetryRPC Send - Happy Path
+
+autonumber
+
+box Client
+participant Send
+participant sendToServer
+participant notifyReply
+participant readReplies
+end box
+box Server
+participant serviceClient
+participant processRequest
+end box
+
+Send -> sendToServer:Pkg request, assign\nrequestID goroutine to send.\nWait on channel for\nresponse
+
+sendToServer -> serviceClient: Write hdr and then write\npayload on socket to server
+note left: retransmit() if write of\nhdr or payload fails
+
+serviceClient -> processRequest: Read hdr and payload.\nGoroutine to process RPC
+
+processRequest -> processRequest: Unmarshal RPC, call RPC,\nmarshal response.
+
+processRequest -> readReplies: Write header\nand then payload to client
+note left: retransmit() if write of\nhdr or payload fails
+
+readReplies -> readReplies: Read header and then\npayload off socket.\nCall goroutine to notify\nsender
+
+readReplies -> notifyReply:Unmarshal response.\nWrite response on\nchannel to sender.
+note left: retransmit() if unmarshal of\nhdr or payload fails
+
+Send -> Send:See response on channel and\nreturn response to caller.
+
+@enduml

--- a/docs/source/architecture/uml/retryrpc-send.uml
+++ b/docs/source/architecture/uml/retryrpc-send.uml
@@ -11,9 +11,20 @@ participant notifyReply
 participant readReplies
 end box
 box Server
+participant run
 participant serviceClient
 participant processRequest
 end box
+
+Send -> run:dial() server
+run -> run:Accept connection
+run -> run:Wait for uniqueID on socket
+Send -> run:Send uniqueID on socket
+Send -> readReplies:Start readReplies goroutine
+
+run -> run:Read uniqueID of new client
+run -> run:Call getClientIDAndWait()\nif new uniqueID create entry in perClientInfo\notherwise drain RPCs on old connection
+run -> serviceClient:Start serviceClient goroutine for new client connection
 
 Send -> sendToServer:Pkg request, assign\nrequestID goroutine to send.\nWait on channel for\nresponse
 

--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -158,9 +158,10 @@ func (server *Server) Close() {
 
 	server.listenersWG.Wait()
 
-	// Now close the client sockets to wakeup our blocked readers
-	server.closeClientConn()
 	server.goroutineWG.Wait()
+
+	// Now close the client sockets to wakeup them up
+	server.closeClientConn()
 
 	server.completedLongTicker.Stop()
 	server.completedShortTicker.Stop()
@@ -189,16 +190,6 @@ func (server *Server) CloseClientConn() {
 func (server *Server) CompletedCnt() (totalCnt int) {
 	for _, v := range server.perClientInfo {
 		totalCnt += v.completedCnt()
-	}
-	return
-}
-
-// PendingCnt returns count of pendingRequests
-//
-// This is only useful for testing.
-func (server *Server) PendingCnt() (totalCnt int) {
-	for _, v := range server.perClientInfo {
-		totalCnt += v.pendingCnt()
 	}
 	return
 }

--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -172,7 +172,6 @@ func (server *Server) Close() {
 // CloseClientConn - This is debug code to cause some connections to be closed
 // It is called from a stress test case to cause retransmits
 func (server *Server) CloseClientConn() {
-	logger.Infof("CloseClientConn() called --------")
 	if server == nil {
 		return
 	}

--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -169,18 +169,18 @@ func (server *Server) Close() {
 }
 
 // CloseClientConn - This is debug code to cause some connections to be closed
-// TODO - call this from stress test case to cause retransmits
+// It is called from a stress test case to cause retransmits
 func (server *Server) CloseClientConn() {
+	logger.Infof("CloseClientConn() called --------")
 	if server == nil {
 		return
 	}
-	logger.Infof("CloseClientConn() called --------")
-	server.Lock()
+	server.connLock.Lock()
 	for c := server.connections.Front(); c != nil; c = c.Next() {
 		conn := c.Value.(net.Conn)
 		conn.Close()
 	}
-	server.Unlock()
+	server.connLock.Unlock()
 }
 
 // CompletedCnt returns count of pendingRequests
@@ -213,6 +213,9 @@ const (
 	DISCONNECTED
 	// CONNECTED means the Client is connected to the server
 	CONNECTED
+	// RETRANSMITTING means a goroutine is in the middle of recovering
+	// from a loss of a connection with the server
+	RETRANSMITTING
 )
 
 type connectionTracker struct {

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -208,6 +208,7 @@ func getIO(genNum uint64, conn net.Conn) (buf []byte, err error) {
 
 	conn.SetDeadline(time.Now().Add(deadlineIO))
 	err = binary.Read(conn, binary.BigEndian, &hdr)
+	//fmt.Printf("binary.Read() returned err: %v\n", err)
 	if err != nil {
 		return
 	}

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -43,7 +43,8 @@ type requestID uint64
 // such as completed requests, etc
 type clientInfo struct {
 	sync.Mutex
-	pendingRequest           map[requestID]*pendingCtx     // Key: "RequestID"
+	cCtx                     *connCtx                      // Current connCtx for client
+	rpcWG                    sync.WaitGroup                // WaitGroup tracking current RPC "threads"
 	completedRequest         map[requestID]*completedEntry // Key: "RequestID"
 	completedRequestLRU      *list.List                    // LRU used to remove completed request in ticker
 	highestReplySeen         requestID                     // Highest consectutive requestID client has seen

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -66,6 +66,7 @@ type connCtx struct {
 	sync.Mutex
 	conn         net.Conn
 	activeRPCsWG sync.WaitGroup // WaitGroup tracking active RPCs from this client on this connection
+	ci           *clientInfo    // Back pointer to the CI
 }
 
 // pendingCtx tracks an individual request from a client

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -49,11 +49,6 @@ type clientInfo struct {
 	completedRequestLRU      *list.List                    // LRU used to remove completed request in ticker
 	highestReplySeen         requestID                     // Highest consectutive requestID client has seen
 	previousHighestReplySeen requestID                     // Previous highest consectutive requestID client has seen
-	/*
-		drainingRPCs             bool                          // True if draining outstanding RPCs
-		drainingCond             *sync.Cond                    // Condition to serialize new connection for a clientInfo
-		drainingMutex            sync.Mutex                    // Mutex used to serialize new connection for a clientInfo
-	*/
 }
 
 type completedEntry struct {

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -208,7 +208,6 @@ func getIO(genNum uint64, conn net.Conn) (buf []byte, err error) {
 
 	conn.SetDeadline(time.Now().Add(deadlineIO))
 	err = binary.Read(conn, binary.BigEndian, &hdr)
-	//fmt.Printf("binary.Read() returned err: %v\n", err)
 	if err != nil {
 		return
 	}

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -62,9 +62,11 @@ type completedEntry struct {
 // reading or writing on the socket.
 type connCtx struct {
 	sync.Mutex
-	conn         net.Conn
-	activeRPCsWG sync.WaitGroup // WaitGroup tracking active RPCs from this client on this connection
-	ci           *clientInfo    // Back pointer to the CI
+	conn                net.Conn
+	activeRPCsWG        sync.WaitGroup // WaitGroup tracking active RPCs from this client on this connection
+	cond                *sync.Cond     // Signal waiting goroutines that serviceClient() has exited
+	serviceClientExited bool
+	ci                  *clientInfo // Back pointer to the CI
 }
 
 // pendingCtx tracks an individual request from a client

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -112,11 +112,12 @@ func (client *Client) sendToServer(crID requestID, ctx *reqCtx, queue bool) {
 	client.connection.tlsConn.SetDeadline(time.Now().Add(deadlineIO))
 	err := binary.Write(client.connection.tlsConn, binary.BigEndian, ctx.ioreq.Hdr)
 	if err != nil {
+		genNum := ctx.genNum
 		client.Unlock()
 
 		// Just return - the retransmit code will start another
 		// sendToServer() goroutine
-		client.retransmit(ctx.genNum)
+		client.retransmit(genNum)
 		return
 	}
 

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -221,7 +221,6 @@ func (client *Client) readReplies(callingGenNum uint64, tlsConn *tls.Conn) {
 
 		// Wait reply from server
 		buf, getErr := getIO(callingGenNum, tlsConn)
-		//logger.Infof("readReplies getIO returned: %v", getErr)
 
 		// This must happen before checking error
 		client.Lock()
@@ -250,7 +249,6 @@ func (client *Client) readReplies(callingGenNum uint64, tlsConn *tls.Conn) {
 // retransmit is called when a socket related error occurs on the
 // connection to the server.
 func (client *Client) retransmit(genNum uint64) {
-	//logger.Infof("RETRANSMIT CALLED!!!!")
 	client.Lock()
 
 	// Check if we are already processing the socket error via

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -165,11 +165,11 @@ func (client *Client) notifyReply(buf []byte, genNum uint64) {
 	// original request anyway.
 	crID := jReply.RequestID
 	client.Lock()
+
 	// If this message is from an old socket - throw it away
 	// since the request was resent.
 	if client.connection.genNum != genNum {
 		client.Unlock()
-		fmt.Printf("===========    notifyReply() saw old message - throwing away\n")
 		return
 	}
 	ctx, ok := client.outstandingRequest[crID]

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -221,6 +221,7 @@ func (client *Client) readReplies(callingGenNum uint64, tlsConn *tls.Conn) {
 
 		// Wait reply from server
 		buf, getErr := getIO(callingGenNum, tlsConn)
+		//logger.Infof("readReplies getIO returned: %v", getErr)
 
 		// This must happen before checking error
 		client.Lock()
@@ -249,6 +250,7 @@ func (client *Client) readReplies(callingGenNum uint64, tlsConn *tls.Conn) {
 // retransmit is called when a socket related error occurs on the
 // connection to the server.
 func (client *Client) retransmit(genNum uint64) {
+	//logger.Infof("RETRANSMIT CALLED!!!!")
 	client.Lock()
 
 	// Check if we are already processing the socket error via

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -248,7 +248,6 @@ func (client *Client) readReplies(callingGenNum uint64, tlsConn *tls.Conn) {
 // retransmit is called when a socket related error occurs on the
 // connection to the server.
 func (client *Client) retransmit(genNum uint64) {
-	fmt.Printf("retransmit() BEGIN - genNum: %v\n", genNum)
 	client.Lock()
 
 	// Check if we are already processing the socket error via

--- a/retryrpc/client.go
+++ b/retryrpc/client.go
@@ -299,15 +299,9 @@ func (client *Client) retransmit(genNum uint64) {
 	client.Unlock()
 }
 
-// TOOD - this routine
-// 1. fills in header
-// 2. sends client info
-// 3. reads response
-// 4. returns error or other as needed
+// Send myUniqueID to server
 //
 // NOTE: Client lock is already held during this call.
-// TODO - what issues with retransmit.... assume do not do that
-// automatically... how recover while doing that????
 func (client *Client) sendMyInfo(tlsConn *tls.Conn) (err error) {
 
 	// Setup ioreq to write structure on socket to server
@@ -370,8 +364,8 @@ func (client *Client) dial() (err error) {
 	client.connection.state = CONNECTED
 	client.connection.genNum++
 
-	// TODO - what do if connection fails again - loop back
-	// in for loop?
+	// Send myUniqueID to server.   If this fails the dial will
+	// be retried.
 	err = client.sendMyInfo(tlsConn)
 	if err != nil {
 		return

--- a/retryrpc/client_tracking.go
+++ b/retryrpc/client_tracking.go
@@ -3,24 +3,8 @@ package retryrpc
 // This file contains functions in the server which
 // keep track of clients.
 
-func (ci *clientInfo) buildAndQPendingCtx(rID requestID, buf []byte, cCtx *connCtx, lockHeld bool) {
-	pc := &pendingCtx{buf: buf, cCtx: cCtx}
-
-	if lockHeld == false {
-		ci.Lock()
-	}
-
-	ci.pendingRequest[rID] = pc
-
-	if lockHeld == false {
-		ci.Unlock()
-	}
-}
-
-// NOTE: This function assumes ci Lock is held
 func (ci *clientInfo) isEmpty() bool {
-	if len(ci.completedRequest) == 0 &&
-		len(ci.pendingRequest) == 0 {
+	if len(ci.completedRequest) == 0 {
 		return true
 	}
 	return false
@@ -28,8 +12,4 @@ func (ci *clientInfo) isEmpty() bool {
 
 func (ci *clientInfo) completedCnt() int {
 	return len(ci.completedRequest)
-}
-
-func (ci *clientInfo) pendingCnt() int {
-	return len(ci.pendingRequest)
 }

--- a/retryrpc/retryrpc_test.go
+++ b/retryrpc/retryrpc_test.go
@@ -39,7 +39,7 @@ func (m *MyType) unexportedFunction(i int) {
 	m.field1 = i
 }
 
-func getNewServer() (rrSvr *Server, ip string, p int) {
+func getNewServer(t time.Duration) (rrSvr *Server, ip string, p int) {
 	var (
 		ipaddr = "127.0.0.1"
 		port   = 24456
@@ -47,7 +47,7 @@ func getNewServer() (rrSvr *Server, ip string, p int) {
 
 	// Create a new RetryRPC Server.  Completed request will live on
 	// completedRequests for 10 seconds.
-	rrSvr = NewServer(10*time.Second, 100*time.Millisecond, ipaddr, port)
+	rrSvr = NewServer(t, 100*time.Millisecond, ipaddr, port)
 	ip = ipaddr
 	p = port
 	return
@@ -63,7 +63,7 @@ func testServer(t *testing.T) {
 	// RPCs
 	myJrpcfs := rpctest.NewServer()
 
-	rrSvr, ipaddr, port := getNewServer()
+	rrSvr, ipaddr, port := getNewServer(10 * time.Second)
 	assert.NotNil(rrSvr)
 
 	// Register the Server - sets up the methods supported by the
@@ -125,7 +125,7 @@ func testServer(t *testing.T) {
 func testBtree(t *testing.T) {
 	assert := assert.New(t)
 
-	rrSvr, ipaddr, port := getNewServer()
+	rrSvr, ipaddr, port := getNewServer(10 * time.Second)
 	assert.NotNil(rrSvr)
 
 	// Setup a client - we only will be targeting the btree

--- a/retryrpc/retryrpc_test.go
+++ b/retryrpc/retryrpc_test.go
@@ -14,7 +14,7 @@ import (
 // circular dependency if the test was in retryrpc.
 func TestRetryRPC(t *testing.T) {
 
-	//	testServer(t)
+	testServer(t)
 	testBtree(t)
 }
 
@@ -89,8 +89,6 @@ func testServer(t *testing.T) {
 	sendErr := rrClnt.Send("RpcPing", pingRequest, pingReply)
 	assert.Nil(sendErr)
 	assert.Equal("pong 8 bytes", pingReply.Message)
-
-	assert.Equal(0, rrSvr.PendingCnt())
 	assert.Equal(1, rrSvr.CompletedCnt())
 
 	// Send an RPC which should return an error
@@ -99,7 +97,6 @@ func testServer(t *testing.T) {
 	sendErr = rrClnt.Send("RpcPingWithError", pingRequest, pingReply)
 	assert.NotNil(sendErr)
 
-	assert.Equal(0, rrSvr.PendingCnt())
 	assert.Equal(2, rrSvr.CompletedCnt())
 
 	// TODO - TODO - TODO....
@@ -112,7 +109,6 @@ func testServer(t *testing.T) {
 	sendErr = rrClnt.Send("RpcInvalidMethod", pingRequest, pingReply)
 	assert.NotNil(sendErr)
 
-	assert.Equal(0, rrSvr.PendingCnt())
 	assert.Equal(3, rrSvr.CompletedCnt())
 
 	// Stop the client before exiting

--- a/retryrpc/retryrpc_test.go
+++ b/retryrpc/retryrpc_test.go
@@ -99,10 +99,6 @@ func testServer(t *testing.T) {
 
 	assert.Equal(2, rrSvr.CompletedCnt())
 
-	// TODO - TODO - TODO....
-	// Verify that the server has seen the updated
-	// highestReplySeen
-
 	// Send an RPC which should return an error
 	pingRequest = &rpctest.PingReq{Message: "Ping Me!"}
 	pingReply = &rpctest.PingReply{}

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -252,8 +252,6 @@ func (server *Server) serviceClient(ci *clientInfo, cCtx *connCtx) {
 	}
 }
 
-// TODO - review the locking here to make it simplier
-
 // callRPCAndMarshal calls the RPC and returns results to requestor
 func (server *Server) callRPCAndFormatReply(buf []byte, jReq *jsonRequest) (ior *ioReply) {
 	var (

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/swiftstack/ProxyFS/logger"
-	"golang.org/x/sys/unix"
 )
 
 // Variable to control debug output
@@ -249,10 +248,10 @@ func (server *Server) callRPCAndMarshal(cCtx *connCtx, ci *clientInfo, buf []byt
 			}
 			jReply.ErrStr = e.Error()
 		}
-	} else {
+	} /* else {
 		// Method does not exist
 		jReply.ErrStr = fmt.Sprintf("errno: %d", unix.ENOENT)
-	}
+	} */
 
 	// Convert response into JSON for return trip
 	reply.JResult, err = json.Marshal(jReply)
@@ -264,6 +263,9 @@ func (server *Server) callRPCAndMarshal(cCtx *connCtx, ci *clientInfo, buf []byt
 	lruEntry := completedLRUEntry{requestID: rID, timeCompleted: time.Now()}
 
 	ci.Lock()
+
+	// TODO TODO TODO - Why else case???
+
 	// connCtx may have changed while we dropped the lock due to new connection or
 	// the RPC may have completed.
 	//

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -86,7 +86,8 @@ func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint
 
 	var sendWg sync.WaitGroup
 
-	var z, r int
+	// var z, r int
+	var z int
 	for i := 0; i < sendCnt; i++ {
 		z = (z + i) * 10
 
@@ -95,10 +96,15 @@ func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint
 
 		// Occasionally drop the connection to the server to
 		// simulate retransmits
-		r = i % 10
-		if r == 0 && (i != 0) {
+		if i == (sendCnt - 1) {
 			rrSvr.CloseClientConn()
 		}
+		/*
+			r = i % 10
+			if r == 0 && (i != 0) {
+				rrSvr.CloseClientConn()
+			}
+		*/
 	}
 	fmt.Printf("pfsagent: %v sentCnt: %v - now wait=========\n", agentID, sendCnt)
 	sendWg.Wait()

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -20,7 +20,7 @@ func testLoop(t *testing.T) {
 	var (
 		//agentCount = 10
 		agentCount = 1
-		sendCount  = 15
+		sendCount  = 150
 	)
 	assert := assert.New(t)
 	zero := 0
@@ -86,8 +86,7 @@ func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint
 
 	var sendWg sync.WaitGroup
 
-	// var z, r int
-	var z int
+	var z, r int
 	for i := 0; i < sendCnt; i++ {
 		z = (z + i) * 10
 
@@ -96,20 +95,10 @@ func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint
 
 		// Occasionally drop the connection to the server to
 		// simulate retransmits
-		/****** - March 3
-		if i == (sendCnt - 1) {
+		r = i % 10
+		if r == 0 && (i != 0) {
 			rrSvr.CloseClientConn()
 		}
-		******/
-		if i == 0 {
-			rrSvr.CloseClientConn()
-		}
-		/*******
-			r = i % 10
-			if r == 0 && (i != 0) {
-				rrSvr.CloseClientConn()
-			}
-		********/
 	}
 	fmt.Printf("pfsagent: %v sentCnt: %v - now wait=========\n", agentID, sendCnt)
 	sendWg.Wait()

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -75,7 +75,7 @@ func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint
 	defer agentWg.Done()
 
 	clientID := fmt.Sprintf("client - %v", agentID)
-	client, err := NewClient(clientID, ipAddr, port, rootCAx509CertificatePEM)
+	client, err := NewClient(clientID, ipAddr, port, rootCAx509CertificatePEM, nil)
 	if err != nil {
 		fmt.Printf("Dial() failed with err: %v\n", err)
 		return

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -18,8 +18,8 @@ func TestStress(t *testing.T) {
 
 func testLoop(t *testing.T) {
 	var (
-		agentCount = 10
-		sendCount  = 150
+		agentCount = 15
+		sendCount  = 300
 	)
 	assert := assert.New(t)
 	zero := 0

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -96,15 +96,20 @@ func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint
 
 		// Occasionally drop the connection to the server to
 		// simulate retransmits
+		/****** - March 3
 		if i == (sendCnt - 1) {
 			rrSvr.CloseClientConn()
 		}
-		/*
+		******/
+		if i == 0 {
+			rrSvr.CloseClientConn()
+		}
+		/*******
 			r = i % 10
 			if r == 0 && (i != 0) {
 				rrSvr.CloseClientConn()
 			}
-		*/
+		********/
 	}
 	fmt.Printf("pfsagent: %v sentCnt: %v - now wait=========\n", agentID, sendCnt)
 	sendWg.Wait()

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -1,0 +1,130 @@
+package retryrpc
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/swiftstack/ProxyFS/retryrpc/rpctest"
+)
+
+func TestStress(t *testing.T) {
+
+	testLoop(t)
+}
+
+func testLoop(t *testing.T) {
+	var (
+		//agentCount = 10
+		agentCount = 1
+		sendCount  = 15
+	)
+	assert := assert.New(t)
+	zero := 0
+	assert.Equal(0, zero)
+
+	// Create new rpctest server - needed for calling
+	// RPCs
+	myJrpcfs := rpctest.NewServer()
+
+	rrSvr, ipAddr, port := getNewServer(65 * time.Second)
+	assert.NotNil(rrSvr)
+
+	// Register the Server - sets up the methods supported by the
+	// server
+	err := rrSvr.Register(myJrpcfs)
+	assert.Nil(err)
+
+	// Start listening for requests on the ipaddr/port
+	startErr := rrSvr.Start()
+	assert.Nil(startErr, "startErr is not nil")
+
+	// Tell server to start accepting and processing requests
+	rrSvr.Run()
+
+	// Start up the agents
+	parallelAgentSenders(t, rrSvr, ipAddr, port, agentCount, sendCount, rrSvr.Creds.RootCAx509CertificatePEM)
+}
+
+func sendIt(t *testing.T, client *Client, i int, sendWg *sync.WaitGroup, agentID uint64) {
+	assert := assert.New(t)
+	defer sendWg.Done()
+
+	// Send a ping RPC and print the results
+	msg := fmt.Sprintf("Ping Me - %v", i)
+	pingRequest := &rpctest.PingReq{Message: msg}
+	pingReply := &rpctest.PingReply{}
+	expectedReply := fmt.Sprintf("pong %d bytes", len(msg))
+	err := client.Send("RpcPing", pingRequest, pingReply)
+	assert.Nil(err, "client.Send() returned an error")
+	if expectedReply != pingReply.Message {
+		fmt.Printf("		 client - AGENTID: %v\n", agentID)
+		fmt.Printf("         client.Send(RpcPing) reply '%+v'\n", pingReply)
+		fmt.Printf("         client.Send(RpcPing) expected '%s' but received '%s'\n", expectedReply, pingReply.Message)
+		fmt.Printf("         client.Send(RpcPing) SENT: msg '%v' but received '%s'\n", msg, pingReply.Message)
+		fmt.Printf("         client.Send(RpcPing) len(pingRequest.Message): '%d' i: %v\n", len(pingRequest.Message), i)
+	}
+	assert.Equal(expectedReply, pingReply.Message, "Received different output then expected")
+}
+
+// Represents a pfsagent - sepearate client
+func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint64, agentWg *sync.WaitGroup,
+	sendCnt int, rootCAx509CertificatePEM []byte) {
+	defer agentWg.Done()
+
+	clientID := fmt.Sprintf("client - %v", agentID)
+	fmt.Printf("pfsagent() - calling NewClient - clientID: %v\n", clientID)
+	client, err := NewClient(clientID, ipAddr, port, rootCAx509CertificatePEM)
+	if err != nil {
+		fmt.Printf("Dial() failed with err: %v\n", err)
+		return
+	}
+	defer client.Close()
+
+	var sendWg sync.WaitGroup
+
+	var z, r int
+	for i := 0; i < sendCnt; i++ {
+		z = (z + i) * 10
+
+		sendWg.Add(1)
+		go sendIt(t, client, z, &sendWg, agentID)
+
+		// Occasionally drop the connection to the server to
+		// simulate retransmits
+		r = i % 10
+		if r == 0 && (i != 0) {
+			rrSvr.CloseClientConn()
+		}
+	}
+	fmt.Printf("pfsagent: %v sentCnt: %v - now wait=========\n", agentID, sendCnt)
+	sendWg.Wait()
+	fmt.Printf("pfsagent: %v COMPLETED agentWG\n", agentID)
+}
+
+// Start a bunch of "pfsagents" in parallel
+func parallelAgentSenders(t *testing.T, rrSrv *Server, ipAddr string, port int, agentCnt int,
+	sendCnt int, rootCAx509CertificatePEM []byte) {
+
+	var agentWg sync.WaitGroup
+
+	// Figure out random seed for runs
+	r := rand.New(rand.NewSource(99))
+	clientSeed := r.Uint64()
+
+	fmt.Printf("parallelAgentSenders - agentCnt: %v\n", agentCnt)
+
+	// Start parallel pfsagents - each agent doing sendCnt parallel sends
+	var agentID uint64
+	for i := 0; i < agentCnt; i++ {
+		agentID = clientSeed + uint64(i)
+
+		agentWg.Add(1)
+		go pfsagent(t, rrSrv, ipAddr, port, agentID, &agentWg, sendCnt, rootCAx509CertificatePEM)
+	}
+	agentWg.Wait()
+	fmt.Printf("parallelAgentSenders() - after agentWg.Wait()-----\n")
+}

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -18,8 +18,7 @@ func TestStress(t *testing.T) {
 
 func testLoop(t *testing.T) {
 	var (
-		//agentCount = 10
-		agentCount = 1
+		agentCount = 10
 		sendCount  = 150
 	)
 	assert := assert.New(t)

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -19,7 +19,7 @@ func TestStress(t *testing.T) {
 func testLoop(t *testing.T) {
 	var (
 		agentCount = 15
-		sendCount  = 300
+		sendCount  = 250
 	)
 	assert := assert.New(t)
 	zero := 0
@@ -75,7 +75,6 @@ func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint
 	defer agentWg.Done()
 
 	clientID := fmt.Sprintf("client - %v", agentID)
-	fmt.Printf("pfsagent() - calling NewClient - clientID: %v\n", clientID)
 	client, err := NewClient(clientID, ipAddr, port, rootCAx509CertificatePEM)
 	if err != nil {
 		fmt.Printf("Dial() failed with err: %v\n", err)
@@ -99,9 +98,7 @@ func pfsagent(t *testing.T, rrSvr *Server, ipAddr string, port int, agentID uint
 			rrSvr.CloseClientConn()
 		}
 	}
-	fmt.Printf("pfsagent: %v sentCnt: %v - now wait=========\n", agentID, sendCnt)
 	sendWg.Wait()
-	fmt.Printf("pfsagent: %v COMPLETED agentWG\n", agentID)
 }
 
 // Start a bunch of "pfsagents" in parallel
@@ -114,8 +111,6 @@ func parallelAgentSenders(t *testing.T, rrSrv *Server, ipAddr string, port int, 
 	r := rand.New(rand.NewSource(99))
 	clientSeed := r.Uint64()
 
-	fmt.Printf("parallelAgentSenders - agentCnt: %v\n", agentCnt)
-
 	// Start parallel pfsagents - each agent doing sendCnt parallel sends
 	var agentID uint64
 	for i := 0; i < agentCnt; i++ {
@@ -125,5 +120,4 @@ func parallelAgentSenders(t *testing.T, rrSrv *Server, ipAddr string, port int, 
 		go pfsagent(t, rrSrv, ipAddr, port, agentID, &agentWg, sendCnt, rootCAx509CertificatePEM)
 	}
 	agentWg.Wait()
-	fmt.Printf("parallelAgentSenders() - after agentWg.Wait()-----\n")
 }


### PR DESCRIPTION
Add a stress test which stresses retryrpc while causing retransmits.  Fix bugs found.

The test simulates 15 pfsagents sending RPCs in parallel where:
* each agent sends 250 RPCs in parallel
* after every 10 RPCs are scheduled in separate goroutines, close all connections between the clients and the server to cause a retransmit including cascading retransmits
* expected results are calculated and asserted

Add UML which shows basic path in retryrpc although not retransmit handling

This test found numerous race conditions and other issues including:
* retransmit on client was requeuing RPCs which have already queued
* race condition on server between RPCs from old connection and RPCs on new connection
* hangs when reading/writing a socket

The fixes are:
Client
      * serialize goroutines so that only one goroutine is calling retransmit for a socket instead of all goroutines using the socket
      * retransmit() -> sendToServer() path on client no longer requeues
      * retry dial() if fails

Server
     * remove pending queue.  Instead:
          ** when a client connects on a socket if first shares its uniqueID so that it can be looked up in perClientInfo map
          ** in-process RPCs as tracked in clientInfo structure complete before RPCs for new connection are processed

Both:
     * set a deadline for read/write on socket instead of hanging.   Current deadline is 60 seconds