### PR TITLE
Fixed utils_test.go in {iclient|imgr}/{iclient|imgr}pkg/utils_test.go…

### DIFF
--- a/iclient/iclientpkg/utils_test.go
+++ b/iclient/iclientpkg/utils_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	testIPAddr               = "127.0.0.1" // Don't use IPv6... the code doesn't properly "join" this with :port #s
+	testIPAddr               = "127.0.0.1"
 	testRetryRPCPort         = 32356
 	testMgrHTTPServerPort    = 15346
 	testClientHTTPServerPort = 15347
@@ -34,6 +34,7 @@ const (
 	testVolume               = "testvol"
 	testRPCDeadlineIO        = "60s"
 	testRPCKeepAlivePeriod   = "60s"
+	testStartupDelay         = 100 * time.Millisecond
 )
 
 type testGlobalsStruct struct {
@@ -82,8 +83,8 @@ func testSetup(t *testing.T) {
 		caKeyFile:         tempDir + "/caKeyFile",
 		endpointCertFile:  tempDir + "/endpoingCertFile",
 		endpointKeyFile:   tempDir + "/endpointKeyFile",
-		imgrHTTPServerURL: fmt.Sprintf("http://%s:%d", testIPAddr, testMgrHTTPServerPort),
-		authURL:           fmt.Sprintf("http://%s:%d/auth/v1.0", testIPAddr, testSwiftProxyTCPPort),
+		imgrHTTPServerURL: "http://" + net.JoinHostPort(testIPAddr, fmt.Sprintf("%d", testMgrHTTPServerPort)),
+		authURL:           "http://" + net.JoinHostPort(testIPAddr, fmt.Sprintf("%d", testSwiftProxyTCPPort)) + "/auth/v1.0",
 	}
 
 	testGlobals.caCertPEMBlock, testGlobals.caKeyPEMBlock, err = icertpkg.GenCACert(
@@ -244,14 +245,18 @@ func testSetup(t *testing.T) {
 		t.Fatalf("iswiftpkg.Start(testGlobals.confMap) failed: %v", err)
 	}
 
-	authRequestHeaders = make(http.Header)
+	for {
+		authRequestHeaders = make(http.Header)
 
-	authRequestHeaders["X-Auth-User"] = []string{testSwiftAuthUser}
-	authRequestHeaders["X-Auth-Key"] = []string{testSwiftAuthKey}
+		authRequestHeaders["X-Auth-User"] = []string{testSwiftAuthUser}
+		authRequestHeaders["X-Auth-Key"] = []string{testSwiftAuthKey}
 
-	authResponseHeaders, _, err = testDoHTTPRequest("GET", testGlobals.authURL, authRequestHeaders, nil)
-	if nil != err {
-		t.Fatalf("testDoHTTPRequest(\"GET\", testGlobals.authURL, authRequestHeaders, nil) failed: %v", err)
+		authResponseHeaders, _, err = testDoHTTPRequest("GET", testGlobals.authURL, authRequestHeaders, nil)
+		if nil == err {
+			break
+		}
+
+		time.Sleep(testStartupDelay)
 	}
 
 	testGlobals.authToken = authResponseHeaders.Get("X-Auth-Token")
@@ -286,6 +291,14 @@ func testSetup(t *testing.T) {
 	err = imgrpkg.Start(testGlobals.confMap)
 	if nil != err {
 		t.Fatalf("imgrpkg.Start(testGlobals.confMap) failed: %v", err)
+	}
+
+	for {
+		_, _, err = testDoHTTPRequest("GET", testGlobals.imgrHTTPServerURL+"/version", nil, nil)
+		if nil == err {
+			break
+		}
+		time.Sleep(testStartupDelay)
 	}
 
 	postAndPutVolumePayload = fmt.Sprintf("{\"StorageURL\":\"%s\",\"AuthToken\":\"%s\"}", testGlobals.containerURL, testGlobals.authToken)

--- a/imgr/imgrpkg/utils_test.go
+++ b/imgr/imgrpkg/utils_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	testIPAddr             = "127.0.0.1" // Don't use IPv6... the code doesn't properly "join" this with :port #s
+	testIPAddr             = "127.0.0.1"
 	testRetryRPCPort       = 32356
 	testHTTPServerPort     = 15346
 	testSwiftProxyTCPPort  = 8080
@@ -31,6 +31,7 @@ const (
 	testVolume             = "testVolume"
 	testRPCDeadlineIO      = "60s"
 	testRPCKeepAlivePeriod = "60s"
+	testStartupDelay       = 100 * time.Millisecond
 )
 
 type testGlobalsStruct struct {
@@ -76,8 +77,8 @@ func testSetup(t *testing.T, overrideConfStrings []string, retryrpcCallbacks int
 		caKeyFile:        tempDir + "/caKeyFile",
 		endpointCertFile: tempDir + "/endpoingCertFile",
 		endpointKeyFile:  tempDir + "/endpointKeyFile",
-		httpServerURL:    fmt.Sprintf("http://%s:%d", testIPAddr, testHTTPServerPort),
-		authURL:          fmt.Sprintf("http://%s:%d/auth/v1.0", testIPAddr, testSwiftProxyTCPPort),
+		httpServerURL:    "http://" + net.JoinHostPort(testIPAddr, fmt.Sprintf("%d", testHTTPServerPort)),
+		authURL:          "http://" + net.JoinHostPort(testIPAddr, fmt.Sprintf("%d", testSwiftProxyTCPPort)) + "/auth/v1.0",
 	}
 
 	testGlobals.caCertPEMBlock, testGlobals.caKeyPEMBlock, err = icertpkg.GenCACert(
@@ -194,9 +195,12 @@ func testSetup(t *testing.T, overrideConfStrings []string, retryrpcCallbacks int
 		t.Fatalf("iswiftpkg.Start(testGlobals.confMap) failed: %v", err)
 	}
 
-	err = testDoAuth()
-	if nil != err {
-		t.Fatalf("testDoAuth() failed: %v", err)
+	for {
+		err = testDoAuth()
+		if nil == err {
+			break
+		}
+		time.Sleep(testStartupDelay)
 	}
 
 	testGlobals.containerURL = testGlobals.accountURL + "/" + testContainer
@@ -222,6 +226,14 @@ func testSetup(t *testing.T, overrideConfStrings []string, retryrpcCallbacks int
 	err = Start(testGlobals.confMap)
 	if nil != err {
 		t.Fatalf("Start(testGlobals.confMap) failed: %v", err)
+	}
+
+	for {
+		_, _, err = testDoHTTPRequest("GET", testGlobals.httpServerURL+"/version", nil, nil, http.StatusOK)
+		if nil == err {
+			break
+		}
+		time.Sleep(testStartupDelay)
 	}
 
 	retryrpcDeadlineIO, err = time.ParseDuration(testRPCDeadlineIO)


### PR DESCRIPTION
… to not "race" during startup

Previously, we were just lucky that iswift and imgr came up faster than test code's first attempt to talk to them