### PR TITLE
Simplest fix to allow `git describe` from within the `dev` container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN go build github.com/go-delve/delve/cmd/dlv
 RUN cp dlv /usr/local/go/bin/.
 VOLUME /src
 WORKDIR /src
+RUN git config --global --add safe.directory /src
 
 FROM dev as build
 ARG MakeTarget


### PR DESCRIPTION
Note that make test on the iclient/iclientpkg will need > 4GiB memory in the dev container (VM)