### PR TITLE
Forced use of 512 Byte BlkSize in PFSAgent... to honor stat()'s clien…

### DIFF
--- a/pfsagentd/README.md
+++ b/pfsagentd/README.md
@@ -70,7 +70,6 @@ ReadDirPlusEnabled:                                       false
 XAttrEnabled:                                             false
 EntryDuration:                                               0s
 AttrDuration:                                                0s
-AttrBlockSize:                                            65536
 ReaddirMaxEntries:                                         1024
 FUSEMaxBackground:                                          100
 FUSECongestionThreshhold:                                     0

--- a/pfsagentd/fission.go
+++ b/pfsagentd/fission.go
@@ -21,6 +21,8 @@ import (
 )
 
 const (
+	attrBlockSize = uint32(512)
+
 	initOutFlagsMaskReadDirPlusDisabled = uint32(0) |
 		fission.InitFlagsAsyncRead |
 		fission.InitFlagsFileOps |
@@ -87,9 +89,9 @@ func convertErrToErrno(err error, defaultErrno syscall.Errno) (errno syscall.Err
 
 func fixAttrSizes(attr *fission.Attr) {
 	if syscall.S_IFREG == (attr.Mode & syscall.S_IFMT) {
-		attr.Blocks = attr.Size + (globals.config.AttrBlockSize - 1)
-		attr.Blocks /= globals.config.AttrBlockSize
-		attr.BlkSize = uint32(globals.config.AttrBlockSize)
+		attr.Blocks = attr.Size + (uint64(attrBlockSize) - 1)
+		attr.Blocks /= uint64(attrBlockSize)
+		attr.BlkSize = attrBlockSize
 	} else {
 		attr.Size = 0
 		attr.Blocks = 0

--- a/pfsagentd/globals.go
+++ b/pfsagentd/globals.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"math"
 	"net/http"
 	"os"
 	"os/exec"
@@ -67,7 +66,6 @@ type configStruct struct {
 	XAttrEnabled                 bool
 	EntryDuration                time.Duration
 	AttrDuration                 time.Duration
-	AttrBlockSize                uint64
 	ReaddirMaxEntries            uint64
 	FUSEMaxBackground            uint16
 	FUSECongestionThreshhold     uint16
@@ -614,14 +612,6 @@ func initializeGlobals(confMap conf.ConfMap) {
 	globals.config.AttrDuration, err = confMap.FetchOptionValueDuration("Agent", "AttrDuration")
 	if nil != err {
 		logFatal(err)
-	}
-
-	globals.config.AttrBlockSize, err = confMap.FetchOptionValueUint64("Agent", "AttrBlockSize")
-	if nil != err {
-		logFatal(err)
-	}
-	if (0 == globals.config.AttrBlockSize) || (math.MaxUint32 < globals.config.AttrBlockSize) {
-		logFatalf("AttrBlockSize must be non-zero and fit in a uint32")
 	}
 
 	globals.config.ReaddirMaxEntries, err = confMap.FetchOptionValueUint64("Agent", "ReaddirMaxEntries")

--- a/pfsagentd/pfsagent.conf
+++ b/pfsagentd/pfsagent.conf
@@ -36,7 +36,6 @@ ReadDirPlusEnabled:                                       false
 XAttrEnabled:                                             false
 EntryDuration:                                               0s
 AttrDuration:                                                0s
-AttrBlockSize:                                            65536
 ReaddirMaxEntries:                                         1024
 FUSEMaxBackground:                                          100
 FUSECongestionThreshhold:                                     0

--- a/pfsagentd/setup_teardown_test.go
+++ b/pfsagentd/setup_teardown_test.go
@@ -120,7 +120,6 @@ func testSetup(t *testing.T) {
 		"Agent.XAttrEnabled=false",
 		"Agent.EntryDuration=10s",
 		"Agent.AttrDuration=10s",
-		"Agent.AttrBlockSize=65536",
 		"Agent.ReaddirMaxEntries=1024",
 		"Agent.FUSEMaxBackground=100",
 		"Agent.FUSECongestionThreshhold=0",


### PR DESCRIPTION
…ts' insistence on ignoring it