### PR TITLE
Move eventlet.Timeout handling into JsonRpcClient.call()

### DIFF
--- a/pfs_middleware/pfs_middleware/bimodal_checker.py
+++ b/pfs_middleware/pfs_middleware/bimodal_checker.py
@@ -22,7 +22,6 @@ access to ProxyFS volumes. It doesn't have any user-visible functionality on
 its own, but it is required for the other middlewares to work.
 """
 
-import eventlet
 import random
 import socket
 import time
@@ -100,11 +99,6 @@ class BimodalChecker(object):
                     continue
                 else:
                     raise
-            except eventlet.Timeout:
-                errstr = "Timeout ({0:.6f}s) calling {1}".format(
-                    self.proxyfsd_rpc_timeout,
-                    rpc_request.get("method", "<unknown method>"))
-                raise utils.RpcTimeout(errstr)
 
             errstr = result.get("error")
             if errstr:

--- a/pfs_middleware/pfs_middleware/middleware.py
+++ b/pfs_middleware/pfs_middleware/middleware.py
@@ -1040,11 +1040,8 @@ class PfsMiddleware(object):
             payload['params'][0]['AccountName'] = ctx.account_name
             response = client.call(payload, self.proxyfsd_rpc_timeout,
                                    raise_on_rpc_error=False)
-        except eventlet.Timeout:
-            self.logger.debug(
-                "Timeout (%.6fs) communicating with %s, calling %s",
-                self.proxyfsd_rpc_timeout, ctx.proxyfsd_addrinfo,
-                payloads[0]['method'])
+        except utils.RpcTimeout as err:
+            self.logger.debug(str(err))
             return swob.HTTPBadGateway(request=req)
         except socket.error as err:
             self.logger.debug("Error communicating with %r: %s.",
@@ -2179,11 +2176,6 @@ class PfsMiddleware(object):
                     continue
                 else:
                     raise
-            except eventlet.Timeout:
-                errstr = "Timeout ({0:.6f}s) calling {1}".format(
-                    self.proxyfsd_rpc_timeout,
-                    rpc_request.get("method", "<unknown method>"))
-                raise utils.RpcTimeout(errstr)
 
             errstr = result.get("error")
             if errstr:

--- a/pfs_middleware/tests/test_bimodal_checker.py
+++ b/pfs_middleware/tests/test_bimodal_checker.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import errno
-import eventlet
 import mock
 import os
 import socket
@@ -307,7 +306,7 @@ class TestRetry(unittest.TestCase):
             ('Server.RpcIsAccountBimodal', ({'AccountName': 'AUTH_test'},))))
 
     def test_no_retry_timeout(self):
-        err = eventlet.Timeout(None)  # don't really time anything out
+        err = utils.RpcTimeout()
         self.fake_rpc.add_call_error(err)
 
         req = swob.Request.blank(


### PR DESCRIPTION
We previously documented that `call()` would raise `RpcTimeout`s; let's make that actually be true.

This also gives us a handy place to centralize our error formatting. As a drive-by, make sure that we include the ip/port we were trying to talk to in the error.