### PR TITLE
Implemented pfsagentd/container/{build|insert}/Dockerfile's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ gobinsubdirs = \
 	pfs-stress \
 	pfs-swift-load \
 	pfsagentd \
+	pfsagentd/pfsagentd-init \
 	pfsagentd/pfsagentd-swift-auth-plugin \
 	pfsagentConfig \
 	pfsagentConfig/pfsagentConfig \
@@ -182,6 +183,7 @@ install:
 
 pfsagent-install:
 	$(MAKE) --no-print-directory -C pfsagentd install
+	$(MAKE) --no-print-directory -C pfsagentd/pfsagentd-init install
 	$(MAKE) --no-print-directory -C pfsagentd/pfsagentd-swift-auth-plugin install
 
 pre-generate:

--- a/pfsagentd/README.md
+++ b/pfsagentd/README.md
@@ -39,7 +39,7 @@ FUSEUnMountRetryDelay:                                    100ms
 FUSEUnMountRetryCap:                                        100
 PlugInPath:                         pfsagentd-swift-auth-plugin
 PlugInEnvName:                                    SwiftAuthBlob
-PlugInEnvValue: {"AuthURL":"http://172.28.128.2:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"}
+PlugInEnvValue: {"AuthURL":"http://localhost:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"}
 SwiftTimeout:                                               10m
 SwiftRetryLimit:                                             10
 SwiftRetryDelay:                                             1s

--- a/pfsagentd/container/build/Dockerfile
+++ b/pfsagentd/container/build/Dockerfile
@@ -1,4 +1,5 @@
 FROM centos
+ARG ProxyFS_Version=stable
 RUN yum install -y fuse gcc git make python2 tar wget
 RUN ln -s /usr/bin/python2 /usr/bin/python
 WORKDIR /opt/PFSAgent
@@ -10,12 +11,10 @@ RUN mkdir -p $GOPATH/src/github.com/swiftstack
 WORKDIR $GOPATH/src/github.com/swiftstack
 RUN git clone https://github.com/swiftstack/ProxyFS.git
 WORKDIR $GOPATH/src/github.com/swiftstack/ProxyFS
+RUN git checkout $ProxyFS_Version
 RUN make version pfsagent
-WORKDIR /opt/PFSAgent/fake_usr_local
-RUN ln $GOPATH/bin/pfsagentd .
-RUN ln $GOPATH/bin/pfsagentd-swift-auth-plugin  .
-RUN ln $GOPATH/src/github.com/swiftstack/ProxyFS/pfsagentd/pfsagent.conf .
-RUN tar -czf ../pfsagent.tar.gz *
 WORKDIR /opt/PFSAgent
-RUN mkdir AgentMountPoint
-COPY pfsagent.conf .
+
+# To build this image:
+#
+#   docker build [--build-arg ProxyFS_Version=<branch-name-or-tag-or-SHA>] [-t <repository>:<tag>] .

--- a/pfsagentd/container/insert/.gitignore
+++ b/pfsagentd/container/insert/.gitignore
@@ -1,0 +1,5 @@
+Dockerfile
+pfsagentd
+pfsagentd-init
+pfsagentd-swift-auth-plugin
+pfsagent.conf_*

--- a/pfsagentd/container/insert/MakePFSAgentDockerfile
+++ b/pfsagentd/container/insert/MakePFSAgentDockerfile
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+function usage {
+    echo "usage:"
+    echo "  $0 -h"
+    echo "      outputs this usage and conf file format"
+    echo "  $0 --clean"
+    echo "      cleans current directory of generated files"
+    echo "  $0 <conf-file>"
+    echo "      derives a PFSAgent-enabled Dockerfile"
+    echo "      based on directives in <conf-file>"
+}
+
+trim()
+{
+    local trimmed="$1"
+    while [[ $trimmed == ' '* ]]; do
+       trimmed="${trimmed## }"
+    done
+    while [[ $trimmed == *' ' ]]; do
+        trimmed="${trimmed%% }"
+    done
+    echo "$trimmed"
+}
+
+if [[ $# -eq 1 ]]
+then
+    if [[ "$1" = "-h" ]]
+    then
+        usage
+        echo
+        echo "<conf-file> is in .INI format"
+        echo
+        echo "Commented lines begin with '#'"
+        echo
+        echo "The first section, [Globals], should have the following Key:Value pairs:"
+        echo
+        echo "SourceImage:   <repository:tag>"
+        echo "PFSAgentImage: <repository:tag>"
+        echo
+        echo "Other sections enumerate each PFSAgent instance to configure."
+        echo "The name of each section should be unique, ane be neither"
+        echo "\"Globals\" nor \"TEMPLATE\" and enclosed in '[' and ']'."
+        echo
+        echo "Each such section (and there must be at least one of them)"
+        echo "should have the following Key:Value pairs:"
+        echo
+        echo "FUSEVolumeName:     <e.g. CommonVolume>"
+        echo "FUSEMountPointPath: <e.g. AgentMountPoint>"
+        echo "PlugInEnvValue:     <e.g. {\"AuthURL\":\"http://localhost:8080/auth/v1.0\"\\u002C"
+        echo "                           \"AuthUser\":\"test:tester\"\\u002C"
+        echo "                           \"AuthKey\":\"testing\"\\u002C"
+        echo "                           \"Account\":\"AUTH_test\"}>"
+        echo "HTTPServerTCPPort:  <e.g. 9090>"
+        exit 0
+    elif [[ "$1" = "--clean" ]]
+    then
+        rm -f pfsagentd pfsagentd-init pfsagentd-swift-auth-plugin pfsagent.conf_* Dockerfile
+        exit 0
+    else
+        CONF_FILE=$1
+    fi
+else
+    usage
+    exit 1
+fi
+
+CURRENT_SECTION_NAME=""
+SOURCE_IMAGE=""
+PFS_AGENT_IMAGE=""
+
+while IFS= read -r line
+do
+    if [[ ${#line} -ne 0 ]]
+    then
+        if [[ ${line:0:1} != "#" ]]
+        then
+            if [[ ${line:0:1} = "[" ]]
+            then
+                NEW_SECTION_NAME=${line:1:${#line}-2}
+                if [[ ${#NEW_SECTION_NAME} -eq 0 ]]
+                then
+                    echo "Section name cannot be empty"
+                    exit 1
+                fi
+                if [[ $NEW_SECTION_NAME = "Globals" ]]
+                then
+                    if [[ ${CURRENT_SECTION_NAME} != "" ]]
+                    then
+                        echo "Encountered 2nd [Globals] section"
+                        exit 1
+                    fi
+                    CURRENT_SECTION_NAME="Globals"
+                else
+                    if [[ ${CURRENT_SECTION_NAME} = "" ]]
+                    then
+                        echo "First section must be [Globals]"
+                        exit 1
+                    elif [[ ${CURRENT_SECTION_NAME} = "Globals" ]]
+                    then
+                        if [[ $NEW_SECTION_NAME = "TEMPLATE" ]]
+                        then
+                            echo "Encountered illegal section [TEMPLATE]"
+                            exit 1
+                        fi
+                        if [[ ${SOURCE_IMAGE} = "" ]]
+                        then
+                            echo "Missing SourceImage in [Globals] section"
+                            exit 1
+                        fi
+                        if [[ ${PFS_AGENT_IMAGE} = "" ]]
+                        then
+                            echo "Missing PFSAgentImage in [Globals] section"
+                            exit 1
+                        fi
+                        CONTAINER=`docker create -ti pfsagent-build:latest`
+                        docker cp $CONTAINER:/opt/PFSAgent/GOPATH/bin/pfsagentd .
+                        docker cp $CONTAINER:/opt/PFSAgent/GOPATH/bin/pfsagentd-init .
+                        docker cp $CONTAINER:/opt/PFSAgent/GOPATH/bin/pfsagentd-swift-auth-plugin .
+                        docker cp $CONTAINER:/opt/PFSAgent/GOPATH/src/github.com/swiftstack/ProxyFS/pfsagentd/pfsagent.conf pfsagent.conf_TEMPLATE
+                        docker container rm $CONTAINER > /dev/null
+                    else
+                        if [[ $NEW_SECTION_NAME = "TEMPLATE" ]]
+                        then
+                            echo "Encountered illegal section [TEMPLATE]"
+                            exit 1
+                        fi
+                   fi
+                    CURRENT_SECTION_NAME=$NEW_SECTION_NAME
+                    cp pfsagent.conf_TEMPLATE pfsagent.conf_$CURRENT_SECTION_NAME
+                fi
+            else
+                if [[ ${CURRENT_SECTION_NAME} == "" ]]
+                then
+                    echo "Found Key:Value line before any section"
+                    exit 1
+                elif [[ ${CURRENT_SECTION_NAME} == "Globals" ]]
+                then
+                    if [[ $line == "SourceImage:"* ]]
+                    then
+                        SOURCE_IMAGE="$(trim "${line:12}")"
+                    elif [[ $line == "PFSAgentImage:"* ]]
+                    then
+                        PFS_AGENT_IMAGE="$(trim "${line:14}")"
+                   else
+                        echo "Encountered unexpected Key:Value line in [Globals] section: $line"
+                        exit 1
+                    fi
+                else
+                    echo $line >> pfsagent.conf_$CURRENT_SECTION_NAME
+                fi
+            fi
+        fi
+    fi
+done < $CONF_FILE
+
+if [[ ${CURRENT_SECTION_NAME} = "" ]]
+then
+    echo "Must have properly populated [Globals] section"
+    echo "and at least one other section"
+    exit 1
+fi
+
+if [[ ${CURRENT_SECTION_NAME} = "Globals" ]]
+then
+    if [[ ${SOURCE_IMAGE} = "" ]]
+    then
+        echo "Missing SourceImage in [Globals] section"
+        exit 1
+    fi
+    if [[ ${PFS_AGENT_IMAGE} = "" ]]
+    then
+        echo "Missing PFSAgentImage in [Globals] section"
+        exit 1
+    fi
+    CONTAINER=`docker create -ti pfsagent-build:latest`
+    docker cp $CONTAINER:/opt/PFSAgent/GOPATH/bin/pfsagentd .
+    docker cp $CONTAINER:/opt/PFSAgent/GOPATH/bin/pfsagentd-init .
+    docker cp $CONTAINER:/opt/PFSAgent/GOPATH/bin/pfsagentd-swift-auth-plugin .
+    docker cp $CONTAINER:/opt/PFSAgent/GOPATH/src/github.com/swiftstack/ProxyFS/pfsagentd/pfsagent.conf pfsagent.conf_TEMPLATE
+    docker container rm $CONTAINER > /dev/null
+fi
+
+ENTRYPOINT=`docker inspect --format '{{json .Config.Entrypoint}}' ${SOURCE_IMAGE}`
+CMD=`docker inspect --format '{{json .Config.Cmd}}' ${SOURCE_IMAGE}`
+WORKING_DIR=`docker inspect --format '{{json .Config.WorkingDir}}' ${SOURCE_IMAGE}`
+
+echo "FROM ${SOURCE_IMAGE}"                                                                   >  Dockerfile
+echo "RUN yum install -y fuse"                                                                >> Dockerfile
+echo "WORKDIR /opt/PFSAgent"                                                                  >> Dockerfile
+echo "COPY pfsagentd ."                                                                       >> Dockerfile
+echo "COPY pfsagentd-init ."                                                                  >> Dockerfile
+echo "COPY pfsagentd-swift-auth-plugin ."                                                     >> Dockerfile
+echo "COPY pfsagent.conf_* /opt/PFSAgent/"                                                    >> Dockerfile
+echo "ENV PATH /opt/PFSAgent:$PATH"                                                           >> Dockerfile
+echo "ENV PFSAGENT_PARENT_ENTRYPOINT  '${ENTRYPOINT}'"                                        >> Dockerfile
+echo "ENV PFSAGENT_PARENT_CMD         '${CMD}'"                                               >> Dockerfile
+echo "ENV PFSAGENT_PARENT_WORKING_DIR  ${WORKING_DIR}"                                        >> Dockerfile
+echo "ENTRYPOINT [\"pfsagentd-init\"]"                                                        >> Dockerfile
+echo ""                                                                                       >> Dockerfile
+echo "# To run a container for this image:"                                                   >> Dockerfile
+echo "#"                                                                                      >> Dockerfile
+echo "#   docker run -it --rm --device /dev/fuse --cap-add SYS_ADMIN -p 9090:9090 <IMAGE ID>" >> Dockerfile

--- a/pfsagentd/container/insert/MakePFSAgentDockerfile.conf_SAMPLE
+++ b/pfsagentd/container/insert/MakePFSAgentDockerfile.conf_SAMPLE
@@ -1,0 +1,17 @@
+# [Globals] section identifies docker container images in <repository:tag> format
+#
+# Note: This section should appear before all other sections
+#
+[Globals]
+SourceImage:        centos:latest
+PFSAgentImage:      pfsagent-build:latest  
+
+# [<other>] section identifies the PFSAgent volume-specific Key:Value settings desired
+#
+# Note: The value of <other> should follow the rules of a valid POSIX basename
+#
+[SampleVolume]
+FUSEVolumeName:     CommonVolume
+FUSEMountPointPath: AgentMountPoint
+PlugInEnvValue:     {"AuthURL":"http://172.17.0.2:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"}
+HTTPServerTCPPort:  9090

--- a/pfsagentd/pfsagentd-init/Makefile
+++ b/pfsagentd/pfsagentd-init/Makefile
@@ -1,0 +1,3 @@
+gosubdir := github.com/swiftstack/ProxyFS/pfsagentd/pfsagentd-init
+
+include ../../GoMakefile

--- a/pfsagentd/pfsagentd-init/README.md
+++ b/pfsagentd/pfsagentd-init/README.md
@@ -1,0 +1,24 @@
+# PFSAgent Init Daemon For Use In Containers
+
+Docker-style containers are designed to run a single program. If that program
+has a dependency on running services, such as `pfsagentd`, there is no opportunity
+to ensure these are running with a subsystem like `systemd`. While there are a
+number of `systemd` substitutes in wide use in containers that have this service
+requirement (e.g. `supervisord` and `s6`), these tools generally don't have a
+mechanism to order such services nor ensure that each is up and running sufficient
+for the subsequent service or the application to immediately consume.
+
+The program in this directory, `pfsagentd-init`, provides the capability to launch
+a number of instances of `pfsagentd`, ensures that they are able to receive traffic
+via their `FUSEMountPointPath`, and finally launching the desired application.
+
+As may be common, the application to be dependent upon one or more `pfsagentd`
+instances has already been containerized in some existing container image.
+A `Dockerfile` in `../container/build` is provided to build the components that
+need to be added to a derived container image based off the application's original
+container image. Then, a tool in `../container/insert` will create a `Dockerfile`
+derived from the application's original container image that imports these
+to-be-inserted components.
+
+As part of the created `Dockerfile` is a replacement for any ENTRYPOINT and/or
+CMD that will launch `pfsagentd-init` that accomplishes this conversion.

--- a/pfsagentd/pfsagentd-init/dummy_test.go
+++ b/pfsagentd/pfsagentd-init/dummy_test.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestDummy(t *testing.T) {
+}

--- a/pfsagentd/pfsagentd-init/main.go
+++ b/pfsagentd/pfsagentd-init/main.go
@@ -1,0 +1,394 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/swiftstack/ProxyFS/conf"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// PFSAgentReadyAttemptLimit defines the number of times pfsagentd-init
+	// will poll for the successful launching of each child pfsagentd instance
+	//
+	PFSAgentReadyAttemptLimit = uint32(100)
+
+	// PFSAgentReadyRetryDelay is the delay between polling attempts by
+	// pfsagentd-init of each child pfsagentd instance
+	//
+	PFSAgentReadyRetryDelay = "100ms"
+)
+
+type pfsagentdInstanceStruct struct {
+	confFileName       string        //
+	confMap            conf.ConfMap  //
+	httpServerHostPort string        //
+	stopChan           chan struct{} // Closed by main() to tell (*pfsagentdInstanceStruct).daemon() to exit
+}
+
+type globalsStruct struct {
+	parentEntrypoint         []string                   // A non-existent or empty PFSAGENT_PARENT_ENTRYPOINT will result in []string{}
+	parentCmd                []string                   // A non-existent or empty PFSAGENT_PARENT_CMD will result in []string{}
+	parentWorkingDir         string                     // A non-existent or empty PFSAGENT_PARENT_WORKING_DIR will result in "/"
+	pfsagentdReadyRetryDelay time.Duration              //
+	pfsagentdInstance        []*pfsagentdInstanceStruct //
+	pfsagentdInstanceUpChan  chan struct{}              // Signaled by each pfsagentdInstance once they are up
+	childErrorChan           chan struct{}              // Signaled by an unexpectedly exiting child to
+	//                                                       indicate that the entire container should exit
+	applicationCleanExitChan  chan struct{}  //            Signaled by applicationDaemon() on clean exit
+	applicationDaemonStopChan chan struct{}  //            Closed by main() to tell applicationDaemon() to exit
+	signalChan                chan os.Signal //            Signaled by OS or Container Framework to trigger exit
+	pfsagentdInstanceWG       sync.WaitGroup //
+	applicationDaemonWG       sync.WaitGroup //
+}
+
+var globals globalsStruct
+
+func main() {
+	var (
+		err                                 error
+		fileInfo                            os.FileInfo
+		fileInfoName                        string
+		fileInfoSlice                       []os.FileInfo
+		parentCmdBuf                        string
+		parentEntrypointBuf                 string
+		pfsagentdInstance                   *pfsagentdInstanceStruct
+		pfsagentdInstanceFUSEMountPointPath string
+		pfsagentdInstanceHTTPServerIPAddr   string
+		pfsagentdInstanceHTTPServerTCPPort  uint16
+		pfsagentdInstanceUpCount            int
+	)
+
+	log.Printf("Launch of %s\n", os.Args[0])
+
+	parentEntrypointBuf = os.Getenv("PFSAGENT_PARENT_ENTRYPOINT")
+	if (parentEntrypointBuf == "") || (parentEntrypointBuf == "null") {
+		globals.parentEntrypoint = make([]string, 0)
+	} else {
+		globals.parentEntrypoint = make([]string, 0)
+		err = json.Unmarshal([]byte(parentEntrypointBuf), &globals.parentEntrypoint)
+		if err != nil {
+			log.Fatalf("Couldn't parse PFSAGENT_PARENT_ENTRYPOINT: \"%s\"\n", parentEntrypointBuf)
+		}
+	}
+
+	parentCmdBuf = os.Getenv("PFSAGENT_PARENT_CMD")
+	if (parentCmdBuf == "") || (parentCmdBuf == "null") {
+		globals.parentCmd = make([]string, 0)
+	} else {
+		globals.parentCmd = make([]string, 0)
+		err = json.Unmarshal([]byte(parentCmdBuf), &globals.parentCmd)
+		if err != nil {
+			log.Fatalf("Couldn't parse PFSAGENT_PARENT_CMD: \"%s\"\n", parentCmdBuf)
+		}
+	}
+
+	globals.parentWorkingDir = os.Getenv("PFSAGENT_PARENT_WORKING_DIR")
+	if globals.parentWorkingDir == "" {
+		globals.parentWorkingDir = "/"
+	}
+
+	fileInfoSlice, err = ioutil.ReadDir(".")
+	if err != nil {
+		log.Fatalf("Couldn't read directory: %v\n", err)
+	}
+
+	globals.pfsagentdReadyRetryDelay, err = time.ParseDuration(PFSAgentReadyRetryDelay)
+	if err != nil {
+		log.Fatalf("Couldn't parse PFSAgentReadyRetryDelay\n")
+	}
+
+	globals.pfsagentdInstance = make([]*pfsagentdInstanceStruct, 0)
+
+	for _, fileInfo = range fileInfoSlice {
+		fileInfoName = fileInfo.Name()
+		if strings.HasPrefix(fileInfoName, "pfsagent.conf_") {
+			if fileInfoName != "pfsagent.conf_TEMPLATE" {
+				pfsagentdInstance = &pfsagentdInstanceStruct{
+					confFileName: fileInfoName,
+					stopChan:     make(chan struct{}),
+				}
+				globals.pfsagentdInstance = append(globals.pfsagentdInstance, pfsagentdInstance)
+			}
+		}
+	}
+
+	globals.pfsagentdInstanceUpChan = make(chan struct{}, len(globals.pfsagentdInstance))
+	globals.childErrorChan = make(chan struct{}, len(globals.pfsagentdInstance)+1)
+
+	globals.signalChan = make(chan os.Signal, 1)
+	signal.Notify(globals.signalChan, unix.SIGINT, unix.SIGTERM, unix.SIGHUP)
+
+	globals.pfsagentdInstanceWG.Add(len(globals.pfsagentdInstance))
+
+	for _, pfsagentdInstance = range globals.pfsagentdInstance {
+		pfsagentdInstance.confMap, err = conf.MakeConfMapFromFile(pfsagentdInstance.confFileName)
+		if err != nil {
+			log.Fatalf("Unable to parse %s: %v\n", pfsagentdInstance.confFileName, err)
+		}
+
+		pfsagentdInstanceFUSEMountPointPath, err = pfsagentdInstance.confMap.FetchOptionValueString("Agent", "FUSEMountPointPath")
+		if err != nil {
+			log.Fatalf("In %s, parsing [Agent]FUSEMountPointPath failed: %v\n", pfsagentdInstance.confFileName, err)
+		}
+
+		err = os.MkdirAll(pfsagentdInstanceFUSEMountPointPath, 0777)
+		if err != nil {
+			log.Fatalf("For %s, could not create directory path %s: %v\n", pfsagentdInstance.confFileName, pfsagentdInstanceFUSEMountPointPath, err)
+		}
+
+		pfsagentdInstanceHTTPServerIPAddr, err = pfsagentdInstance.confMap.FetchOptionValueString("Agent", "HTTPServerIPAddr")
+		if err != nil {
+			log.Fatalf("In %s, parsing [Agent]HTTPServerIPAddr failed: %v\n", pfsagentdInstance.confFileName, err)
+		}
+		if pfsagentdInstanceHTTPServerIPAddr == "0.0.0.0" {
+			pfsagentdInstanceHTTPServerIPAddr = "127.0.0.1"
+		} else if pfsagentdInstanceHTTPServerIPAddr == "::" {
+			pfsagentdInstanceHTTPServerIPAddr = "::1"
+		}
+
+		pfsagentdInstanceHTTPServerTCPPort, err = pfsagentdInstance.confMap.FetchOptionValueUint16("Agent", "HTTPServerTCPPort")
+		if err != nil {
+			log.Fatalf("In %s, parsing [Agent]HTTPServerTCPPort failed: %v\n", pfsagentdInstance.confFileName, err)
+		}
+
+		pfsagentdInstance.httpServerHostPort = net.JoinHostPort(pfsagentdInstanceHTTPServerIPAddr, strconv.Itoa(int(pfsagentdInstanceHTTPServerTCPPort)))
+
+		go pfsagentdInstance.daemon()
+	}
+
+	if len(globals.pfsagentdInstance) > 0 {
+		pfsagentdInstanceUpCount = 0
+
+		for {
+			select {
+			case _ = <-globals.pfsagentdInstanceUpChan:
+				pfsagentdInstanceUpCount++
+				if pfsagentdInstanceUpCount == len(globals.pfsagentdInstance) {
+					goto pfsagentdInstanceUpComplete
+				}
+			case _ = <-globals.childErrorChan:
+				for _, pfsagentdInstance = range globals.pfsagentdInstance {
+					close(pfsagentdInstance.stopChan)
+				}
+
+				globals.pfsagentdInstanceWG.Wait()
+
+				log.Fatalf("Abnormal exit during PFSAgent Instances creation\n")
+			case _ = <-globals.signalChan:
+				for _, pfsagentdInstance = range globals.pfsagentdInstance {
+					close(pfsagentdInstance.stopChan)
+				}
+
+				globals.pfsagentdInstanceWG.Wait()
+
+				log.Printf("Signaled exit during PFSAgent Instances creation\n")
+				os.Exit(0)
+			}
+		}
+
+	pfsagentdInstanceUpComplete:
+	}
+
+	globals.applicationCleanExitChan = make(chan struct{}, 1)
+	globals.applicationDaemonStopChan = make(chan struct{})
+
+	globals.applicationDaemonWG.Add(1)
+
+	go applicationDaemon()
+
+	for {
+		select {
+		case _ = <-globals.childErrorChan:
+			close(globals.applicationDaemonStopChan)
+
+			globals.applicationDaemonWG.Wait()
+
+			for _, pfsagentdInstance = range globals.pfsagentdInstance {
+				close(pfsagentdInstance.stopChan)
+			}
+
+			globals.pfsagentdInstanceWG.Wait()
+
+			log.Fatalf("Abnormal exit after PFSAgent Instances creation\n")
+		case _ = <-globals.applicationCleanExitChan:
+			globals.applicationDaemonWG.Wait()
+
+			for _, pfsagentdInstance = range globals.pfsagentdInstance {
+				close(pfsagentdInstance.stopChan)
+			}
+
+			globals.pfsagentdInstanceWG.Wait()
+
+			log.Printf("Normal exit do to application clean exit\n")
+			os.Exit(0)
+		case _ = <-globals.signalChan:
+			close(globals.applicationDaemonStopChan)
+
+			globals.applicationDaemonWG.Wait()
+
+			for _, pfsagentdInstance = range globals.pfsagentdInstance {
+				close(pfsagentdInstance.stopChan)
+			}
+
+			globals.pfsagentdInstanceWG.Wait()
+
+			log.Printf("Signaled exit after PFSAgent Instances creation\n")
+			os.Exit(0)
+		}
+	}
+}
+
+func (pfsagentdInstance *pfsagentdInstanceStruct) daemon() {
+	var (
+		cmd          *exec.Cmd
+		cmdExitChan  chan struct{}
+		err          error
+		getResponse  *http.Response
+		readyAttempt uint32
+	)
+
+	cmd = exec.Command("pfsagentd", pfsagentdInstance.confFileName)
+
+	err = cmd.Start()
+	if err != nil {
+		globals.childErrorChan <- struct{}{}
+		globals.pfsagentdInstanceWG.Done()
+		runtime.Goexit()
+	}
+
+	readyAttempt = 1
+
+	for {
+		getResponse, err = http.Get("http://" + pfsagentdInstance.httpServerHostPort + "/version")
+		if err == nil {
+			_, err = ioutil.ReadAll(getResponse.Body)
+			if err != nil {
+				log.Fatalf("Failure to read GET Response Body: %v\n", err)
+			}
+			err = getResponse.Body.Close()
+			if err != nil {
+				log.Fatalf("Failure to close GET Response Body: %v\n", err)
+			}
+
+			if getResponse.StatusCode == http.StatusOK {
+				break
+			}
+		}
+
+		readyAttempt++
+
+		if readyAttempt > PFSAgentReadyAttemptLimit {
+			log.Fatalf("Ready attempt limit exceeded for pfsagentd instance %s\n", pfsagentdInstance.confFileName)
+		}
+
+		time.Sleep(globals.pfsagentdReadyRetryDelay)
+	}
+
+	globals.pfsagentdInstanceUpChan <- struct{}{}
+
+	cmdExitChan = make(chan struct{}, 1)
+	go watchCmdDaemon(cmd, cmdExitChan)
+
+	for {
+		select {
+		case _ = <-cmdExitChan:
+			globals.childErrorChan <- struct{}{}
+			globals.pfsagentdInstanceWG.Done()
+			runtime.Goexit()
+		case _, _ = <-pfsagentdInstance.stopChan:
+			err = cmd.Process.Signal(unix.SIGTERM)
+			if err == nil {
+				_ = cmd.Wait()
+			}
+			globals.pfsagentdInstanceWG.Done()
+			runtime.Goexit()
+		}
+	}
+}
+
+func applicationDaemon() {
+	var (
+		cmd         *exec.Cmd
+		cmdArgs     []string
+		cmdExitChan chan struct{}
+		cmdPath     string
+		err         error
+	)
+
+	cmdArgs = make([]string, 0)
+
+	if len(globals.parentEntrypoint) > 0 {
+		cmdPath = globals.parentEntrypoint[0]
+		cmdArgs = globals.parentEntrypoint[1:]
+
+		if len(os.Args) > 1 {
+			cmdArgs = append(cmdArgs, os.Args[1:]...)
+		} else {
+			cmdArgs = append(cmdArgs, globals.parentCmd...)
+		}
+	} else { // len(globals.parentEntrypoint) == 0
+		if len(os.Args) > 1 {
+			cmdPath = os.Args[1]
+			cmdArgs = os.Args[2:]
+		} else {
+			if len(globals.parentCmd) > 0 {
+				cmdPath = globals.parentCmd[0]
+				cmdArgs = globals.parentCmd[1:]
+			} else {
+				cmdPath = "/bin/sh"
+				cmdArgs = make([]string, 0)
+			}
+		}
+	}
+
+	cmd = exec.Command(cmdPath, cmdArgs...)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Start()
+	if err != nil {
+		globals.childErrorChan <- struct{}{}
+		globals.applicationDaemonWG.Done()
+		runtime.Goexit()
+	}
+
+	cmdExitChan = make(chan struct{}, 1)
+	go watchCmdDaemon(cmd, cmdExitChan)
+
+	for {
+		select {
+		case _ = <-cmdExitChan:
+			if cmd.ProcessState.ExitCode() == 0 {
+				globals.applicationCleanExitChan <- struct{}{}
+			} else {
+				globals.childErrorChan <- struct{}{}
+			}
+			globals.applicationDaemonWG.Done()
+			runtime.Goexit()
+		case _, _ = <-globals.applicationDaemonStopChan:
+			globals.applicationDaemonWG.Done()
+			runtime.Goexit()
+		}
+	}
+}
+
+func watchCmdDaemon(cmd *exec.Cmd, cmdExitChan chan struct{}) {
+	_ = cmd.Wait()
+
+	cmdExitChan <- struct{}{}
+}


### PR DESCRIPTION
The build/ Dockerfile is provided to construct PFSAgent elements
It is intended that the Container Image resulting from this is
widely available to anyone wanting to buld PFSAgent for a
Linux environment (typically containerized).

The insert/ directory actually includes a bash script and a
sample .conf file that are used to construct a Dockerfile
based off the desired base Docker Image extended to include
the PFSAgent components from the build/ Docker Image as well
as configuration of any desired PFSAgent instances.

It should be noted that the resultant Dockder Image must be
run with `--device /dev/fuse --cap-add SYS_ADMIN` options
since each PFSAgent instance leverages the FUSE subsystem.