### PR TITLE
Prevent ReadCache overflow from stopping proxyfsd startup.

### DIFF
--- a/conf/api.go
+++ b/conf/api.go
@@ -360,10 +360,10 @@ func (confMap ConfMap) Dump() (confMapString string) {
 		confSectionNameSliceIndex int
 	)
 
-	// 1 Mibyte should be more than enough to hold the confMap so get the
+	// 2 Mibyte should be more than enough to hold the confMap so get the
 	// memory in 1 allocation
 	var buf strings.Builder
-	buf.Grow(1024 * 1024)
+	buf.Grow(2 * 1024 * 1024)
 
 	confSectionNameSlice = make([]string, 0, len(confMap))
 

--- a/inode/cache.go
+++ b/inode/cache.go
@@ -53,8 +53,9 @@ func adoptVolumeGroupReadCacheParameters(confMap conf.ConfMap) (err error) {
 
 			readCacheLineCount = readCacheTotalSize / volumeGroup.readCacheLineSize
 			if 0 == readCacheLineCount {
-				err = fmt.Errorf("[VolumeGroup:%s]ReadCacheWeight must result in at least one ReadCacheLineSize (%v) of memory", volumeGroup.name, volumeGroup.readCacheLineSize)
-				return
+				logger.Infof("Computed 0 ReadCacheLines for Volume Group %v; increasing to 1",
+					volumeGroup.name)
+				readCacheLineCount = 1
 			}
 
 			volumeGroup.Lock()

--- a/logger/config.go
+++ b/logger/config.go
@@ -97,7 +97,7 @@ func openLogFile(confMap conf.ConfMap) (err error) {
 	if logFilePath != "" {
 		logFile, err = os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
-			log.Errorf("couldn't open log file: %v", err)
+			log.Errorf("couldn't open log file '%s': %v", logFilePath, err)
 			return err
 		}
 	}
@@ -131,7 +131,7 @@ func openLogFile(confMap conf.ConfMap) (err error) {
 	debugConfSlice, _ := confMap.FetchOptionValueStringSlice("Logging", "DebugLevelLogging")
 	setDebugLoggingLevel(debugConfSlice)
 
-	Infof("logger opened logfile (PID %d)", os.Getpid())
+	Infof("logger opened logfile '%s' (PID %d)", logFilePath, os.Getpid())
 	return
 }
 
@@ -184,10 +184,11 @@ func SignaledStart(confMap conf.ConfMap) (err error) {
 
 func SignaledFinish(confMap conf.ConfMap) (err error) {
 
-	Infof("logger is closing and reopening logfile (PID %d)", os.Getpid())
+	Infof("logger is closing logfile (PID %d)", os.Getpid())
 	err = closeLogFile(confMap)
 	if nil == err {
 		err = openLogFile(confMap)
+		Infof("logger opened logfile (PID %d)", os.Getpid())
 	}
 	return
 }


### PR DESCRIPTION
Instead of having package `inode` throw an error and triggering proxyfsd
to exit when we run out of memory for the ReadCache due to a large number
of Volume Groups, give each volume group 1 ReadCacheLine.

Improve logger start/stop messages.

Improve memory fragmentation by ConfMap.Dump() by changing the
initial buffer to 2 Mibyte.

P# Please enter the commit message for your changes. Lines starting