### PR TITLE
Added ability to pause and resume object deletions

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -156,12 +156,12 @@ For each of the keys supported, the following table will list whether or not its
 |                                           | DefaultPhysicalContainerLayout           | Yes          |                    | Yes                      | Yes for newly served volume  |
 |                                           | MaxFlushSize                             | Yes          |                    | Yes                      | Yes for newly served volume  |
 |                                           | MaxFlushTime                             | Yes          |                    | Yes                      | Yes for newly served volume  |
-|                                           | FileDefragmentChunkSize                  | No           | 10485760           | No                       | Yes for newly served volume  |
-|                                           | FileDefragmentChunkDelay                 | No           | 10ms               | No                       | Yes for newly served volume  |
-|                                           | ReportedBlockSize                        | No           | 64Kibi             | No                       | Yes                          |
-|                                           | ReportedFragmentSize                     | No           | 64Kibi             | No                       | Yes                          |
-|                                           | ReportedNumBlocks                        | No           | 100Tebi/64Kibi     | No                       | Yes                          |
-|                                           | ReportedNumInodes                        | No           | 100Gibi            | No                       | Yes                          |
+|                                           | FileDefragmentChunkSize                  | No           | 10485760           | Yes                      | Yes for newly served volume  |
+|                                           | FileDefragmentChunkDelay                 | No           | 10ms               | Yes                      | Yes for newly served volume  |
+|                                           | ReportedBlockSize                        | No           | 64Kibi             | Yes                      | Yes for newly served volume  |
+|                                           | ReportedFragmentSize                     | No           | 64Kibi             | Yes                      | Yes for newly served volume  |
+|                                           | ReportedNumBlocks                        | No           | 100Tebi/64Kibi     | Yes                      | Yes for newly served volume  |
+|                                           | ReportedNumInodes                        | No           | 100Gibi            | Yes                      | Yes for newly served volume  |
 |                                           | SnapShotIDNumBits                        | No           | 10                 | No                       | No                           |
 |                                           | MaxBytesInodeCache                       | No           | 10485760           | Yes                      | Yes for newly served volume  |
 |                                           | InodeCacheEvictInterval                  | No           | 1s                 | Yes                      | Yes for newly served volume  |

--- a/headhunter/checkpoint.go
+++ b/headhunter/checkpoint.go
@@ -2801,6 +2801,21 @@ func (volume *volumeStruct) performDelayedObjectDeletes(delayedObjectDeleteList 
 		err                     error
 	)
 
+RetryCheckForObjectDeleteEnabled:
+	globals.backgroundObjectDeleteActiveWG.Add(1)
+
+	globals.backgroundObjectDeleteRWMutex.RLock()
+
+	if !globals.backgroundObjectDeleteEnabled {
+		// We must block...and retry
+		globals.backgroundObjectDeleteActiveWG.Done()
+		globals.backgroundObjectDeleteRWMutex.RUnlock()
+		globals.backgroundObjectDeleteEnabledWG.Wait()
+		goto RetryCheckForObjectDeleteEnabled
+	}
+
+	globals.backgroundObjectDeleteRWMutex.RUnlock()
+
 	for _, delayedObjectDelete = range delayedObjectDeleteList {
 		delayedObjectDeleteName = utils.Uint64ToHexStr(delayedObjectDelete.objectNumber)
 		if globals.metadataRecycleBin && (delayedObjectDelete.containerName == volume.checkpointContainerName) {
@@ -2823,7 +2838,9 @@ func (volume *volumeStruct) performDelayedObjectDeletes(delayedObjectDeleteList 
 			}
 		}
 	}
+
 	volume.backgroundObjectDeleteWG.Done()
+	globals.backgroundObjectDeleteActiveWG.Done()
 }
 
 func (volume *volumeStruct) openCheckpointChunkedPutContextIfNecessary() (err error) {

--- a/httpserver/request_handler.go
+++ b/httpserver/request_handler.go
@@ -1602,10 +1602,51 @@ func doGetOfSnapShot(responseWriter http.ResponseWriter, request *http.Request, 
 
 func doPost(responseWriter http.ResponseWriter, request *http.Request) {
 	switch {
+	case strings.HasPrefix(request.URL.Path, "/deletions"):
+		doPostOfDeletions(responseWriter, request)
 	case strings.HasPrefix(request.URL.Path, "/trigger"):
 		doPostOfTrigger(responseWriter, request)
 	case strings.HasPrefix(request.URL.Path, "/volume"):
 		doPostOfVolume(responseWriter, request)
+	default:
+		responseWriter.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func doPostOfDeletions(responseWriter http.ResponseWriter, request *http.Request) {
+	var (
+		numPathParts int
+		pathSplit    []string
+	)
+
+	pathSplit = strings.Split(request.URL.Path, "/") // leading  "/" places "" in pathSplit[0]
+	//                                                  pathSplit[1] should be "deletions" based on how we got here
+	//                                                  trailing "/" places "" in pathSplit[len(pathSplit)-1]
+
+	numPathParts = len(pathSplit) - 1
+	if "" == pathSplit[numPathParts] {
+		numPathParts--
+	}
+
+	if "deletions" != pathSplit[1] {
+		responseWriter.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	switch numPathParts {
+	case 2:
+		// Form: /deletions/{pause|resume}
+
+		switch pathSplit[2] {
+		case "pause":
+			headhunter.DisableObjectDeletions()
+			responseWriter.WriteHeader(http.StatusNoContent)
+		case "resume":
+			headhunter.EnableObjectDeletions()
+			responseWriter.WriteHeader(http.StatusNoContent)
+		default:
+			responseWriter.WriteHeader(http.StatusNotFound)
+		}
 	default:
 		responseWriter.WriteHeader(http.StatusNotFound)
 	}


### PR DESCRIPTION
curl -X POST http://<PrivateIPAddr>:<HTTPServer.TCPPort>/deletions/pause to pause them
curl -X POST http://<PrivateIPAddr>:<HTTPServer.TCPPort>/deletions/resume to resume them

Note that any signal will resume deletions lest shutdown/signal-handling hang

Also added a small fix to CONFIGURING.md