### PR TITLE
Bugfix 10 k volumes

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -77,6 +77,7 @@ For each of the keys supported, the following table will list whether or not its
 |                                           | HeartBeatMissLimit                       | No           | 3                  | Yes                      | No                           |
 |                                           | MessageQueueDepthPerPeer                 | No           | 4                  | Yes                      | No                           |
 |                                           | MaxRequestDuration                       | No           | 1s                 | Yes                      | No                           |
+|                                           | LivenessCheckerEnabled                   | No           | false              | Yes                      | Yes                          |
 |                                           | LivenessCheckRedundancy                  | No           | 2                  | Yes                      | No                           |
 |                                           | LogLevel                                 | No           | <i>None</i>        | Yes                      | No                           |
 | Peer:<i>PeerName</i>                      | PublicIPAddr                             | Yes          |                    | Yes                      | Yes but WhoAmI should remain |

--- a/conf/api.go
+++ b/conf/api.go
@@ -416,7 +416,8 @@ func (confMap ConfMap) Dump() (confMapString string) {
 	return
 }
 
-// VerifyOptionIsMissing returns an error if [sectionName]optionName exists
+// VerifyOptionIsMissing returns an error if [sectionName]optionName does not
+// exist.
 func (confMap ConfMap) VerifyOptionIsMissing(sectionName string, optionName string) (err error) {
 	section, ok := confMap[sectionName]
 	if !ok {
@@ -434,7 +435,8 @@ func (confMap ConfMap) VerifyOptionIsMissing(sectionName string, optionName stri
 	return
 }
 
-// VerifyOptionValueIsEmpty returns an error if [sectionName]optionName's value is not empty
+// VerifyOptionValueIsEmpty returns an error if [sectionName]optionName's value
+// is not empty or if the option does not exist.
 func (confMap ConfMap) VerifyOptionValueIsEmpty(sectionName string, optionName string) (err error) {
 	section, ok := confMap[sectionName]
 	if !ok {
@@ -455,6 +457,41 @@ func (confMap ConfMap) VerifyOptionValueIsEmpty(sectionName string, optionName s
 	}
 
 	return
+}
+
+// SetOptionIfMissing sets the value of the option to optionVal if and only if
+// the option is not already specified.  The section is created if it doesn't
+// already exist.
+//
+// This is useful to apply "default" options after the confmap has been loaded.
+func (confMap ConfMap) SetOptionIfMissing(sectionName string, optionName string, optionVal ConfMapOption) {
+
+	section, ok := confMap[sectionName]
+	if !ok {
+		section := make(ConfMapSection)
+		confMap[sectionName] = section
+	}
+
+	_, ok = section[optionName]
+	if ok {
+		return
+	}
+	confMap[sectionName][optionName] = optionVal
+}
+
+// SetSectionIfMissing sets the section value to the valued passed in if and
+// only if the sectionName is not already specified.  The section is created if
+// it doesn't already exist.
+//
+// This is useful to apply "default" sections after the confmap has been loaded.
+func (confMap ConfMap) SetSectionIfMissing(sectionName string, sectionVal ConfMapSection) {
+
+	_, ok := confMap[sectionName]
+	if ok {
+		return
+	}
+
+	confMap[sectionName] = sectionVal
 }
 
 // FetchOptionValueStringSlice returns [sectionName]optionName's string values as a []string

--- a/conf/api_test.go
+++ b/conf/api_test.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const errnoEACCES = int(13)
@@ -563,4 +565,84 @@ func TestDump(t *testing.T) {
 	if !reflect.DeepEqual(confMap6, confMap7) {
 		t.Fatalf("DumpConfMapToFile() failed to reproduce \"%v\" into \"%v\"", tempFile6Name, tempFile7Name)
 	}
+}
+
+// test SetOptionIfMissing and SetSectionIfMissing
+func TestIfMissing(t *testing.T) {
+
+	assert := assert.New(t)
+
+	// create an empty confMap and populate it with one option (in one section)
+	confMap := MakeConfMap()
+
+	testSectionName0 := "TestSection0"
+	testSectionName1 := "TestSection1e"
+	testOptionName0 := "Test_-_Option0"
+	testOptionName1 := "Test_-_Option1"
+	testOptionString0 := "OptionValue0"
+	missingOptionString0 := "DefaultString0"
+	missingOptionString1 := "DefaultString1"
+
+	confStringToSection0Option0 := testSectionName0 + "." + testOptionName0 + " = " + testOptionString0
+
+	// populate testSectionName0.testOptionName0
+	err := confMap.UpdateFromString(confStringToSection0Option0)
+	assert.NoError(err, "UpdateFromString() should not fail with a valid option string")
+
+	// verify option was set
+	optionString, err := confMap.FetchOptionValueString(testSectionName0, testOptionName0)
+	assert.NoError(err, "FetchOptionValueString() cannot fail a valid request")
+	assert.Equal(testOptionString0, optionString, "FetchOptionValueString should return the option that was set")
+
+	missingOptionValue0 := ConfMapOption{missingOptionString0}
+	missingOptionValue1 := ConfMapOption{missingOptionString1}
+
+	// a new ConfMapOption should not overwrite the existing one
+	confMap.SetOptionIfMissing(testSectionName0, testOptionName0, missingOptionValue0)
+
+	optionString, err = confMap.FetchOptionValueString(testSectionName0, testOptionName0)
+	assert.NoError(err, "FetchOptionalValueString should not fail since the option exists")
+	assert.Equal(testOptionString0, optionString, "SetOptionIfMissing should not change existing optionValue")
+
+	// but a new ConfMapOption should replace a missing one
+	optionString, err = confMap.FetchOptionValueString(testSectionName0, testOptionName1)
+	assert.Error(err, "FetchOptionalValueString should fail since '%s' has not been set", testOptionName1)
+
+	confMap.SetOptionIfMissing(testSectionName0, testOptionName1, missingOptionValue1)
+
+	optionString, err = confMap.FetchOptionValueString(testSectionName0, testOptionName1)
+	assert.NoError(err, "FetchOptionalValueString should not fail since missing value was set")
+	assert.Equal(missingOptionString1, optionString, "SetOptionIfMissing should have set missing value")
+
+	// repeat a similar set of tests for sections
+	//
+	// verify option still exists
+	optionString, err = confMap.FetchOptionValueString(testSectionName0, testOptionName0)
+	assert.NoError(err, "FetchOptionValueString() cannot fail a valid request")
+
+	// a new ConfMapSection should not overwrite an existing one
+	missingSection0 := ConfMapSection{
+		testOptionName0: ConfMapOption{missingOptionString0},
+		testOptionName1: ConfMapOption{missingOptionString1},
+	}
+	confMap.SetSectionIfMissing(testSectionName0, missingSection0)
+
+	optionString, err = confMap.FetchOptionValueString(testSectionName0, testOptionName0)
+	assert.NoError(err, "FetchOptionalValueString should not fail since the option exists")
+	assert.Equal(testOptionString0, optionString, "SetOptionIfMissing should not change existing optionValue")
+
+	optionString, err = confMap.FetchOptionValueString(testSectionName0, testOptionName1)
+	assert.NoError(err, "second option should have been added")
+	assert.Equal(missingOptionString1, optionString, "SetOptionIfMissing should not change existing optionValue")
+
+	// but a new ConfMapSection should replace a missing one
+	confMap.SetSectionIfMissing(testSectionName1, missingSection0)
+
+	optionString, err = confMap.FetchOptionValueString(testSectionName1, testOptionName0)
+	assert.NoError(err, "FetchOptionalValueString should not fail since section was added")
+	assert.Equal(missingOptionString0, optionString, "missing Option should have been set")
+
+	optionString, err = confMap.FetchOptionValueString(testSectionName1, testOptionName1)
+	assert.NoError(err, "FetchOptionalValueString should not fail since section was added")
+	assert.Equal(missingOptionString1, optionString, "missing Option should have been set")
 }

--- a/httpserver/setup_teardown_test.go
+++ b/httpserver/setup_teardown_test.go
@@ -56,6 +56,7 @@ func testSetup(t *testing.T) {
 		"Cluster.HeartBeatMissLimit=3",
 		"Cluster.MessageQueueDepthPerPeer=4",
 		"Cluster.MaxRequestDuration=1s",
+		"Cluster.LivenessCheckerEnable=true",
 		"Cluster.LivenessCheckRedundancy=2",
 		"FSGlobals.VolumeGroupList=",
 		"FSGlobals.CheckpointHeaderConsensusAttempts=5",

--- a/httpserver/setup_teardown_test.go
+++ b/httpserver/setup_teardown_test.go
@@ -90,6 +90,7 @@ func testSetup(t *testing.T) {
 		"RamSwiftInfo.MaxObjectNameLength=1024",
 		"RamSwiftInfo.AccountListingLimit=10000",
 		"RamSwiftInfo.ContainerListingLimit=10000",
+
 		"HTTPServer.TCPPort=53461",
 	}
 

--- a/inode/cache.go
+++ b/inode/cache.go
@@ -41,11 +41,8 @@ func adoptVolumeGroupReadCacheParameters(confMap conf.ConfMap) (err error) {
 
 	readCacheMemSize = uint64(float64(totalMemSize) * readCacheQuotaFraction / platform.GoHeapAllocationMultiplier)
 
-	logger.Infof("Adopting ReadCache Parameters...")
-	logger.Infof("...ReadCacheQuotaFraction(%v) of memSize(0x%016X) totals 0x%016X",
-		readCacheQuotaFraction,
-		totalMemSize,
-		readCacheMemSize)
+	logger.Infof("Adopting ReadCache Parameters: ReadCacheQuotaFraction(%v) of memSize(0x%016X) totals 0x%016X",
+		readCacheQuotaFraction, totalMemSize, readCacheMemSize)
 
 	for _, volumeGroup = range globals.volumeGroupMap {
 		if 0 < volumeGroup.numServed {
@@ -63,11 +60,10 @@ func adoptVolumeGroupReadCacheParameters(confMap conf.ConfMap) (err error) {
 			volumeGroup.capReadCacheWhileLocked()
 			volumeGroup.Unlock()
 
-			logger.Infof("...0x%08X cache lines (each of size 0x%08X) totalling 0x%016X for Volume Group %v",
-				volumeGroup.readCacheLineCount,
-				volumeGroup.readCacheLineSize,
-				volumeGroup.readCacheLineCount*volumeGroup.readCacheLineSize,
-				volumeGroup.name)
+			logger.Infof("Volume Group %s: %d cache lines (each of size 0x%08X) totalling 0x%016X",
+				volumeGroup.name,
+				volumeGroup.readCacheLineCount, volumeGroup.readCacheLineSize,
+				volumeGroup.readCacheLineCount*volumeGroup.readCacheLineSize)
 		}
 	}
 

--- a/inode/config.go
+++ b/inode/config.go
@@ -284,7 +284,7 @@ func (dummy *globalsStruct) VolumeGroupCreated(confMap conf.ConfMap, volumeGroup
 		return
 	}
 	if volumeGroup.readCacheLineSize < 4096 {
-		logger.Warnf("Section '%s' for VolumeGroup '%s' ReadCacheWeight %d is < 4096; changing to 4096",
+		logger.Warnf("Section '%s' for VolumeGroup '%s' ReadCacheLineSize %d is < 4096; changing to 4096",
 			volumeGroupSectionName, volumeGroupName, volumeGroup.readCacheLineSize)
 		volumeGroup.readCacheLineSize = 4096
 	}

--- a/inode/file_flusher.go
+++ b/inode/file_flusher.go
@@ -103,6 +103,7 @@ func openLogSegmentLRURemove(inFlightLogSegment *inFlightLogSegmentStruct) {
 
 func (volumeGroup *volumeGroupStruct) capReadCacheWhileLocked() {
 	for uint64(len(volumeGroup.readCache)) > volumeGroup.readCacheLineCount {
+
 		delete(volumeGroup.readCache, volumeGroup.readCacheLRU.readCacheKey)
 		volumeGroup.readCacheLRU = volumeGroup.readCacheLRU.prev
 		volumeGroup.readCacheLRU.next = nil

--- a/liveness/config.go
+++ b/liveness/config.go
@@ -376,7 +376,7 @@ func (dummy *globalsStruct) SignaledFinish(confMap conf.ConfMap) (err error) {
 	}
 
 	// don't set globals.enabled = true until it's actually started
-	logger.Infof("Liveness checker enabled")
+	logger.Infof("Liveness checker will be enabled")
 
 	// Fetch cluster parameters
 

--- a/liveness/config.go
+++ b/liveness/config.go
@@ -129,6 +129,7 @@ type internalLivenessReportStruct struct {
 type globalsStruct struct {
 	trackedlock.Mutex
 	active                         bool
+	enabled                        bool
 	whoAmI                         string
 	myPublicIPAddr                 net.IP
 	myPrivateIPAddr                net.IP
@@ -267,6 +268,12 @@ func (dummy *globalsStruct) SignaledStart(confMap conf.ConfMap) (err error) {
 		stillDeactivating bool
 	)
 
+	// If the liveness checker is not enabled, stopping it will hang
+
+	if !globals.enabled {
+		return
+	}
+
 	// Disable API behavior as we enter the SIGHUP-handling state
 
 	globals.active = false
@@ -336,6 +343,7 @@ func (dummy *globalsStruct) SignaledFinish(confMap conf.ConfMap) (err error) {
 	var (
 		myTuple                       string
 		ok                            bool
+		enabled                       bool
 		peer                          *peerStruct
 		peerName                      string
 		peerList                      []string
@@ -352,6 +360,23 @@ func (dummy *globalsStruct) SignaledFinish(confMap conf.ConfMap) (err error) {
 		volumeList                    []string
 		volumeName                    string
 	)
+
+	// see if liveness checker is enabled
+	globals.enabled = false
+	enabled, err = confMap.FetchOptionValueBool("Cluster", "LivenessCheckerEnabled")
+	if nil != err {
+		logger.InfoWithError(err, "Unable to find and/or parse [Cluster]LivenessCheckerEnabled;"+
+			" defaulting to disabled")
+		err = nil
+		return
+	}
+	if !enabled {
+		logger.Infof("Liveness checker disabled")
+		return
+	}
+
+	// don't set globals.enabled = true until it's actually started
+	logger.Infof("Liveness checker enabled")
 
 	// Fetch cluster parameters
 
@@ -803,6 +828,10 @@ func (dummy *globalsStruct) SignaledFinish(confMap conf.ConfMap) (err error) {
 			globals.swiftConfDir = DefaultSwiftConfDir
 		}
 	}
+
+	// the liveness checker will be enabled (no more error out cases)
+
+	globals.enabled = true
 
 	// Initialize remaining globals
 

--- a/proxyfsd/daemon.go
+++ b/proxyfsd/daemon.go
@@ -51,10 +51,8 @@ func Daemon(confFile string, confStrings []string, errChan chan error, wg *sync.
 	// available if transitions.Up() hangs (the embedded http server will
 	// return http.StatusServiceUnavailable (503) during the transition.
 	debugServerPortAsUint16, err := confMap.FetchOptionValueUint16("ProxyfsDebug", "DebugServerPort")
-	if nil != err {
-		debugServerPortAsUint16 = 6058 // TODO: Eventually set it to zero
-	}
-	if uint16(0) != debugServerPortAsUint16 {
+	if nil != err && debugServerPortAsUint16 != 0 {
+
 		debugServerPortAsString := fmt.Sprintf("%d", debugServerPortAsUint16)
 		logger.Infof("proxyfsd.Daemon() starting debug HTTP Server on localhost:%s", debugServerPortAsString)
 		go http.ListenAndServe("localhost:"+debugServerPortAsString, nil)

--- a/proxyfsd/daemon.go
+++ b/proxyfsd/daemon.go
@@ -60,6 +60,18 @@ func Daemon(confFile string, confStrings []string, errChan chan error, wg *sync.
 		go http.ListenAndServe("localhost:"+debugServerPortAsString, nil)
 	}
 
+	// Arm signal handler used to catch signals
+	//
+	// Note: signalChan must be buffered to avoid race with window between
+	// arming handler and blocking on the chan read when signals might
+	// otherwise be lost.  No signals will be processed until
+	// transitions.Up() finishes, but an incoming SIGHUP will not cause the
+	// process to immediately exit.
+	signalChan := make(chan os.Signal, 16)
+
+	// if signals is empty it means "catch all signals" it is possible to catch
+	signal.Notify(signalChan, signals...)
+
 	// Start up dæmon packages
 
 	err = transitions.Up(confMap)
@@ -80,17 +92,7 @@ func Daemon(confFile string, confStrings []string, errChan chan error, wg *sync.
 		wg.Done()
 	}()
 
-	// Arm signal handler used to indicate termination and wait on it
-	//
-	// Note: signalled chan must be buffered to avoid race with window between
-	// arming handler and blocking on the chan read
-
-	signalChan := make(chan os.Signal, 8)
-
-	// if signals is empty it means "catch all signals" its possible to catch
-	signal.Notify(signalChan, signals...)
-
-	// indicate signal handlers have been armed successfully
+	// indicate transitions finished and signal handlers have been armed successfully
 	errChan <- nil
 
 	// Await a signal - reloading confFile each SIGHUP - exiting otherwise

--- a/proxyfsd/daemon_test.go
+++ b/proxyfsd/daemon_test.go
@@ -75,6 +75,8 @@ func TestDaemon(t *testing.T) {
 		"Cluster.LivenessCheckerEnabled=true",
 		"Cluster.LivenessCheckRedundancy=2",
 
+		"ProxyfsDebug.DebugServerPort=6058",
+
 		"HTTPServer.TCPPort=53461",
 
 		"SwiftClient.NoAuthIPAddr=127.0.0.1",

--- a/proxyfsd/daemon_test.go
+++ b/proxyfsd/daemon_test.go
@@ -72,6 +72,7 @@ func TestDaemon(t *testing.T) {
 		"Cluster.HeartBeatMissLimit=3",
 		"Cluster.MessageQueueDepthPerPeer=4",
 		"Cluster.MaxRequestDuration=1s",
+		"Cluster.LivenessCheckerEnabled=true",
 		"Cluster.LivenessCheckRedundancy=2",
 
 		"HTTPServer.TCPPort=53461",

--- a/proxyfsd/debug.conf
+++ b/proxyfsd/debug.conf
@@ -10,4 +10,4 @@
 #
 [ProxyfsDebug]
 ProfileType:     None
-DebugServerPort: 6060
+DebugServerPort: 6058

--- a/transitions/api_internal.go
+++ b/transitions/api_internal.go
@@ -684,7 +684,7 @@ func computeConfMapDelta(confMap conf.ConfMap) (newConfMapDelta *confMapDeltaStr
 		toStartServingVolumeList: make(map[string]*volumeStruct),
 	}
 
-	// Injest confMap
+	// Ingest confMap
 
 	whoAmI, err = confMap.FetchOptionValueString("Cluster", "WhoAmI")
 	if nil != err {


### PR DESCRIPTION
Address issues in ProxyFS discovered when trying to serve 10,000 volumes in a cluster (more than ~1,600 on a single node).

Add a new config variable to enable the liveness checker, `cluster.LivenessCheckerEnabled`, and disable it by default until we address the panic in the code.

Add back the debug HTTP server so we can get goroutine stack tracebacks before `transitions.Up()` has finished, (which is taking ~15 min on my AWS cluster with ~1,500 volumes, while we are mounting filesystems).

Arm the signal handler so they can catch SIGHUP before transitions.Up() has completed.

Slightly unrelated: add `conf.SetOptionIfMissing()` to support monitord setting LivenessCheckerEnabled if the Controller hasn't and `conf.SetSectionIfMissing()`, to be used to set backing policies for NGC Batch volumes if the cluster hasn't.