### PR TITLE
ENAMETOOLONG

### DIFF
--- a/iclient/dev.conf
+++ b/iclient/dev.conf
@@ -13,7 +13,7 @@ FUSEMaxRead:                      1048576
 FUSEMaxWrite:                     1048576
 FUSEEntryValidDuration:           250ms
 FUSEAttrValidDuration:            250ms
-FUSENameLenMax:                   1024
+FUSENameLenMax:                   255
 AuthPlugInPath:                   iauth/iauth-swift/iauth-swift.so
 AuthPlugInEnvName:
 AuthPlugInEnvValue:               {"AuthURL":"http://swift:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"\u002C"Container":"con"}

--- a/iclient/dev.conf
+++ b/iclient/dev.conf
@@ -13,6 +13,7 @@ FUSEMaxRead:                      1048576
 FUSEMaxWrite:                     1048576
 FUSEEntryValidDuration:           250ms
 FUSEAttrValidDuration:            250ms
+FUSENameLenMax:                   1024
 AuthPlugInPath:                   iauth/iauth-swift/iauth-swift.so
 AuthPlugInEnvName:
 AuthPlugInEnvValue:               {"AuthURL":"http://swift:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"\u002C"Container":"con"}

--- a/iclient/iclient.conf
+++ b/iclient/iclient.conf
@@ -13,6 +13,7 @@ FUSEMaxRead:                      1048576
 FUSEMaxWrite:                     1048576
 FUSEEntryValidDuration:           250ms
 FUSEAttrValidDuration:            250ms
+FUSENameLenMax:                   1024
 AuthPlugInPath:                   iauth-swift.so
 AuthPlugInEnvName:
 AuthPlugInEnvValue:               {"AuthURL":"http://swift:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"\u002C"Container":"con"}

--- a/iclient/iclient.conf
+++ b/iclient/iclient.conf
@@ -13,7 +13,7 @@ FUSEMaxRead:                      1048576
 FUSEMaxWrite:                     1048576
 FUSEEntryValidDuration:           250ms
 FUSEAttrValidDuration:            250ms
-FUSENameLenMax:                   1024
+FUSENameLenMax:                   255
 AuthPlugInPath:                   iauth-swift.so
 AuthPlugInEnvName:
 AuthPlugInEnvValue:               {"AuthURL":"http://swift:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"\u002C"Container":"con"}

--- a/iclient/iclientpkg/api.go
+++ b/iclient/iclientpkg/api.go
@@ -19,7 +19,7 @@
 //  FUSEMaxWrite:                     1048576        # 1MiB == FUSEMaxPages(256) * 4KiB
 //  FUSEEntryValidDuration:           250ms
 //  FUSEAttrValidDuration:            250ms
-//  FUSENameLenMax:                   1024
+//  FUSENameLenMax:                   255
 //  AuthPlugInPath:                   iauth-swift.so
 //  AuthPlugInEnvName:                               # Only used if not defining AuthPlugInEnvValue here
 //  AuthPlugInEnvValue:               {"AuthURL":"http://swift:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"\u002C"Container":"con"}

--- a/iclient/iclientpkg/api.go
+++ b/iclient/iclientpkg/api.go
@@ -19,6 +19,7 @@
 //  FUSEMaxWrite:                     1048576        # 1MiB == FUSEMaxPages(256) * 4KiB
 //  FUSEEntryValidDuration:           250ms
 //  FUSEAttrValidDuration:            250ms
+//  FUSENameLenMax:                   1024
 //  AuthPlugInPath:                   iauth-swift.so
 //  AuthPlugInEnvName:                               # Only used if not defining AuthPlugInEnvValue here
 //  AuthPlugInEnvValue:               {"AuthURL":"http://swift:8080/auth/v1.0"\u002C"AuthUser":"test:tester"\u002C"AuthKey":"testing"\u002C"Account":"AUTH_test"\u002C"Container":"con"}

--- a/iclient/iclientpkg/fission.go
+++ b/iclient/iclientpkg/fission.go
@@ -98,6 +98,12 @@ func (dummy *globalsStruct) DoLookup(inHeader *fission.InHeader, lookupIn *fissi
 		globals.stats.DoLookupUsecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
 
+	if len(lookupIn.Name) > int(globals.config.FUSENameLenMax) {
+		lookupOut = nil
+		errno = syscall.ENAMETOOLONG
+		return
+	}
+
 Retry:
 	inodeLockRequest = newLockRequest()
 	inodeLockRequest.inodeNumber = inHeader.NodeID
@@ -498,6 +504,12 @@ func (dummy *globalsStruct) DoSymLink(inHeader *fission.InHeader, symLinkIn *fis
 		globals.stats.DoSymLinkUsecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
 
+	if (len(symLinkIn.Name) > int(globals.config.FUSENameLenMax)) || (len(symLinkIn.Data) > int(globals.config.FUSENameLenMax)) {
+		symLinkOut = nil
+		errno = syscall.ENAMETOOLONG
+		return
+	}
+
 Retry:
 	inodeLockRequest = newLockRequest()
 	inodeLockRequest.inodeNumber = inHeader.NodeID
@@ -701,6 +713,12 @@ func (dummy *globalsStruct) DoMkDir(inHeader *fission.InHeader, mkDirIn *fission
 	defer func() {
 		globals.stats.DoMkDirUsecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
+
+	if len(mkDirIn.Name) > int(globals.config.FUSENameLenMax) {
+		mkDirOut = nil
+		errno = syscall.ENAMETOOLONG
+		return
+	}
 
 Retry:
 	inodeLockRequest = newLockRequest()
@@ -931,6 +949,11 @@ func (dummy *globalsStruct) DoUnlink(inHeader *fission.InHeader, unlinkIn *fissi
 		globals.stats.DoUnlinkUsecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
 
+	if len(unlinkIn.Name) > int(globals.config.FUSENameLenMax) {
+		errno = syscall.ENAMETOOLONG
+		return
+	}
+
 Retry:
 	inodeLockRequest = newLockRequest()
 	inodeLockRequest.inodeNumber = inHeader.NodeID
@@ -1084,6 +1107,11 @@ func (dummy *globalsStruct) DoRmDir(inHeader *fission.InHeader, rmDirIn *fission
 	defer func() {
 		globals.stats.DoRmDirUsecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
+
+	if len(rmDirIn.Name) > int(globals.config.FUSENameLenMax) {
+		errno = syscall.ENAMETOOLONG
+		return
+	}
 
 Retry:
 	inodeLockRequest = newLockRequest()
@@ -1241,6 +1269,11 @@ func (dummy *globalsStruct) DoRename(inHeader *fission.InHeader, renameIn *fissi
 		globals.stats.DoRenameUsecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
 
+	if (len(renameIn.OldName) > int(globals.config.FUSENameLenMax)) || (len(renameIn.NewName) > int(globals.config.FUSENameLenMax)) {
+		errno = syscall.ENAMETOOLONG
+		return
+	}
+
 	errno = doRenameCommon(inHeader.NodeID, string(renameIn.OldName[:]), renameIn.NewDir, string(renameIn.NewName[:]), startTime)
 	return
 }
@@ -1263,6 +1296,12 @@ func (dummy *globalsStruct) DoLink(inHeader *fission.InHeader, linkIn *fission.L
 	defer func() {
 		globals.stats.DoLinkUsecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
+
+	if len(linkIn.Name) > int(globals.config.FUSENameLenMax) {
+		linkOut = nil
+		errno = syscall.ENAMETOOLONG
+		return
+	}
 
 Retry:
 	inodeLockRequest = newLockRequest()
@@ -2122,6 +2161,7 @@ func (dummy *globalsStruct) DoStatFS(inHeader *fission.InHeader) (statFSOut *fis
 			Files:   math.MaxUint64,
 			FFree:   math.MaxUint64,
 			BSize:   globals.config.FUSEBlockSize,
+			NameLen: globals.config.FUSENameLenMax,
 			FRSize:  globals.config.FUSEBlockSize,
 			Padding: 0,
 			Spare:   [6]uint32{0, 0, 0, 0, 0, 0},
@@ -3113,6 +3153,12 @@ func (dummy *globalsStruct) DoCreate(inHeader *fission.InHeader, createIn *fissi
 		globals.stats.DoCreateUsecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
 
+	if len(createIn.Name) > int(globals.config.FUSENameLenMax) {
+		createOut = nil
+		errno = syscall.ENAMETOOLONG
+		return
+	}
+
 Retry:
 	inodeLockRequest = newLockRequest()
 	inodeLockRequest.inodeNumber = inHeader.NodeID
@@ -3640,6 +3686,11 @@ func (dummy *globalsStruct) DoRename2(inHeader *fission.InHeader, rename2In *fis
 	defer func() {
 		globals.stats.DoRename2Usecs.Add(uint64(time.Since(startTime) / time.Microsecond))
 	}()
+
+	if (len(rename2In.OldName) > int(globals.config.FUSENameLenMax)) || (len(rename2In.NewName) > int(globals.config.FUSENameLenMax)) {
+		errno = syscall.ENAMETOOLONG
+		return
+	}
 
 	errno = doRenameCommon(inHeader.NodeID, string(rename2In.OldName[:]), rename2In.NewDir, string(rename2In.NewName[:]), startTime)
 	return

--- a/iclient/iclientpkg/globals.go
+++ b/iclient/iclientpkg/globals.go
@@ -34,6 +34,7 @@ type configStruct struct {
 	FUSEMaxWrite                     uint32
 	FUSEEntryValidDuration           time.Duration
 	FUSEAttrValidDuration            time.Duration
+	FUSENameLenMax                   uint32
 	AuthPlugInPath                   string
 	AuthPlugInEnvName                string
 	AuthPlugInEnvValue               string
@@ -334,6 +335,10 @@ func initializeGlobals(confMap conf.ConfMap, fissionErrChan chan error) (err err
 	if nil != err {
 		logFatal(err)
 	}
+	globals.config.FUSENameLenMax, err = confMap.FetchOptionValueUint32("ICLIENT", "FUSENameLenMax")
+	if nil != err {
+		logFatal(err)
+	}
 	globals.config.AuthPlugInPath, err = confMap.FetchOptionValueString("ICLIENT", "AuthPlugInPath")
 	if nil != err {
 		logFatal(err)
@@ -562,6 +567,7 @@ func uninitializeGlobals() (err error) {
 	globals.config.FUSEMaxWrite = 0
 	globals.config.FUSEEntryValidDuration = time.Duration(0)
 	globals.config.FUSEAttrValidDuration = time.Duration(0)
+	globals.config.FUSENameLenMax = 0
 	globals.config.AuthPlugInPath = ""
 	globals.config.AuthPlugInEnvName = ""
 	globals.config.AuthPlugInEnvValue = ""

--- a/iclient/iclientpkg/utils_test.go
+++ b/iclient/iclientpkg/utils_test.go
@@ -141,7 +141,7 @@ func testSetup(t *testing.T) {
 		"ICLIENT.FUSEMaxWrite=1048576",
 		"ICLIENT.FUSEEntryValidDuration=250ms",
 		"ICLIENT.FUSEAttrValidDuration=250ms",
-		"ICLIENT.FUSENameLenMax=1024",
+		"ICLIENT.FUSENameLenMax=255",
 		"ICLIENT.AuthPlugInPath=../../iauth/iauth-swift/iauth-swift.so",
 		"ICLIENT.AuthPlugInEnvName=",
 		"ICLIENT.AuthPlugInEnvValue=" + fmt.Sprintf("{\"AuthURL\":\"http://%s:%d/auth/v1.0\"\\u002C\"AuthUser\":\"%s\"\\u002C\"AuthKey\":\"%s\"\\u002C\"Account\":\"%s\"\\u002C\"Container\":\"%s\"}", testIPAddr, testSwiftProxyTCPPort, testSwiftAuthUser, testSwiftAuthKey, testAccount, testContainer),

--- a/iclient/iclientpkg/utils_test.go
+++ b/iclient/iclientpkg/utils_test.go
@@ -141,6 +141,7 @@ func testSetup(t *testing.T) {
 		"ICLIENT.FUSEMaxWrite=1048576",
 		"ICLIENT.FUSEEntryValidDuration=250ms",
 		"ICLIENT.FUSEAttrValidDuration=250ms",
+		"ICLIENT.FUSENameLenMax=1024",
 		"ICLIENT.AuthPlugInPath=../../iauth/iauth-swift/iauth-swift.so",
 		"ICLIENT.AuthPlugInEnvName=",
 		"ICLIENT.AuthPlugInEnvValue=" + fmt.Sprintf("{\"AuthURL\":\"http://%s:%d/auth/v1.0\"\\u002C\"AuthUser\":\"%s\"\\u002C\"AuthKey\":\"%s\"\\u002C\"Account\":\"%s\"\\u002C\"Container\":\"%s\"}", testIPAddr, testSwiftProxyTCPPort, testSwiftAuthUser, testSwiftAuthKey, testAccount, testContainer),


### PR DESCRIPTION
While configurable, note that PJD seems to insist upon the new FUSENameLenMax value being set to precisely 255.