### PR TITLE
Cleaned up TestTryLockMutex() to make success more reliably reported

### DIFF
--- a/utils/api.go
+++ b/utils/api.go
@@ -38,9 +38,11 @@ func (tryLockMutex *TryLockMutex) TryLock(timeout time.Duration) (gotIt bool) {
 	timer := time.NewTimer(timeout)
 	select {
 	case tryLockMutex.c <- struct{}{}:
-		timer.Stop()
+		if !timer.Stop() {
+			<-timer.C
+		}
 		gotIt = true
-	case <-time.After(time.Duration(timeout)):
+	case <-timer.C:
 		gotIt = false
 	}
 	return

--- a/utils/api_test.go
+++ b/utils/api_test.go
@@ -23,10 +23,11 @@ func testTryLockMutexAsyncUnlock() {
 
 func TestTryLockMutex(t *testing.T) {
 	testTryLockMutex = NewTryLockMutex()
+
 	testTryLockMutex.Lock()
 	testTryLockMutex.Unlock()
 
-	shouldHaveGottonIt := testTryLockMutex.TryLock(100 * time.Millisecond)
+	shouldHaveGottonIt := testTryLockMutex.TryLock(10 * time.Second)
 	if !shouldHaveGottonIt {
 		t.Fatalf("1st TryLock() should have succeeded")
 	}
@@ -37,10 +38,12 @@ func TestTryLockMutex(t *testing.T) {
 	}
 
 	_ = time.AfterFunc(20*time.Millisecond, testTryLockMutexAsyncUnlock)
-	shouldHaveGottonIt = testTryLockMutex.TryLock(120 * time.Millisecond)
+
+	shouldHaveGottonIt = testTryLockMutex.TryLock(10 * time.Second)
 	if !shouldHaveGottonIt {
 		t.Fatalf("3rd TryLock() should have succeeded")
 	}
+
 	testTryLockMutex.Unlock()
 }
 


### PR DESCRIPTION
...avoids (by seriously elongating the wait time) that 3rd TryLock() call that is supposed to succeed