### PR TITLE
resolve error

### DIFF
--- a/iclient/iclientpkg/fission.go
+++ b/iclient/iclientpkg/fission.go
@@ -3989,7 +3989,6 @@ Retry:
 
 		renamedInode.dirty = true
 
-		renamedInode.inodeHeadV1.ModificationTime = startTime
 		renamedInode.inodeHeadV1.StatusChangeTime = startTime
 
 		delete(renamedInode.linkSet, ilayout.InodeLinkTableEntryStruct{
@@ -4069,7 +4068,6 @@ Retry:
 
 			renamedInode.dirty = true
 
-			renamedInode.inodeHeadV1.ModificationTime = startTime
 			renamedInode.inodeHeadV1.StatusChangeTime = startTime
 
 			delete(renamedInode.linkSet, ilayout.InodeLinkTableEntryStruct{
@@ -4115,7 +4113,6 @@ Retry:
 		} else {
 			renamedInode.dirty = true
 
-			renamedInode.inodeHeadV1.ModificationTime = startTime
 			renamedInode.inodeHeadV1.StatusChangeTime = startTime
 
 			delete(renamedInode.linkSet, ilayout.InodeLinkTableEntryStruct{


### PR DESCRIPTION
Noticed that there were mtime change at every condition. I preserved the mtime change in the following cases:

- Modifying a file within a directory should indeed change the parent directory's mtime

e.g. 

We have dir/z

mv z y
stat y -> only ctime changed
stat dir -> ctime, mtime changed

And removed the mtime change in the following cases:

- If renamedInode is a directory, renaming a directory shouldn't change directory mtime
- If renamedInode is a file, renaming a file shouldn't change file's mtime

POSIX ctime/mtime test output:

```
+ TESTCASE=posix/ctime-mtime/rename-ctime-mtime.py
+ TESTCASE_STRIPPED=posix/ctime-mtime/rename-ctime-mtime
+ echo '@ posix/ctime-mtime/rename-ctime-mtime'
+ tee -a /home/swift/code/functional-tests/functional/tap/tmp_results.txt
@ posix/ctime-mtime/rename-ctime-mtime
+ mkdir -p /mnt/tap/posix/ctime-mtime/rename-ctime-mtime
+ start=0
+ sh
1..10
ok 1
ok 2
ok 3
ok 4
ok 5
ok 6
ok 7
ok 8
ok 9
ok 10
+ echo 'Elapsed time for posix/ctime-mtime/rename-ctime-mtime: 8 seconds'
Elapsed time for posix/ctime-mtime/rename-ctime-mtime: 8 seconds
```

