### PR TITLE
Pass reference to the connection in the call to the goroutine

### DIFF
--- a/retryrpc/api.go
+++ b/retryrpc/api.go
@@ -345,7 +345,7 @@ func NewClient(config *ClientConfig) (client *Client, err error) {
 	client.outstandingRequest = make(map[requestID]*reqCtx)
 	client.bt = btree.New(2)
 
-	if nil == config.RootCAx509CertificatePEM {
+	if config.RootCAx509CertificatePEM == nil {
 		client.connection.useTLS = false
 		client.connection.tlsConn = nil
 		client.connection.x509CertPool = nil
@@ -395,7 +395,5 @@ func (client *Client) Close() {
 
 	// Wait for the goroutines to return
 	client.goroutineWG.Wait()
-	logger.Infof("bucketstats for myUniqueID: '%v' -  %s\n", client.myUniqueID,
-		bucketstats.SprintStats(bucketstats.StatFormatParsable1, bucketStatsPkgName, client.GetStatsGroupName()))
 	bucketstats.UnRegister(bucketStatsPkgName, client.GetStatsGroupName())
 }


### PR DESCRIPTION
Pass the connection as a reference when starting the goroutine.

Previously, the goroutine would find the connection directly which would
fail if another goroutine and niled the connection.   This solution
allows the goroutine to get the EOF and gracefully exit.