### PR TITLE
Fix another panic caused by a bad config value.

### DIFF
--- a/inode/config.go
+++ b/inode/config.go
@@ -283,6 +283,11 @@ func (dummy *globalsStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroup
 	if nil != err {
 		return
 	}
+	if volumeGroup.readCacheLineSize < 4096 {
+		logger.Warnf("Section '%s' for VolumeGroup '%s' ReadCacheWeight %d is < 4096; changing to 4096",
+			volumeGroupSectionName, volumeGroupName, volumeGroup.readCacheLineSize)
+		volumeGroup.readCacheLineSize = 4096
+	}
 
 	volumeGroup.readCacheWeight, err = confMap.FetchOptionValueUint64(volumeGroupSectionName, "ReadCacheWeight")
 	if nil != err {

--- a/inode/config_test.go
+++ b/inode/config_test.go
@@ -31,6 +31,7 @@ func TestConfig(t *testing.T) {
 	testConfUpdateStrings = []string{
 		"FSGlobals.VolumeGroupList=TestVolumeGroup",
 		"VolumeGroup:TestVolumeGroup.ReadCacheWeight=0",
+		"VolumeGroup:TestVolumeGroup.ReadCacheLineSize=0",
 	}
 
 	err = testConfMap.UpdateFromStrings(testConfUpdateStrings)


### PR DESCRIPTION
If ReadCacheLineSize is 0 in the config file then proxfys will panic.

Therfore, insure ReadCacheLineSize is at least 4096 bytes.

Unit test included.