### PR TITLE
Fix memory leak and more unit tests

### DIFF
--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -55,16 +55,18 @@ type Server struct {
 	deadlineIO           time.Duration
 	keepalivePeriod      time.Duration
 	completedDoneWG      sync.WaitGroup
+	dontStartTrimmers    bool // Used for testing
 }
 
 // ServerConfig is used to configure a retryrpc Server
 type ServerConfig struct {
-	LongTrim        time.Duration // How long the results of an RPC are stored on a Server before removed
-	ShortTrim       time.Duration // How frequently completed and ACKed RPCs results are removed from Server
-	IPAddr          string        // IP Address that Server uses to listen
-	Port            int           // Port that Server uses to listen
-	DeadlineIO      time.Duration // How long I/Os on sockets wait even if idle
-	KEEPALIVEPeriod time.Duration // How frequently a KEEPALIVE is sent
+	LongTrim          time.Duration // How long the results of an RPC are stored on a Server before removed
+	ShortTrim         time.Duration // How frequently completed and ACKed RPCs results are removed from Server
+	IPAddr            string        // IP Address that Server uses to listen
+	Port              int           // Port that Server uses to listen
+	DeadlineIO        time.Duration // How long I/Os on sockets wait even if idle
+	KEEPALIVEPeriod   time.Duration // How frequently a KEEPALIVE is sent
+	dontStartTrimmers bool          // Used for testing
 }
 
 // NewServer creates the Server object
@@ -74,7 +76,7 @@ func NewServer(config *ServerConfig) *Server {
 	)
 	server := &Server{ipaddr: config.IPAddr, port: config.Port, completedLongTTL: config.LongTrim,
 		completedAckTrim: config.ShortTrim, deadlineIO: config.DeadlineIO,
-		keepalivePeriod: config.KEEPALIVEPeriod}
+		keepalivePeriod: config.KEEPALIVEPeriod, dontStartTrimmers: config.dontStartTrimmers}
 	server.svrMap = make(map[string]*methodArgs)
 	server.perClientInfo = make(map[string]*clientInfo)
 	server.completedTickerDone = make(chan bool)
@@ -117,24 +119,39 @@ func (server *Server) Start() (err error) {
 
 	server.listenersWG.Add(1)
 
-	// Start ticker which removes older completedRequests
-	server.completedLongTicker = time.NewTicker(server.completedLongTTL)
-	// Start ticker which removes requests already ACKed by client
-	server.completedShortTicker = time.NewTicker(server.completedAckTrim)
+	// Some of the unit tests disable starting trimmers
+	if !server.dontStartTrimmers {
+		// Start ticker which removes older completedRequests
+		server.completedLongTicker = time.NewTicker(server.completedLongTTL)
+		// Start ticker which removes requests already ACKed by client
+		server.completedShortTicker = time.NewTicker(server.completedAckTrim)
+	}
 	server.completedDoneWG.Add(1)
-	go func() {
-		for {
-			select {
-			case <-server.completedTickerDone:
-				server.completedDoneWG.Done()
-				return
-			case tl := <-server.completedLongTicker.C:
-				server.trimCompleted(tl, true)
-			case ts := <-server.completedShortTicker.C:
-				server.trimCompleted(ts, false)
+	if !server.dontStartTrimmers {
+		go func() {
+			for {
+				select {
+				case <-server.completedTickerDone:
+					server.completedDoneWG.Done()
+					return
+				case tl := <-server.completedLongTicker.C:
+					server.trimCompleted(tl, true)
+				case ts := <-server.completedShortTicker.C:
+					server.trimCompleted(ts, false)
+				}
 			}
-		}
-	}()
+		}()
+	} else {
+		go func() {
+			for {
+				select {
+				case <-server.completedTickerDone:
+					server.completedDoneWG.Done()
+					return
+				}
+			}
+		}()
+	}
 
 	return err
 }
@@ -197,8 +214,10 @@ func (server *Server) Close() {
 	// Now close the client sockets to wakeup them up
 	server.closeClientConn()
 
-	server.completedLongTicker.Stop()
-	server.completedShortTicker.Stop()
+	if !server.dontStartTrimmers {
+		server.completedLongTicker.Stop()
+		server.completedShortTicker.Stop()
+	}
 	server.completedTickerDone <- true
 	server.completedDoneWG.Wait()
 }

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -37,6 +37,20 @@ const (
 
 type requestID uint64
 
+// Useful stats for the clientInfo instance
+type statsInfo struct {
+	cntAddCompleted        uint64        // Number added to completed list
+	cntRmCompleted         uint64        // Number removed from completed list
+	longestRPC             time.Duration // Time of longest RPC
+	longestRPCMethod       string        // Method of longest RPC
+	largestReplySize       int           // Largest RPC reply size completed
+	largestReplySizeMethod string        // Method of largest RPC reply size completed
+	numRPCcompleted        uint64        // Number of RPCs which completed - incremented after call returns
+	numRPCretried          uint64        // Number of RPCs which were just pulled from completed list
+	numRPCattempted        uint64        // Number of RPCs attempted - may be completed or in process
+	numRPCinprocess        uint64        // Number presently calling RPC - decremented when completed
+}
+
 // Server side data structure storing per client information
 // such as completed requests, etc
 type clientInfo struct {
@@ -47,16 +61,7 @@ type clientInfo struct {
 	completedRequestLRU      *list.List                    // LRU used to remove completed request in ticker
 	highestReplySeen         requestID                     // Highest consectutive requestID client has seen
 	previousHighestReplySeen requestID                     // Previous highest consectutive requestID client has seen
-	// TODO - debug
-	// add to 10 min timer message
-	cntAddCompleted  int           // Number added to completed list
-	cntRmCompleted   int           // Number removed from completed list
-	longestRPC       time.Duration // Time of longest RPC
-	largestReplySize int           // Largest RPC reply size completed
-	numRPCcompleted  int           // Number of RPCs which completed - incremented after call returns
-	numRPCretried    int           // Number of RPCs which were just pulled from completed list
-	numRPCattempted  int           // Number of RPCs attempted - may be completed or in process
-	numRPCinprocess  int           // Number presently calling RPC - decremented when completed
+	stats                    statsInfo
 }
 
 type completedEntry struct {

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -47,6 +47,16 @@ type clientInfo struct {
 	completedRequestLRU      *list.List                    // LRU used to remove completed request in ticker
 	highestReplySeen         requestID                     // Highest consectutive requestID client has seen
 	previousHighestReplySeen requestID                     // Previous highest consectutive requestID client has seen
+	// TODO - debug
+	// add to 10 min timer message
+	cntAddCompleted  int           // Number added to completed list
+	cntRmCompleted   int           // Number removed from completed list
+	longestRPC       time.Duration // Time of longest RPC
+	largestReplySize int           // Largest RPC reply size completed
+	numRPCcompleted  int           // Number of RPCs which completed - incremented after call returns
+	numRPCretried    int           // Number of RPCs which were just pulled from completed list
+	numRPCattempted  int           // Number of RPCs attempted - may be completed or in process
+	numRPCinprocess  int           // Number presently calling RPC - decremented when completed
 }
 
 type completedEntry struct {

--- a/retryrpc/api_internal.go
+++ b/retryrpc/api_internal.go
@@ -48,7 +48,7 @@ type statsInfo struct {
 	numRPCcompleted        uint64        // Number of RPCs which completed - incremented after call returns
 	numRPCretried          uint64        // Number of RPCs which were just pulled from completed list
 	numRPCattempted        uint64        // Number of RPCs attempted - may be completed or in process
-	numRPCinprocess        uint64        // Number presently calling RPC - decremented when completed
+	numRPCinprocess        uint64        // Number of RPCs presently calling RPC - decremented when completed
 }
 
 // Server side data structure storing per client information

--- a/retryrpc/retryrpc_test.go
+++ b/retryrpc/retryrpc_test.go
@@ -39,13 +39,13 @@ func (m *MyType) unexportedFunction(i int) {
 	m.field1 = i
 }
 
-func getNewServer(lt time.Duration) (rrSvr *Server, ip string, p int) {
+func getNewServer(lt time.Duration, dontStartTrimmers bool) (rrSvr *Server, ip string, p int) {
 	var (
 		ipaddr = "127.0.0.1"
 		port   = 24456
 	)
 	config := &ServerConfig{LongTrim: lt, ShortTrim: 100 * time.Millisecond, IPAddr: "127.0.0.1",
-		Port: 24456, DeadlineIO: 5 * time.Second}
+		Port: 24456, DeadlineIO: 5 * time.Second, dontStartTrimmers: dontStartTrimmers}
 
 	// Create a new RetryRPC Server.  Completed request will live on
 	// completedRequests for 10 seconds.
@@ -65,7 +65,7 @@ func testServer(t *testing.T) {
 	// RPCs
 	myJrpcfs := rpctest.NewServer()
 
-	rrSvr, ipaddr, port := getNewServer(10 * time.Second)
+	rrSvr, ipaddr, port := getNewServer(10*time.Second, false)
 	assert.NotNil(rrSvr)
 
 	// Register the Server - sets up the methods supported by the
@@ -121,7 +121,7 @@ func testServer(t *testing.T) {
 func testBtree(t *testing.T) {
 	assert := assert.New(t)
 
-	rrSvr, ipaddr, port := getNewServer(10 * time.Second)
+	rrSvr, ipaddr, port := getNewServer(10*time.Second, false)
 	assert.NotNil(rrSvr)
 
 	// Setup a client - we only will be targeting the btree

--- a/retryrpc/rpctest/ping.go
+++ b/retryrpc/rpctest/ping.go
@@ -2,6 +2,7 @@ package rpctest
 
 // Simple ping for testing the RPC layer
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/swiftstack/ProxyFS/blunder"
@@ -17,6 +18,23 @@ func encodeErrno(e *error) {
 func (s *Server) RpcPing(in *PingReq, reply *PingReply) (err error) {
 
 	reply.Message = fmt.Sprintf("pong %d bytes", len(in.Message))
+	return nil
+}
+
+var largeStr string = "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+
+// RpcPingLarge simply does a len on the message path and returns the result
+// along with a larger buffer.
+func (s *Server) RpcPingLarge(in *PingReq, reply *PingReply) (err error) {
+
+	buf := bytes.Buffer{}
+	p := fmt.Sprintf("pong %d bytes", len(in.Message))
+	buf.WriteString(p)
+	for i := 0; i < 1000; i++ {
+		buf.WriteString(largeStr)
+	}
+
+	reply.Message = fmt.Sprintf("%v", buf.String())
 	return nil
 }
 

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -502,11 +502,12 @@ func (server *Server) trimTLLBased(ci *clientInfo, t time.Time) (numItems int) {
 		}
 	}
 	s := ci.stats
-	logger.Infof("ID: %v completedRequest len: %v completedRequestLRU len: %v previousHighestReplySeen: %v highestReplySeen: %v ",
-		"largestReplySize: %v largestReplySizeMethod: %v numRPCcompleted: %v numRPCretried: %v numRPCattempted: %v ",
+	logger.Infof("ID: %v completedRequest len: %v completedRequestLRU len: %v previousHighestReplySeen: %v highestReplySeen: %v "+
+		"largestReplySize: %v largestReplySizeMethod: %v numRPCcompleted: %v numRPCretried: %v numRPCattempted: %v "+
 		"numRPCinprocess: %v longest RPC: %v longest RPC Method: %v cntAddCompleted: %v cntRmCompleted: %v",
-		ci.myUniqueID, len(ci.completedRequest), ci.completedRequestLRU.Len(), s.largestReplySizeMethod, s.numRPCcompleted,
-		s.numRPCretried, s.numRPCattempted, s.numRPCinprocess, s.longestRPC, s.longestRPCMethod, s.cntAddCompleted, s.cntRmCompleted)
+		ci.myUniqueID, len(ci.completedRequest), ci.completedRequestLRU.Len(), ci.previousHighestReplySeen, ci.highestReplySeen,
+		s.largestReplySize, s.largestReplySizeMethod, s.numRPCcompleted, s.numRPCretried, s.numRPCattempted, s.numRPCinprocess,
+		s.longestRPC, s.longestRPCMethod, s.cntAddCompleted, s.cntRmCompleted)
 
 	ci.Unlock()
 	return

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -431,14 +431,14 @@ func (server *Server) trimCompleted(t time.Time, long bool) {
 		// lock.
 		for e := l.Front(); e != nil; e = e.Next() {
 			key := e.Value.(string)
-			v := server.perClientInfo[key]
+			ci := server.perClientInfo[key]
 
-			v.Lock()
-			if v.isEmpty() {
+			ci.Lock()
+			if ci.isEmpty() && ci.cCtx.serviceClientExited == true {
 				delete(server.perClientInfo, key)
-				logger.Infof("Trim - DELETE inactive clientInfo with ID: %v", v.myUniqueID)
+				logger.Infof("Trim - DELETE inactive clientInfo with ID: %v", ci.myUniqueID)
 			}
-			v.Unlock()
+			ci.Unlock()
 		}
 		logger.Infof("Trimmed completed RetryRpcs - Total: %v", totalItems)
 	} else {

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -82,8 +82,8 @@ func (server *Server) run() {
 			logger.Infof("Closing client: %v address: %v", ci.myUniqueID, myConn.RemoteAddr())
 			server.closeClient(conn, elm)
 
-			// TODO - should we call both trims on this client to release freeable memory now?
-			// Wait until we fully debug memory leak
+			// The clientInfo for this client will first be trimmed and then later
+			// deleted from the list of server.perClientInfo by the TTL trimmer.
 
 		}(conn, elm)
 	}

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -76,9 +76,15 @@ func (server *Server) run() {
 		go func(myConn net.Conn, myElm *list.Element) {
 			defer server.goroutineWG.Done()
 
+			logger.Infof("Servicing client: %v address: %v\n", ci.myUniqueID, myConn.RemoteAddr())
 			server.serviceClient(ci, cCtx)
 
+			logger.Infof("Closing client: %v address: %v\n", ci.myUniqueID, myConn.RemoteAddr())
 			server.closeClient(conn, elm)
+
+			// TODO - should we call both trims on this client to release freeable memory now?
+			// Wait until we fully debug memory leak
+
 		}(conn, elm)
 	}
 }

--- a/retryrpc/server.go
+++ b/retryrpc/server.go
@@ -76,10 +76,10 @@ func (server *Server) run() {
 		go func(myConn net.Conn, myElm *list.Element) {
 			defer server.goroutineWG.Done()
 
-			logger.Infof("Servicing client: %v address: %v\n", ci.myUniqueID, myConn.RemoteAddr())
+			logger.Infof("Servicing client: %v address: %v", ci.myUniqueID, myConn.RemoteAddr())
 			server.serviceClient(ci, cCtx)
 
-			logger.Infof("Closing client: %v address: %v\n", ci.myUniqueID, myConn.RemoteAddr())
+			logger.Infof("Closing client: %v address: %v", ci.myUniqueID, myConn.RemoteAddr())
 			server.closeClient(conn, elm)
 
 			// TODO - should we call both trims on this client to release freeable memory now?

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	/* DEBUG for pprof
-	 */
 	_ "net/http/pprof"
+	*/
 
 	"github.com/stretchr/testify/assert"
 	"github.com/swiftstack/ProxyFS/retryrpc/rpctest"

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -3,7 +3,6 @@ package retryrpc
 import (
 	"fmt"
 	"math/rand"
-	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -19,12 +18,12 @@ import (
 func TestStress(t *testing.T) {
 
 	/*
-	 * DEBUG - used to debug memory leaks
-	 * Run " go tool pprof  http://localhost:12123/debug/pprof/heap"
-	 * to look at memory inuse
-	 */
-	// Start the ws that listens for pprof requests
-	go http.ListenAndServe("localhost:12123", nil)
+		 * DEBUG - used to debug memory leaks
+		 * Run " go tool pprof  http://localhost:12123/debug/pprof/heap"
+		 * to look at memory inuse
+		// Start the ws that listens for pprof requests
+		go http.ListenAndServe("localhost:12123", nil)
+	*/
 
 	testLoop(t)
 	testLoopClientAckTrim(t)

--- a/retryrpc/stress_test.go
+++ b/retryrpc/stress_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	/* DEBUG for pprof
 	_ "net/http/pprof"
+	*/
 
 	"github.com/stretchr/testify/assert"
 	"github.com/swiftstack/ProxyFS/retryrpc/rpctest"

--- a/retryrpc/upcall_test.go
+++ b/retryrpc/upcall_test.go
@@ -40,7 +40,7 @@ func testUpCall(t *testing.T) {
 	// RPCs
 	myJrpcfs := rpctest.NewServer()
 
-	rrSvr, ipaddr, port := getNewServer(10 * time.Second)
+	rrSvr, ipaddr, port := getNewServer(10*time.Second, false)
 	assert.NotNil(rrSvr)
 
 	// Register the Server - sets up the methods supported by the


### PR DESCRIPTION
* don't delete clientInfo from server.perClientInfo unless the completed queue is empty AND the socket has been closed.   If the socket is not close then we continue to queue completed tasks but we do not do trimming
* write unit tests to test short and TTL trimmers
* when trimming, don't push items on second list - just delete inline to avoid copies
* add some basic statistics - will be moved to bucketstats in next commit