### PR TITLE
Fix condition in PFSAgent where DoSetAttr() needs to speculatively re…

### DIFF
--- a/pfsagentd/fission.go
+++ b/pfsagentd/fission.go
@@ -517,7 +517,14 @@ func (dummy *globalsStruct) DoSetAttr(inHeader *fission.InHeader, setAttrIn *fis
 	globals.Unlock()
 
 	if cachedFileInodeCase {
-		fileInode.reference()
+		// Calling referenceFileInode() here even though we "know" fileInode to avoid the
+		// sanity check otherwise valid where fileInode.references should not be zero.
+		//
+		// Note that, to avoid any race ambiguity, we will use the fileInode returned
+		// from referenceFileInode() moving forward on the off-chance the one we fetched
+		// from globals.fileInodeMap was removed just after the globals.Unlock() call.
+
+		fileInode = referenceFileInode(inode.InodeNumber(inHeader.NodeID))
 
 		fileInode.doFlushIfNecessary()
 	}


### PR DESCRIPTION
…ference a fileInode

Unfortunately, the sanity check enforced that fileInode.reference() was only called from DoWrite()
where fileInode.references *WOULD* always be non-zero.

This change switches DoSetAttr() to instead use the referenceFileInode() func to increment the
fileInode.references... possibly from zero. The fact that it will cause a fileInode to be created in
the very small chance it was removed just after DoSetAttr() found it but before the call to
referenceFileInode() is ok... no damage will be done.